### PR TITLE
[M2-4833] Feature: Additional text response

### DIFF
--- a/src/entities/activity/lib/helpers.test.ts
+++ b/src/entities/activity/lib/helpers.test.ts
@@ -1,6 +1,67 @@
-import { hasAdditionalResponse, requiresAdditionalResponse, supportsAdditionalResponseField } from "./helpers"
+import {
+  hasAdditionalResponse,
+  isSupportedActivity,
+  requiresAdditionalResponse,
+  supportsAdditionalResponseField,
+} from "./helpers"
+
+import { ItemResponseTypeDTO } from "~/shared/api"
 
 describe("Activity helpers", () => {
+  describe("isSupportedActivity", () => {
+    it("Returns false if no response types are provided", () => {
+      expect(isSupportedActivity()).toEqual(false)
+    })
+
+    it("Returns false for unsupported response types", () => {
+      const unsupportedResponseTypes: ItemResponseTypeDTO[] = [
+        "geolocation",
+        "drawing",
+        "photo",
+        "video",
+        "sliderRows",
+        "singleSelectRows",
+        "multiSelectRows",
+        "audio",
+      ]
+
+      expect(isSupportedActivity(unsupportedResponseTypes)).toEqual(false)
+    })
+
+    it("Returns false for a mix of supported and unsupported response types", () => {
+      const mixedResponseTypes: ItemResponseTypeDTO[] = [
+        "text",
+        "geolocation",
+        "drawing",
+        "photo",
+        "video",
+        "sliderRows",
+        "singleSelectRows",
+        "multiSelectRows",
+        "audio",
+      ]
+
+      expect(isSupportedActivity(mixedResponseTypes)).toEqual(false)
+    })
+
+    it("Returns true if all response types are supported", () => {
+      const supportedResponseTypes: ItemResponseTypeDTO[] = [
+        "text",
+        "singleSelect",
+        "multiSelect",
+        "slider",
+        "numberSelect",
+        "message",
+        "date",
+        "time",
+        "timeRange",
+        "audioPlayer",
+      ]
+
+      expect(isSupportedActivity(supportedResponseTypes)).toEqual(true)
+    })
+  })
+
   describe("supportsAdditionalResponseField", () => {
     it("Text item should return false", () => {
       expect(supportsAdditionalResponseField({ responseType: "text" })).toEqual(false)

--- a/src/entities/activity/lib/helpers.test.ts
+++ b/src/entities/activity/lib/helpers.test.ts
@@ -1,0 +1,181 @@
+import { hasAdditionalResponse, requiresAdditionalResponse, supportsAdditionalResponseField } from "./helpers"
+
+describe("Activity helpers", () => {
+  describe("supportsAdditionalResponseField", () => {
+    it("Text item should return false", () => {
+      expect(supportsAdditionalResponseField({ responseType: "text" })).toEqual(false)
+    })
+
+    it("Splash screen item should return false", () => {
+      expect(supportsAdditionalResponseField({ responseType: "splashScreen" })).toEqual(false)
+    })
+
+    it("Message item should return false", () => {
+      expect(supportsAdditionalResponseField({ responseType: "message" })).toEqual(false)
+    })
+
+    it("Checkbox item should return true", () => {
+      expect(supportsAdditionalResponseField({ responseType: "multiSelect" })).toEqual(true)
+    })
+
+    it("Radio item should return true", () => {
+      expect(supportsAdditionalResponseField({ responseType: "singleSelect" })).toEqual(true)
+    })
+
+    it("Slider item should return true", () => {
+      expect(supportsAdditionalResponseField({ responseType: "slider" })).toEqual(true)
+    })
+
+    it("Date item should return true", () => {
+      expect(supportsAdditionalResponseField({ responseType: "date" })).toEqual(true)
+    })
+
+    it("Number select item should return true", () => {
+      expect(supportsAdditionalResponseField({ responseType: "numberSelect" })).toEqual(true)
+    })
+
+    it("Time item should return true", () => {
+      expect(supportsAdditionalResponseField({ responseType: "time" })).toEqual(true)
+    })
+
+    it("Time range item should return true", () => {
+      expect(supportsAdditionalResponseField({ responseType: "timeRange" })).toEqual(true)
+    })
+
+    it("Audio player item should return true", () => {
+      expect(supportsAdditionalResponseField({ responseType: "audioPlayer" })).toEqual(true)
+    })
+  })
+
+  describe("hasAdditionalResponse", () => {
+    it("Unsupported item should return false", () => {
+      expect(
+        hasAdditionalResponse({
+          responseType: "text",
+          config: {
+            removeBackButton: false,
+            skippableItem: false,
+            maxResponseLength: 300,
+            correctAnswerRequired: false,
+            correctAnswer: "",
+            numericalResponseRequired: false,
+            responseDataIdentifier: false,
+            responseRequired: false,
+          },
+        }),
+      ).toEqual(false)
+    })
+
+    it("Supported item with additional response option disabled should return false", () => {
+      expect(
+        hasAdditionalResponse({
+          responseType: "singleSelect",
+          config: {
+            removeBackButton: false,
+            skippableItem: false,
+            timer: null,
+            randomizeOptions: false,
+            addScores: false,
+            setAlerts: false,
+            addTooltip: false,
+            setPalette: false,
+            autoAdvance: false,
+            additionalResponseOption: {
+              textInputOption: false,
+              textInputRequired: false,
+            },
+          },
+        }),
+      ).toEqual(false)
+    })
+
+    it("Supported item with additional response option enabled should return true", () => {
+      expect(
+        hasAdditionalResponse({
+          responseType: "singleSelect",
+          config: {
+            removeBackButton: false,
+            skippableItem: false,
+            timer: null,
+            randomizeOptions: false,
+            addScores: false,
+            setAlerts: false,
+            addTooltip: false,
+            setPalette: false,
+            autoAdvance: false,
+            additionalResponseOption: {
+              textInputOption: true,
+              textInputRequired: false,
+            },
+          },
+        }),
+      ).toEqual(true)
+    })
+  })
+
+  describe("requiresAdditionalResponse", () => {
+    it("Unsupported item should return false", () => {
+      expect(
+        requiresAdditionalResponse({
+          responseType: "text",
+          config: {
+            removeBackButton: false,
+            skippableItem: false,
+            maxResponseLength: 300,
+            correctAnswerRequired: false,
+            correctAnswer: "",
+            numericalResponseRequired: false,
+            responseDataIdentifier: false,
+            responseRequired: false,
+          },
+        }),
+      ).toEqual(false)
+    })
+
+    it("Supported item with optional additional response should return false", () => {
+      expect(
+        requiresAdditionalResponse({
+          responseType: "singleSelect",
+          config: {
+            removeBackButton: false,
+            skippableItem: false,
+            timer: null,
+            randomizeOptions: false,
+            addScores: false,
+            setAlerts: false,
+            addTooltip: false,
+            setPalette: false,
+            autoAdvance: false,
+            additionalResponseOption: {
+              textInputOption: true,
+              textInputRequired: false,
+            },
+          },
+        }),
+      ).toEqual(false)
+    })
+
+    it("Supported item with required additional response should return true", () => {
+      expect(
+        requiresAdditionalResponse({
+          responseType: "singleSelect",
+          config: {
+            removeBackButton: false,
+            skippableItem: false,
+            timer: null,
+            randomizeOptions: false,
+            addScores: false,
+            setAlerts: false,
+            addTooltip: false,
+            setPalette: false,
+            autoAdvance: false,
+            additionalResponseOption: {
+              textInputOption: true,
+              textInputRequired: true,
+            },
+          },
+        }),
+      ).toEqual(true)
+    })
+  })
+})

--- a/src/entities/activity/lib/helpers.ts
+++ b/src/entities/activity/lib/helpers.ts
@@ -1,4 +1,5 @@
 import { supportableResponseTypes } from "~/abstract/lib/constants"
+import { appletModel } from "~/entities/applet"
 import { ItemResponseTypeDTO } from "~/shared/api"
 
 export function isSupportedActivity(itemResponseTypes?: Array<ItemResponseTypeDTO>): boolean {
@@ -7,4 +8,37 @@ export function isSupportedActivity(itemResponseTypes?: Array<ItemResponseTypeDT
   }
 
   return itemResponseTypes.every(type => supportableResponseTypes.includes(type))
+}
+
+/**
+ * Check whether an item supports an additional response field
+ * @param item Any item
+ * @returns Whether the item type supports additional text responses
+ */
+export const supportsAdditonalResponseField = (
+  item: appletModel.ItemRecord,
+): item is appletModel.ItemWithAdditionalResponse => {
+  return [
+    "singleSelect",
+    "multiSelect",
+    "slider",
+    "date",
+    "numberSelect",
+    "time",
+    "timeRange",
+    "drawing",
+    "photo",
+    "video",
+    "geolocation",
+    "audio",
+  ].includes(item.responseType)
+}
+
+/**
+ * Check whether an item has been configured with an additional response field
+ * @param item Any item, even those that don't support additional response fields
+ * @returns Whether the item has an additional response field
+ */
+export const hasAdditionalResponse = (item: appletModel.ItemRecord): boolean => {
+  return supportsAdditonalResponseField(item) && item.config.additionalResponseOption.textInputOption
 }

--- a/src/entities/activity/lib/helpers.ts
+++ b/src/entities/activity/lib/helpers.ts
@@ -16,22 +16,11 @@ export function isSupportedActivity(itemResponseTypes?: Array<ItemResponseTypeDT
  * @returns Whether the item type supports additional text responses
  */
 export const supportsAdditionalResponseField = (
-  item: appletModel.ItemRecord,
+  item: Pick<appletModel.ItemRecord, "responseType">,
 ): item is appletModel.ItemWithAdditionalResponse => {
-  return [
-    "singleSelect",
-    "multiSelect",
-    "slider",
-    "date",
-    "numberSelect",
-    "time",
-    "timeRange",
-    "drawing",
-    "photo",
-    "video",
-    "geolocation",
-    "audio",
-  ].includes(item.responseType)
+  return ["singleSelect", "multiSelect", "slider", "date", "numberSelect", "time", "timeRange", "audioPlayer"].includes(
+    item.responseType,
+  )
 }
 
 /**
@@ -39,7 +28,7 @@ export const supportsAdditionalResponseField = (
  * @param item Any item, even those that don't support additional response fields
  * @returns Whether the item has an additional response field
  */
-export const hasAdditionalResponse = (item: appletModel.ItemRecord): boolean => {
+export const hasAdditionalResponse = (item: Pick<appletModel.ItemRecord, "responseType" | "config">): boolean => {
   return supportsAdditionalResponseField(item) && item.config.additionalResponseOption.textInputOption
 }
 
@@ -48,6 +37,6 @@ export const hasAdditionalResponse = (item: appletModel.ItemRecord): boolean => 
  * @param item Any item, even those that don't support additional response fields
  * @returns Whether the item requires an additional response
  */
-export const requiresAdditionalResponse = (item: appletModel.ItemRecord): boolean => {
+export const requiresAdditionalResponse = (item: Pick<appletModel.ItemRecord, "responseType" | "config">): boolean => {
   return supportsAdditionalResponseField(item) && item.config.additionalResponseOption.textInputRequired
 }

--- a/src/entities/activity/lib/helpers.ts
+++ b/src/entities/activity/lib/helpers.ts
@@ -42,3 +42,12 @@ export const supportsAdditonalResponseField = (
 export const hasAdditionalResponse = (item: appletModel.ItemRecord): boolean => {
   return supportsAdditonalResponseField(item) && item.config.additionalResponseOption.textInputOption
 }
+
+/**
+ * Check whether an item has been configured with a required additional response field
+ * @param item Any item, even those that don't support additional response fields
+ * @returns Whether the item requires an additional response
+ */
+export const requiresAdditionalResponse = (item: appletModel.ItemRecord): boolean => {
+  return supportsAdditonalResponseField(item) && item.config.additionalResponseOption.textInputRequired
+}

--- a/src/entities/activity/lib/helpers.ts
+++ b/src/entities/activity/lib/helpers.ts
@@ -15,7 +15,7 @@ export function isSupportedActivity(itemResponseTypes?: Array<ItemResponseTypeDT
  * @param item Any item
  * @returns Whether the item type supports additional text responses
  */
-export const supportsAdditonalResponseField = (
+export const supportsAdditionalResponseField = (
   item: appletModel.ItemRecord,
 ): item is appletModel.ItemWithAdditionalResponse => {
   return [
@@ -40,7 +40,7 @@ export const supportsAdditonalResponseField = (
  * @returns Whether the item has an additional response field
  */
 export const hasAdditionalResponse = (item: appletModel.ItemRecord): boolean => {
-  return supportsAdditonalResponseField(item) && item.config.additionalResponseOption.textInputOption
+  return supportsAdditionalResponseField(item) && item.config.additionalResponseOption.textInputOption
 }
 
 /**
@@ -49,5 +49,5 @@ export const hasAdditionalResponse = (item: appletModel.ItemRecord): boolean => 
  * @returns Whether the item requires an additional response
  */
 export const requiresAdditionalResponse = (item: appletModel.ItemRecord): boolean => {
-  return supportsAdditonalResponseField(item) && item.config.additionalResponseOption.textInputRequired
+  return supportsAdditionalResponseField(item) && item.config.additionalResponseOption.textInputRequired
 }

--- a/src/entities/activity/lib/types/item.ts
+++ b/src/entities/activity/lib/types/item.ts
@@ -48,6 +48,7 @@ export interface ActivityItemBase {
   config: Config
   responseValues: ResponseValues
   answer: Answer
+  additionalText?: string | null
   conditionalLogic: ConditionalLogic | null
 }
 

--- a/src/entities/activity/ui/ActivityCardItem.tsx
+++ b/src/entities/activity/ui/ActivityCardItem.tsx
@@ -1,10 +1,13 @@
 import { useMemo } from "react"
 
+import { AdditionalTextResponse } from "./AdditionalTextResponse"
 import { ItemPicker } from "./items/ItemPicker"
+import { hasAdditionalResponse } from "../lib"
 
 import { appletModel } from "~/entities/applet"
 import { SliderAnimation } from "~/shared/animations"
 import { CardItem } from "~/shared/ui"
+import { useCustomTranslation } from "~/shared/utils"
 
 type ActivityCardItemProps = {
   item: appletModel.ItemRecord
@@ -12,6 +15,8 @@ type ActivityCardItemProps = {
   allowToSkipAllItems?: boolean | undefined
 
   onValueChange: (value: string[]) => void
+
+  onItemAdditionalTextChange: (value: string) => void
 
   replaceText: (value: string) => string
 
@@ -27,12 +32,15 @@ export const ActivityCardItem = ({
   step,
   prevStep,
   onValueChange,
+  onItemAdditionalTextChange,
 }: ActivityCardItemProps) => {
   const questionText = useMemo(() => {
     return replaceText(item.question)
   }, [item.question, replaceText])
 
   const isOptionalFlagHidden = ["message", "audioPlayer", "splashScreen"].includes(item.responseType)
+
+  const { t } = useCustomTranslation()
 
   return (
     <SliderAnimation step={step} prevStep={prevStep ?? step}>
@@ -42,6 +50,14 @@ export const ActivityCardItem = ({
         isOptional={!isOptionalFlagHidden && (item.config.skippableItem || allowToSkipAllItems)}>
         <ItemPicker item={item} onValueChange={onValueChange} isDisabled={false} replaceText={replaceText} />
       </CardItem>
+      {hasAdditionalResponse(item) && (
+        <CardItem
+          markdown={t("additional.additional_text")}
+          watermark={watermark}
+          isOptional={!isOptionalFlagHidden && (item.config.skippableItem || allowToSkipAllItems)}>
+          <AdditionalTextResponse value={item.additionalText || ""} onValueChange={onItemAdditionalTextChange} />
+        </CardItem>
+      )}
     </SliderAnimation>
   )
 }

--- a/src/entities/activity/ui/ActivityCardItem.tsx
+++ b/src/entities/activity/ui/ActivityCardItem.tsx
@@ -2,7 +2,7 @@ import { useMemo } from "react"
 
 import { AdditionalTextResponse } from "./AdditionalTextResponse"
 import { ItemPicker } from "./items/ItemPicker"
-import { hasAdditionalResponse } from "../lib"
+import { hasAdditionalResponse, requiresAdditionalResponse } from "../lib"
 
 import { appletModel } from "~/entities/applet"
 import { SliderAnimation } from "~/shared/animations"
@@ -42,6 +42,10 @@ export const ActivityCardItem = ({
 
   const { t } = useCustomTranslation()
 
+  const additionalTextLabel = requiresAdditionalResponse(item)
+    ? t("additional.additional_text")
+    : t("additional.additional_text_required")
+
   return (
     <SliderAnimation step={step} prevStep={prevStep ?? step}>
       <CardItem
@@ -52,7 +56,7 @@ export const ActivityCardItem = ({
       </CardItem>
       {hasAdditionalResponse(item) && (
         <CardItem
-          markdown={t("additional.additional_text")}
+          markdown={additionalTextLabel}
           watermark={watermark}
           isOptional={!isOptionalFlagHidden && (item.config.skippableItem || allowToSkipAllItems)}>
           <AdditionalTextResponse value={item.additionalText || ""} onValueChange={onItemAdditionalTextChange} />

--- a/src/entities/activity/ui/ActivityCardItem.tsx
+++ b/src/entities/activity/ui/ActivityCardItem.tsx
@@ -42,10 +42,6 @@ export const ActivityCardItem = ({
 
   const { t } = useCustomTranslation()
 
-  const additionalTextLabel = requiresAdditionalResponse(item)
-    ? t("additional.additional_text")
-    : t("additional.additional_text_required")
-
   return (
     <SliderAnimation step={step} prevStep={prevStep ?? step}>
       <CardItem
@@ -56,9 +52,9 @@ export const ActivityCardItem = ({
       </CardItem>
       {hasAdditionalResponse(item) && (
         <CardItem
-          markdown={additionalTextLabel}
+          markdown={t("additional.additional_text")}
           watermark={watermark}
-          isOptional={!isOptionalFlagHidden && (item.config.skippableItem || allowToSkipAllItems)}>
+          isOptional={!requiresAdditionalResponse(item)}>
           <AdditionalTextResponse value={item.additionalText || ""} onValueChange={onItemAdditionalTextChange} />
         </CardItem>
       )}

--- a/src/entities/activity/ui/AdditionalTextResponse.tsx
+++ b/src/entities/activity/ui/AdditionalTextResponse.tsx
@@ -6,21 +6,7 @@ type AdditionalTextResponseProps = {
 }
 
 export const AdditionalTextResponse = ({ value, onValueChange }: AdditionalTextResponseProps) => {
-  const onHandleValueChange = (value: string) => {
-    if (value.length === 0) {
-      return onValueChange("")
-    }
-
-    return onValueChange(value)
-  }
-
   return (
-    <TextField
-      fullWidth
-      size="small"
-      value={value}
-      onChange={e => onHandleValueChange(e.target.value)}
-      disabled={false}
-    />
+    <TextField fullWidth size="small" value={value} onChange={e => onValueChange(e.target.value)} disabled={false} />
   )
 }

--- a/src/entities/activity/ui/AdditionalTextResponse.tsx
+++ b/src/entities/activity/ui/AdditionalTextResponse.tsx
@@ -1,0 +1,26 @@
+import TextField from "@mui/material/TextField"
+
+type AdditionalTextResponseProps = {
+  value: string
+  onValueChange: (value: string) => void
+}
+
+export const AdditionalTextResponse = ({ value, onValueChange }: AdditionalTextResponseProps) => {
+  const onHandleValueChange = (value: string) => {
+    if (value.length === 0) {
+      return onValueChange("")
+    }
+
+    return onValueChange(value)
+  }
+
+  return (
+    <TextField
+      fullWidth
+      size="small"
+      value={value}
+      onChange={e => onHandleValueChange(e.target.value)}
+      disabled={false}
+    />
+  )
+}

--- a/src/entities/activity/ui/index.ts
+++ b/src/entities/activity/ui/index.ts
@@ -1,2 +1,3 @@
 export * from "./ActivityCardItem"
 export * from "./ItemCardButtons"
+export * from "./AdditionalTextResponse"

--- a/src/entities/applet/model/hooks/useSaveActivityItemAnswer.ts
+++ b/src/entities/applet/model/hooks/useSaveActivityItemAnswer.ts
@@ -26,7 +26,22 @@ export const useSaveItemAnswer = ({ activityId, eventId }: Props) => {
     [dispatch, activityId, eventId],
   )
 
+  const saveItemAdditionalText = useCallback(
+    (itemId: string, additionalText: string) => {
+      dispatch(
+        actions.saveAdditionalText({
+          entityId: activityId,
+          eventId,
+          itemId,
+          additionalText,
+        }),
+      )
+    },
+    [dispatch, activityId, eventId],
+  )
+
   return {
     saveItemAnswer,
+    saveItemAdditionalText,
   }
 }

--- a/src/entities/applet/model/hooks/useUserEvents.ts
+++ b/src/entities/applet/model/hooks/useUserEvents.ts
@@ -54,6 +54,8 @@ export const useUserEvents = (props: Props) => {
       if (item.responseType === "text" && userEvents.length > 0) {
         const lastUserEvent = userEvents[userEvents.length - 1]
 
+        // We're only interested in updated the previous event if it is a text item
+        // Otherwise we create a new event with the subsequent answer below
         if (lastUserEvent.screen === activityItemScreenId && lastUserEvent.type === "SET_ANSWER") {
           return dispatch(
             actions.updateUserEventByIndex({
@@ -71,6 +73,8 @@ export const useUserEvents = (props: Props) => {
         }
       }
 
+      // In all cases besides the text item, we create a new event to reflect
+      // the updated answer
       return dispatch(
         actions.saveUserEvent({
           entityId: props.activityId,
@@ -99,38 +103,84 @@ export const useUserEvents = (props: Props) => {
       const activityItemScreenId = getActivityItemScreenId(props.activityId, item.id)
 
       if (userEvents.length > 0) {
-        const lastUserEvent = userEvents[userEvents.length - 1]
+        const previousUserEvent = userEvents[userEvents.length - 1]
 
-        if (lastUserEvent.screen === activityItemScreenId && lastUserEvent.type === "SET_ADDITIONAL_TEXT") {
+        if (
+          previousUserEvent.screen === activityItemScreenId &&
+          previousUserEvent.type === "SET_ANSWER" &&
+          typeof previousUserEvent.response !== "string"
+        ) {
+          // We want to always update the previous event when it is a SET_ANSWER event for
+          // the same item. However, the data model currently only supports additional text
+          // on events for singleSelect and multiSelect items
           return dispatch(
             actions.updateUserEventByIndex({
               entityId: props.activityId,
               eventId: props.eventId,
               userEventIndex: userEvents.length - 1,
               userEvent: {
-                type: "SET_ADDITIONAL_TEXT",
+                type: "SET_ANSWER",
                 screen: activityItemScreenId,
                 time: Date.now(),
-                response: item.additionalText,
+                response: {
+                  // The type doesn't allow setting a null value here, but the flow logic
+                  // prevents proceeding without setting the actual answer so using []
+                  // should be fine
+                  value: previousUserEvent.response?.value ?? [],
+                  text: item.additionalText,
+                },
               },
             }),
           )
         }
       }
 
-      return dispatch(
-        actions.saveUserEvent({
-          entityId: props.activityId,
-          eventId: props.eventId,
-          itemId: item.id,
-          userEvent: {
-            type: "SET_ADDITIONAL_TEXT",
-            screen: activityItemScreenId,
-            time: Date.now(),
-            response: item.additionalText,
-          },
-        }),
-      )
+      // Create a new event in all other cases
+      if (item.responseType === "singleSelect" || item.responseType === "multiSelect") {
+        const response = mapItemAnswerToUserEventResponse(item)
+
+        if (typeof response !== "object") {
+          // This should never happen since text items don't have additional text
+          // but the TS compiler doesn't know that
+          return
+        }
+
+        return dispatch(
+          actions.saveUserEvent({
+            entityId: props.activityId,
+            eventId: props.eventId,
+            itemId: item.id,
+            userEvent: {
+              type: "SET_ANSWER",
+              screen: activityItemScreenId,
+              time: Date.now(),
+              response: {
+                value: response.value,
+                text: item.additionalText,
+              },
+            },
+          }),
+        )
+      } else {
+        // The user event data model for other item types don't yet
+        // support additional text, so we just save the additional text
+        return dispatch(
+          actions.saveUserEvent({
+            entityId: props.activityId,
+            eventId: props.eventId,
+            itemId: item.id,
+            userEvent: {
+              type: "SET_ANSWER",
+              screen: activityItemScreenId,
+              time: Date.now(),
+              response: {
+                value: [],
+                text: item.additionalText,
+              },
+            },
+          }),
+        )
+      }
     },
     [activityProgress, dispatch, props.activityId, props.eventId],
   )

--- a/src/entities/applet/model/hooks/useUserEvents.ts
+++ b/src/entities/applet/model/hooks/useUserEvents.ts
@@ -88,5 +88,52 @@ export const useUserEvents = (props: Props) => {
     [activityProgress, dispatch, props.activityId, props.eventId],
   )
 
-  return { saveUserEventByType, saveSetAnswerUserEvent }
+  const saveSetAdditionalTextUserEvent = useCallback(
+    (item: ItemRecord) => {
+      if (!activityProgress || item.additionalText === null || item.additionalText === undefined) {
+        return
+      }
+
+      const userEvents = activityProgress.userEvents
+
+      const activityItemScreenId = getActivityItemScreenId(props.activityId, item.id)
+
+      if (userEvents.length > 0) {
+        const lastUserEvent = userEvents[userEvents.length - 1]
+
+        if (lastUserEvent.screen === activityItemScreenId && lastUserEvent.type === "SET_ADDITIONAL_TEXT") {
+          return dispatch(
+            actions.updateUserEventByIndex({
+              entityId: props.activityId,
+              eventId: props.eventId,
+              userEventIndex: userEvents.length - 1,
+              userEvent: {
+                type: "SET_ADDITIONAL_TEXT",
+                screen: activityItemScreenId,
+                time: Date.now(),
+                response: item.additionalText,
+              },
+            }),
+          )
+        }
+      }
+
+      return dispatch(
+        actions.saveUserEvent({
+          entityId: props.activityId,
+          eventId: props.eventId,
+          itemId: item.id,
+          userEvent: {
+            type: "SET_ADDITIONAL_TEXT",
+            screen: activityItemScreenId,
+            time: Date.now(),
+            response: item.additionalText,
+          },
+        }),
+      )
+    },
+    [activityProgress, dispatch, props.activityId, props.eventId],
+  )
+
+  return { saveUserEventByType, saveSetAnswerUserEvent, saveSetAdditionalTextUserEvent }
 }

--- a/src/entities/applet/model/mapper.ts
+++ b/src/entities/applet/model/mapper.ts
@@ -9,12 +9,14 @@ export const mapItemAnswerToUserEventResponse = (item: ItemRecord): UserEventRes
   if (responseType === "singleSelect") {
     return {
       value: [Number(itemAnswer[0])],
+      text: item.additionalText ?? undefined,
     }
   }
 
   if (responseType === "multiSelect") {
     return {
       value: itemAnswer.map(answer => Number(answer)),
+      text: item.additionalText ?? undefined,
     }
   }
 

--- a/src/entities/applet/model/mapper.ts
+++ b/src/entities/applet/model/mapper.ts
@@ -20,7 +20,10 @@ export const mapItemAnswerToUserEventResponse = (item: ItemRecord): UserEventRes
     }
   }
 
-  return itemAnswer[0]
+  return {
+    value: itemAnswer[0],
+    text: item.additionalText ?? undefined,
+  }
 }
 
 export function mapItemToRecord(item: ActivityItemDetailsDTO): ItemRecord {

--- a/src/entities/applet/model/slice.ts
+++ b/src/entities/applet/model/slice.ts
@@ -15,6 +15,7 @@ import {
   UpdateStepPayload,
   UpdateUserEventByIndexPayload,
   SaveGroupProgressPayload,
+  SaveItemAdditionalTextPayload,
 } from "./types"
 
 import { ActivityPipelineType, GroupProgress, FlowProgress, getProgressId, GroupProgressState } from "~/abstract/lib"
@@ -82,6 +83,30 @@ const appletsSlice = createSlice({
 
       activityProgress.items[itemIndex].answer = action.payload.answer
     },
+
+    /**
+     * Reducer for saving additionaltext
+     * @param state
+     * @param action
+     * @returns
+     */
+    saveAdditionalText: (state, action: PayloadAction<SaveItemAdditionalTextPayload>) => {
+      const id = getProgressId(action.payload.entityId, action.payload.eventId)
+      const activityProgress = state.progress[id]
+
+      if (!activityProgress) {
+        return state
+      }
+
+      const itemIndex = activityProgress.items.findIndex(({ id }) => id === action.payload.itemId)
+
+      if (itemIndex === -1) {
+        return state
+      }
+
+      activityProgress.items[itemIndex].additionalText = action.payload.additionalText
+    },
+
     saveUserEvent: (state, action: PayloadAction<SaveUserEventPayload>) => {
       const id = getProgressId(action.payload.entityId, action.payload.eventId)
       const activityProgress = state.progress[id]

--- a/src/entities/applet/model/types.ts
+++ b/src/entities/applet/model/types.ts
@@ -18,7 +18,7 @@ export type UserEventTypes = "SET_ANSWER" | "PREV" | "NEXT" | "SKIP" | "DONE"
 export type UserEventResponse =
   | string
   | {
-      value: number[]
+      value: string | string[] | number[]
       text?: string
     }
 

--- a/src/entities/applet/model/types.ts
+++ b/src/entities/applet/model/types.ts
@@ -41,6 +41,11 @@ export type ItemRecord =
   | TimeRangeItem
   | AudioPlayerItem
 
+export type ItemWithAdditionalResponse = Extract<
+  ItemRecord,
+  CheckboxItem | RadioItem | SliderItem | SelectorItem | DateItem | TimeItem | TimeRangeItem | AudioPlayerItem
+>
+
 export type ActivityProgress = {
   items: ItemRecord[]
   step: number

--- a/src/entities/applet/model/types.ts
+++ b/src/entities/applet/model/types.ts
@@ -82,6 +82,13 @@ export type SaveItemAnswerPayload = {
   answer: string[]
 }
 
+export type SaveItemAdditionalTextPayload = {
+  entityId: string
+  eventId: string
+  itemId: string
+  additionalText: string
+}
+
 export type UpdateStepPayload = {
   activityId: string
   eventId: string

--- a/src/entities/applet/model/types.ts
+++ b/src/entities/applet/model/types.ts
@@ -13,12 +13,13 @@ import {
   TimeRangeItem,
 } from "~/entities/activity/lib"
 
-export type UserEventTypes = "SET_ANSWER" | "SET_ADDITIONAL_TEXT" | "PREV" | "NEXT" | "SKIP" | "DONE"
+export type UserEventTypes = "SET_ANSWER" | "PREV" | "NEXT" | "SKIP" | "DONE"
 
 export type UserEventResponse =
   | string
   | {
       value: number[]
+      text?: string
     }
 
 export type UserEvents = {

--- a/src/entities/applet/model/types.ts
+++ b/src/entities/applet/model/types.ts
@@ -13,7 +13,7 @@ import {
   TimeRangeItem,
 } from "~/entities/activity/lib"
 
-export type UserEventTypes = "SET_ANSWER" | "PREV" | "NEXT" | "SKIP" | "DONE"
+export type UserEventTypes = "SET_ANSWER" | "SET_ADDITIONAL_TEXT" | "PREV" | "NEXT" | "SKIP" | "DONE"
 
 export type UserEventResponse =
   | string

--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -256,7 +256,8 @@
       "footer_text": "CHILD MIND INSTITUTE, INC. AND CHILD MIND MEDICAL PRACTICE, PLLC (TOGETHER, “CMI”) DOES NOT DIRECTLY OR INDIRECTLY PRACTICE MEDICINE OR DISPENSE MEDICAL ADVICE AS PART OF THIS QUESTIONNAIRE. CMI ASSUMES NO LIABILITY FOR ANY DIAGNOSIS, TREATMENT, DECISION MADE, OR ACTION TAKEN IN RELIANCE UPON INFORMATION PROVIDED BY THIS QUESTIONNAIRE, AND ASSUMES NO RESPONSIBILITY FOR YOUR USE OF THIS QUESTIONNAIRE.",
       "child_score": "Your Child's Score",
       "child_score_on_subscale": "Your child’s score on the {{name}} subscale was",
-      "fill_out_fields": "Please fill out the required fields"
+      "fill_out_fields": "Please fill out the required fields",
+      "additional_text": "Additional Text"
     },
     "no_markdown": "The authors of this applet have not provided any information!",
     "no_applets": "You currently do not have any applets."

--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -258,8 +258,7 @@
       "child_score": "Your Child's Score",
       "child_score_on_subscale": "Your child’s score on the {{name}} subscale was",
       "fill_out_fields": "Please fill out the required fields",
-      "additional_text": "Additional Text",
-      "additional_text_required": "Additional Text (required)"
+      "additional_text": "Additional Text"
     },
     "no_markdown": "The authors of this applet have not provided any information!",
     "no_applets": "You currently do not have any applets."

--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -15,6 +15,7 @@
     "save_and_exit": "Save & exit",
     "optional": "Optional",
     "pleaseAnswerTheQuestion": "Please answer the question.",
+    "pleaseProvideAdditionalText": "Please provide additional text",
     "onlyNumbersAllowed": "Only numbers are allowed",
 
     "question_count_plural": "{{length}} questions",
@@ -257,7 +258,8 @@
       "child_score": "Your Child's Score",
       "child_score_on_subscale": "Your child’s score on the {{name}} subscale was",
       "fill_out_fields": "Please fill out the required fields",
-      "additional_text": "Additional Text"
+      "additional_text": "Additional Text",
+      "additional_text_required": "Additional Text (required)"
     },
     "no_markdown": "The authors of this applet have not provided any information!",
     "no_applets": "You currently do not have any applets."

--- a/src/i18n/fr/translation.json
+++ b/src/i18n/fr/translation.json
@@ -264,7 +264,8 @@
       "child_score_on_subscale": "Le score de votre enfant pour la sous-échelle {{name}} est de",
       "share_report": "Partager le rapport",
       "share_all_reports": "Partager tous les rapports",
-      "fill_out_fields": "Veuillez remplir les champs obligatoires"
+      "fill_out_fields": "Veuillez remplir les champs obligatoires",
+      "additional_text": "Additional Text"
     },
     "no_markdown": "Les auteurs de cette applet n'ont fourni aucune information !",
     "no_applets": "Vous n'avez actuellement pas d'applets."

--- a/src/i18n/fr/translation.json
+++ b/src/i18n/fr/translation.json
@@ -265,7 +265,7 @@
       "share_report": "Partager le rapport",
       "share_all_reports": "Partager tous les rapports",
       "fill_out_fields": "Veuillez remplir les champs obligatoires",
-      "additional_text": "Additional Text"
+      "additional_text": "Texte supplémentaire"
     },
     "no_markdown": "Les auteurs de cette applet n'ont fourni aucune information !",
     "no_applets": "Vous n'avez actuellement pas d'applets."

--- a/src/i18n/fr/translation.json
+++ b/src/i18n/fr/translation.json
@@ -15,6 +15,7 @@
     "save_and_exit": "Enregistrer et quitter",
     "optional": "Facultatif",
     "pleaseAnswerTheQuestion": "Veuillez répondre à la question.",
+    "pleaseProvideAdditionalText": "Veuillez fournir un texte supplémentaire",
     "onlyNumbersAllowed": "Seuls les numéros sont autorisés",
     
 
@@ -265,7 +266,8 @@
       "share_report": "Partager le rapport",
       "share_all_reports": "Partager tous les rapports",
       "fill_out_fields": "Veuillez remplir les champs obligatoires",
-      "additional_text": "Texte supplémentaire"
+      "additional_text": "Texte supplémentaire",
+      "additional_text_required": "Texte supplémentaire (obligatoire)"
     },
     "no_markdown": "Les auteurs de cette applet n'ont fourni aucune information !",
     "no_applets": "Vous n'avez actuellement pas d'applets."

--- a/src/i18n/fr/translation.json
+++ b/src/i18n/fr/translation.json
@@ -266,8 +266,7 @@
       "share_report": "Partager le rapport",
       "share_all_reports": "Partager tous les rapports",
       "fill_out_fields": "Veuillez remplir les champs obligatoires",
-      "additional_text": "Texte supplémentaire",
-      "additional_text_required": "Texte supplémentaire (obligatoire)"
+      "additional_text": "Texte supplémentaire"
     },
     "no_markdown": "Les auteurs de cette applet n'ont fourni aucune information !",
     "no_applets": "Vous n'avez actuellement pas d'applets."

--- a/src/shared/api/services/axios.ts
+++ b/src/shared/api/services/axios.ts
@@ -19,6 +19,8 @@ axiosService.interceptors.request.use(
     const tokens = secureTokensStorage.getTokens()
 
     if (tokens?.accessToken && tokens?.tokenType) {
+      // @ts-expect-error This error was introduced in https://github.com/ChildMindInstitute/mindlogger-web-refactor/pull/342
+      // and I don't really want to change it as part of this PR
       config.headers.Authorization = `${tokens.tokenType} ${tokens.accessToken}`
     }
 

--- a/src/shared/api/services/axios.ts
+++ b/src/shared/api/services/axios.ts
@@ -19,8 +19,6 @@ axiosService.interceptors.request.use(
     const tokens = secureTokensStorage.getTokens()
 
     if (tokens?.accessToken && tokens?.tokenType) {
-      // @ts-expect-error This error was introduced in https://github.com/ChildMindInstitute/mindlogger-web-refactor/pull/342
-      // and I don't really want to change it as part of this PR
       config.headers.Authorization = `${tokens.tokenType} ${tokens.accessToken}`
     }
 

--- a/src/shared/api/types/item.ts
+++ b/src/shared/api/types/item.ts
@@ -54,6 +54,13 @@ export type ResponseValuesDTO =
 
 export type EmptyResponseValuesDTO = null
 
+export type AdditionalResponseOptionConfigDTO = {
+  additionalResponseOption: {
+    textInputOption: boolean
+    textInputRequired: boolean
+  }
+}
+
 export interface TextItemDTO extends ItemDetailsBaseDTO {
   responseType: "text"
   config: TextItemConfigDTO
@@ -77,7 +84,7 @@ export interface CheckboxItemDTO extends ItemDetailsBaseDTO {
   responseValues: CheckboxItemResponseValuesDTO
 }
 
-export type CheckboxItemConfigDTO = {
+export type CheckboxItemConfigDTO = AdditionalResponseOptionConfigDTO & {
   removeBackButton: boolean
   skippableItem: boolean
   randomizeOptions: boolean
@@ -86,10 +93,6 @@ export type CheckboxItemConfigDTO = {
   setAlerts: boolean
   addTooltip: boolean
   setPalette: boolean
-  additionalResponseOption: {
-    textInputOption: boolean
-    textInputRequired: boolean
-  }
 }
 
 export type CheckboxItemResponseValuesDTO = {
@@ -112,7 +115,7 @@ export interface RadioItemDTO extends ItemDetailsBaseDTO {
   responseValues: RadioItemResponseValuesDTO
 }
 
-export type RadioItemConfigDTO = {
+export type RadioItemConfigDTO = AdditionalResponseOptionConfigDTO & {
   removeBackButton: boolean
   skippableItem: boolean
   randomizeOptions: boolean
@@ -122,10 +125,6 @@ export type RadioItemConfigDTO = {
   addTooltip: boolean
   setPalette: boolean
   autoAdvance: boolean
-  additionalResponseOption: {
-    textInputOption: boolean
-    textInputRequired: boolean
-  }
 }
 
 export type RadioItemResponseValuesDTO = {
@@ -148,7 +147,7 @@ export interface SliderItemDTO extends ItemDetailsBaseDTO {
   responseValues: SliderItemResponseValuesDTO
 }
 
-export type SliderItemConfigDTO = {
+export type SliderItemConfigDTO = AdditionalResponseOptionConfigDTO & {
   addScores: boolean
   setAlerts: boolean
   showTickMarks: boolean
@@ -157,10 +156,6 @@ export type SliderItemConfigDTO = {
   removeBackButton: boolean
   skippableItem: boolean
   timer: number | null
-  additionalResponseOption: {
-    textInputOption: boolean
-    textInputRequired: boolean
-  }
 }
 
 export type SliderItemResponseValuesDTO = {
@@ -185,13 +180,9 @@ export interface SelectorItemDTO extends ItemDetailsBaseDTO {
   responseValues: SelectorItemResponseValues
 }
 
-export type SelectorItemConfigDTO = {
+export type SelectorItemConfigDTO = AdditionalResponseOptionConfigDTO & {
   removeBackButton: boolean
   skippableItem: boolean
-  additionalResponseOption: {
-    textInputOption: boolean
-    textInputRequired: boolean
-  }
 }
 
 export type SelectorItemResponseValues = {
@@ -216,14 +207,10 @@ export interface DateItemDTO extends ItemDetailsBaseDTO {
   responseValues: EmptyResponseValuesDTO
 }
 
-export type DateItemConfigDTO = {
+export type DateItemConfigDTO = AdditionalResponseOptionConfigDTO & {
   removeBackButton: boolean
   skippableItem: boolean
   timer: number | null
-  additionalResponseOption: {
-    textInputOption: boolean
-    textInputRequired: boolean
-  }
 }
 
 export interface TimeItemDTO extends ItemDetailsBaseDTO {
@@ -232,14 +219,10 @@ export interface TimeItemDTO extends ItemDetailsBaseDTO {
   responseValues: EmptyResponseValuesDTO
 }
 
-export type TimeItemConfigDTO = {
+export type TimeItemConfigDTO = AdditionalResponseOptionConfigDTO & {
   removeBackButton: boolean
   skippableItem: boolean
   timer: number | null
-  additionalResponseOption: {
-    textInputOption: boolean
-    textInputRequired: boolean
-  }
 }
 
 export interface TimeRangeItemDTO extends ItemDetailsBaseDTO {
@@ -248,14 +231,10 @@ export interface TimeRangeItemDTO extends ItemDetailsBaseDTO {
   responseValues: EmptyResponseValuesDTO
 }
 
-export type TimeRangeItemConfigDTO = {
+export type TimeRangeItemConfigDTO = AdditionalResponseOptionConfigDTO & {
   removeBackButton: boolean
   skippableItem: boolean
   timer: number | null
-  additionalResponseOption: {
-    textInputOption: boolean
-    textInputRequired: boolean
-  }
 }
 
 export interface AudioPlayerItemDTO extends ItemDetailsBaseDTO {
@@ -264,14 +243,10 @@ export interface AudioPlayerItemDTO extends ItemDetailsBaseDTO {
   responseValues: AudioPlayerItemResponseValuesDTO
 }
 
-export type AudioPlayerItemConfigDTO = {
+export type AudioPlayerItemConfigDTO = AdditionalResponseOptionConfigDTO & {
   playOnce: boolean
   removeBackButton: boolean
   skippableItem: boolean
-  additionalResponseOption: {
-    textInputOption: boolean
-    textInputRequired: boolean
-  }
 }
 
 export type AudioPlayerItemResponseValuesDTO = {

--- a/src/widgets/ActivityDetails/model/hooks/useAutoForward.ts
+++ b/src/widgets/ActivityDetails/model/hooks/useAutoForward.ts
@@ -1,5 +1,6 @@
 import { useEffect } from "react"
 
+import { hasAdditionalResponse } from "~/entities/activity/lib/helpers"
 import { appletModel } from "~/entities/applet"
 import { usePrevious } from "~/shared/utils"
 
@@ -31,7 +32,18 @@ export const useAutoForward = ({ item, onForward, hasNextStep }: Props) => {
 
     const isHasAnswer = item.answer.length > 0
 
-    if (isSingleSelect && isHasAnswer && hasNextStep && isAnswerChanged && isAutoForwardEnabled) {
+    // If there's an additional text field we probably shouldn't auto advance,
+    // even if the field is populated
+    const hasAdditionalTextField = hasAdditionalResponse(item)
+
+    if (
+      isSingleSelect &&
+      isHasAnswer &&
+      hasNextStep &&
+      isAnswerChanged &&
+      isAutoForwardEnabled &&
+      !hasAdditionalTextField
+    ) {
       onForward()
     }
   }, [hasNextStep, item, onForward, prevItem?.answer, prevItem?.id])

--- a/src/widgets/ActivityDetails/model/mappers.ts
+++ b/src/widgets/ActivityDetails/model/mappers.ts
@@ -95,7 +95,7 @@ function convertToSingleSelectAnswer(item: RadioItem): ItemAnswer<SingleSelectAn
   return {
     answer: {
       value: Number(item.answer[0]),
-      text: null,
+      text: item.additionalText || null,
     },
     itemId: item.id,
   }
@@ -112,7 +112,7 @@ function convertToMultiSelectAnswer(item: CheckboxItem): ItemAnswer<MultiSelectA
   return {
     answer: {
       value: item.answer.map(strValue => Number(strValue)),
-      text: null,
+      text: item.additionalText || null,
     },
     itemId: item.id,
   }
@@ -129,7 +129,7 @@ function convertToSliderAnswer(item: SliderItem): ItemAnswer<SliderAnswerPayload
   return {
     answer: {
       value: Number(item.answer[0]),
-      text: null,
+      text: item.additionalText || null,
     },
     itemId: item.id,
   }
@@ -146,7 +146,7 @@ function convertToNumberSelectAnswer(item: SelectorItem): ItemAnswer<NumberSelec
   return {
     answer: {
       value: Number(item.answer[0]),
-      text: null,
+      text: item.additionalText || null,
     },
     itemId: item.id,
   }
@@ -170,7 +170,7 @@ function convertToDateAnswer(item: DateItem): ItemAnswer<DateAnswerPayload> {
   return {
     answer: {
       value: dateToDayMonthYear(new Date(item.answer[0])),
-      text: null,
+      text: item.additionalText || null,
     },
     itemId: item.id,
   }
@@ -187,7 +187,7 @@ function convertToTimeAnswer(item: TimeItem): ItemAnswer<TimeAnswerPayload> {
   return {
     answer: {
       value: dateToHourMinute(new Date(item.answer[0])),
-      text: null,
+      text: item.additionalText || null,
     },
     itemId: item.id,
   }
@@ -210,7 +210,7 @@ function convertToTimeRangeAnswer(item: TimeRangeItem): ItemAnswer<TimeRangeAnsw
         from: { hour: fromDate.getHours(), minute: fromDate.getMinutes() },
         to: { hour: toDate.getHours(), minute: toDate.getMinutes() },
       },
-      text: null,
+      text: item.additionalText || null,
     },
     itemId: item.id,
   }

--- a/src/widgets/ActivityDetails/model/validateItem.ts
+++ b/src/widgets/ActivityDetails/model/validateItem.ts
@@ -1,3 +1,4 @@
+import { hasAdditionalResponse, requiresAdditionalResponse } from "~/entities/activity/lib/helpers"
 import { appletModel } from "~/entities/applet"
 import { ActivityDTO } from "~/shared/api"
 import { stringContainsOnlyNumbers, validateDate, validateTime } from "~/shared/utils"
@@ -95,6 +96,15 @@ export function validateBeforeMoveForward({ item, activity, showWarning }: Valid
 
   if (isNumericOnly) {
     showWarning("onlyNumbersAllowed")
+    return false
+  }
+
+  const hasAdditionalTextField = hasAdditionalResponse(item)
+  const isAdditionalTextRequired = hasAdditionalTextField && requiresAdditionalResponse(item)
+  const isAdditionalTextEmpty = hasAdditionalTextField && !item.additionalText
+
+  if (isAdditionalTextRequired && isAdditionalTextEmpty) {
+    showWarning("pleaseProvideAdditionalText")
     return false
   }
 

--- a/src/widgets/ActivityDetails/ui/AssessmentPassingScreen.tsx
+++ b/src/widgets/ActivityDetails/ui/AssessmentPassingScreen.tsx
@@ -50,10 +50,11 @@ export const AssessmentPassingScreen = (props: Props) => {
 
   const { incrementStep, decrementStep } = appletModel.hooks.useActivityProgress()
 
-  const { saveUserEventByType, saveSetAnswerUserEvent } = appletModel.hooks.useUserEvents({
-    activityId,
-    eventId,
-  })
+  const { saveUserEventByType, saveSetAnswerUserEvent, saveSetAdditionalTextUserEvent } =
+    appletModel.hooks.useUserEvents({
+      activityId,
+      eventId,
+    })
 
   const { saveItemAnswer, saveItemAdditionalText } = appletModel.hooks.useSaveItemAnswer({
     activityId,
@@ -161,7 +162,10 @@ export const AssessmentPassingScreen = (props: Props) => {
 
   const onItemAdditionalTextChange = (value: string) => {
     saveItemAdditionalText(item.id, value)
-    // TODO: saveSetAdditionalTextUserEvent
+    saveSetAdditionalTextUserEvent({
+      ...item,
+      additionalText: value,
+    })
   }
 
   useAutoForward({

--- a/src/widgets/ActivityDetails/ui/AssessmentPassingScreen.tsx
+++ b/src/widgets/ActivityDetails/ui/AssessmentPassingScreen.tsx
@@ -55,7 +55,7 @@ export const AssessmentPassingScreen = (props: Props) => {
     eventId,
   })
 
-  const { saveItemAnswer } = appletModel.hooks.useSaveItemAnswer({
+  const { saveItemAnswer, saveItemAdditionalText } = appletModel.hooks.useSaveItemAnswer({
     activityId,
     eventId,
   })
@@ -159,6 +159,11 @@ export const AssessmentPassingScreen = (props: Props) => {
     })
   }
 
+  const onItemAdditionalTextChange = (value: string) => {
+    saveItemAdditionalText(item.id, value)
+    // TODO: saveSetAdditionalTextUserEvent
+  }
+
   useAutoForward({
     item,
     hasNextStep,
@@ -196,6 +201,7 @@ export const AssessmentPassingScreen = (props: Props) => {
                 step={step}
                 prevStep={prevStep}
                 onValueChange={onItemValueChange}
+                onItemAdditionalTextChange={onItemAdditionalTextChange}
               />
             )}
           </Box>


### PR DESCRIPTION
resolves: [M2-4833](https://mindlogger.atlassian.net/browse/M2-4833)

### Objective

This PR adds an additional text response field in the respondent web app, for those items that support it:
- Single Selection
- Multiple Selection
- Slider
- Date
- Time
- Time Range
- Audio Player

> [!NOTE]
> There are some items missing, and some present that are not even supported in the web app yet. I just added support based on the items that are represented in the codebase.

The PR covers these criteria:
- When an item type that allows an additional text response is presented to the respondent, clearly display a text input field where they can enter their response. 
- Require the user to provide an additional text response when the item type is configured to require it. Respondents will not be able to move to the next Item without entering a text response if it is configured to require it.
- Additional text responses are properly collected, stored, and associated with the corresponding item type response in the system.

> [!WARNING]
> It's not currently possible to prevent a submission with missing additional text for items that require it. The API will need to be updated to facilitate this.

### Notes

There are a number of scenarios that need to be tested to verify this change
- The additional text field should appear for items with additional text
- The additional text field shouldn't appear for items without additional text
- Auto-advance shouldn't work when additional text field is present
- The next button should be blocked when additional text is required, and the user hasn't provided any
- The additional text field should be repopulated when the user resumes an activity
- The provided additional text should be submitted to the backend

Most of this is easy enough to validate by creating an applet in the admin app, configuring it with additional text, and then verifying the behaviour in the web app on this branch. However, I think it bears mentioning that in order to confirm that the submission includes the additional text, you'll need to do an applet data export from the admin side (since the answers are encrypted on the backend, and the admin app currently doesn't display any additional text with the answers in the UI).

You may perform this data export by selecting the applet in the dashboard, identifying the respondent, and selecting the export data option

https://github.com/ChildMindInstitute/mindlogger-web-refactor/assets/14842108/55f5a634-6cf4-433c-a520-8532f850d6d3

This will download a `report.csv` file containing all the answers from that respondent. In the `response` field, answers containing additional text will be formatted like this

```
value: 2 | text: Some text
```

Where _2_ is the answer to the item and _Some text_ is the additional text.

### Follow up tasks

N/A


[M2-4833]: https://mindlogger.atlassian.net/browse/M2-4833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ