### PR TITLE
M2-4826: Update forgot password expired/invalid link message

### DIFF
--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -179,7 +179,7 @@
       "failed": "Failed",
       "backToLogin": "Back to Log in",
       "backToSettings": "Back to Settings",
-      "invalidLink": "Link is invalid"
+      "invalidLink": "This link is invalid or expired. Please click <a href='/forgotpassword'>here</a> to reset your password."
     },
     "Landing": {
       "title": "Welcome to MindLogger",

--- a/src/i18n/fr/translation.json
+++ b/src/i18n/fr/translation.json
@@ -179,7 +179,7 @@
       "password": "le mot de passe",
       "backToLogin": "Back to Log in",
       "backToSettings": "Back to Settings",
-      "invalidLink": "Link is invalid"
+      "invalidLink": "Ce lien est invalide ou expiré. Veuillez cliquer <a href='/forgotpassword'>ici</a> pour réinitialiser votre mot de passe."
     },
     "Landing": {
       "title": "Bienvenue dans MindLogger",

--- a/src/pages/RecoveryPassword/index.tsx
+++ b/src/pages/RecoveryPassword/index.tsx
@@ -3,8 +3,8 @@ import { useSearchParams } from "react-router-dom"
 
 import { useRecoveryPasswordLinkHealthcheckQuery } from "~/entities/user"
 import { RecoveryPasswordForm, useRecoveryPasswordTranslation } from "~/features/RecoveryPassword"
-import { PageMessage } from "~/shared/ui"
 import Loader from "~/shared/ui/Loader"
+import { Text } from "~/shared/ui/Text"
 
 export default function RecoveryPasswordPage() {
   const [searchParams] = useSearchParams()
@@ -13,14 +13,20 @@ export default function RecoveryPasswordPage() {
   const key = searchParams.get("key")
   const email = searchParams.get("email")
 
-  const { isError, isLoading, error } = useRecoveryPasswordLinkHealthcheckQuery({ email: email!, key: key! })
+  const { isError, isLoading } = useRecoveryPasswordLinkHealthcheckQuery({ email: email!, key: key! })
 
   if (isLoading) {
     return <Loader />
   }
 
   if (isError) {
-    return <PageMessage message={error.evaluatedMessage!} />
+    return (
+      <Box display="flex" flex={1} justifyContent="center" alignItems="center" textAlign="center">
+        <Text variant="body1" fontSize="24px" margin="16px 0px">
+          <Box dangerouslySetInnerHTML={{ __html: t("invalidLink") }} />
+        </Text>
+      </Box>
+    )
   }
 
   return (


### PR DESCRIPTION
resolves: [M2-4826](https://mindlogger.atlassian.net/browse/M2-4826)

### Objective

Update message when user tries to use an invalid/expired link to recover password

### Notes

API endpoint: `/users/me/password/recover/healthcheck`

### Screenshots

![MindLogger](https://github.com/ChildMindInstitute/mindlogger-web-refactor/assets/85007/08bec5a9-c663-4a31-a249-a021b5d727c4)


[M2-4826]: https://mindlogger.atlassian.net/browse/M2-4826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ