### PR TITLE
M2-4827: Post password reset redirection

### DIFF
--- a/src/features/RecoveryPassword/ui/RecoveryPasswordForm.tsx
+++ b/src/features/RecoveryPassword/ui/RecoveryPasswordForm.tsx
@@ -50,7 +50,8 @@ export const RecoveryPasswordForm = ({ title, token, email }: RecoveryPasswordFo
 
   if (status === 'success') {
     // Auto-navigate to the login page
-    return navigate(ROUTES.login.path);
+    navigate(ROUTES.login.path);
+    return <></>;
   }
 
   return (

--- a/src/features/RecoveryPassword/ui/RecoveryPasswordForm.tsx
+++ b/src/features/RecoveryPassword/ui/RecoveryPasswordForm.tsx
@@ -50,7 +50,9 @@ export const RecoveryPasswordForm = ({ title, token, email }: RecoveryPasswordFo
 
   if (status === 'success') {
     // Auto-navigate to the login page
-    navigate(ROUTES.login.path);
+    navigate(ROUTES.login.path, {
+      state: { isPasswordReset: true },
+    });
     return <></>;
   }
 
@@ -90,10 +92,7 @@ export const RecoveryPasswordForm = ({ title, token, email }: RecoveryPasswordFo
           />
         </Box>
 
-        <DisplaySystemMessage
-          errorMessage={error?.evaluatedMessage}
-          successMessage={isSuccess ? t('success') : null}
-        />
+        <DisplaySystemMessage errorMessage={error?.evaluatedMessage} />
 
         <Box marginY={3}>
           <BaseButton type="submit" variant="contained" isLoading={isLoading} text={t('submit')} />

--- a/src/features/RecoveryPassword/ui/RecoveryPasswordForm.tsx
+++ b/src/features/RecoveryPassword/ui/RecoveryPasswordForm.tsx
@@ -31,7 +31,6 @@ export const RecoveryPasswordForm = ({ title, token, email }: RecoveryPasswordFo
 
   const {
     mutate: approveRecoveryPassword,
-    isSuccess,
     isLoading,
     error,
     status,

--- a/src/features/RecoveryPassword/ui/RecoveryPasswordForm.tsx
+++ b/src/features/RecoveryPassword/ui/RecoveryPasswordForm.tsx
@@ -49,9 +49,10 @@ export const RecoveryPasswordForm = ({ title, token, email }: RecoveryPasswordFo
   const [newPasswordType, onNewPasswordIconClick] = usePasswordType();
   const [confirmNewPasswordType, onConfirmNewPasswordIconClick] = usePasswordType();
 
-  const backToLogin = () => {
+  if (status === 'success') {
+    // Auto-navigate to the login page
     return navigate(ROUTES.login.path);
-  };
+  }
 
   return (
     <Container className="change-password-form-container">
@@ -94,28 +95,9 @@ export const RecoveryPasswordForm = ({ title, token, email }: RecoveryPasswordFo
           successMessage={isSuccess ? t('success') : null}
         />
 
-        {status === 'success' && (
-          <Box marginY={3}>
-            <BaseButton
-              type="button"
-              onClick={backToLogin}
-              variant="contained"
-              isLoading={isLoading}
-              text={t('backToLogin')}
-            />
-          </Box>
-        )}
-
-        {status !== 'success' && (
-          <Box marginY={3}>
-            <BaseButton
-              type="submit"
-              variant="contained"
-              isLoading={isLoading}
-              text={t('submit')}
-            />
-          </Box>
-        )}
+        <Box marginY={3}>
+          <BaseButton type="submit" variant="contained" isLoading={isLoading} text={t('submit')} />
+        </Box>
       </BasicFormProvider>
     </Container>
   );

--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -130,7 +130,8 @@
       "create": "Create an account",
       "reset": " Reset it",
       "errorMessage": "Incorrect password if that user exists.",
-      "or": "Or"
+      "or": "Or",
+      "passwordResetSuccessful": "Your password has been reset successfully. Please log in with your new password."
     },
 
     "SignUp": {

--- a/src/i18n/fr/translation.json
+++ b/src/i18n/fr/translation.json
@@ -54,7 +54,7 @@
       "english": "Anglaise",
       "french": "Français"
     },
-    
+
     "validation": {
       "passwordRequired": "Mot de passe requis.",
       "passwordMinLength": "Le mot de passe doit être au moins de 6 caractères.",
@@ -65,7 +65,7 @@
       "lastNameRequired": "Last name is required.",
       "passwordShouldNotContainSpaces": "Le mot de passe ne doit pas contenir d'espaces."
     },
-    
+
     "transferOwnership": {
       "adminPanel": "Panneau d'Administration",
       "notFound": "Le lien de transfert de propriété n'est pas valide ou n'est pas actif depuis longtemps.",
@@ -80,7 +80,7 @@
         "message2": "S'il s'agissait d'une erreur, veuillez contacter le propriétaire de l'applet et lui demander de relancer le transfert."
       }
     },
-    
+
     "invitation": {
       "loadingInvitation": "Chargement de l'invitation",
       "invitationRemoved": "Invitation supprimée",
@@ -116,7 +116,7 @@
         "notFound": "The invite link is either invalid or no long active."
       }
     },
-    
+
     "Login": {
       "welcomeMessage": "Bienvenue sur l'application",
       "appType": "Web MindLogger",
@@ -133,7 +133,7 @@
       "logging": "Se connecter...",
       "passwordResetSuccessful": "Votre mot de passe a été réinitialisé avec succès. Veuillez vous connecter avec votre nouveau mot de passe."
     },
-    
+
     "SignUp": {
       "title": "S'inscrire",
       "submit": "Nous faire parvenir",

--- a/src/i18n/fr/translation.json
+++ b/src/i18n/fr/translation.json
@@ -54,7 +54,7 @@
       "english": "Anglaise",
       "french": "Français"
     },
-
+    
     "validation": {
       "passwordRequired": "Mot de passe requis.",
       "passwordMinLength": "Le mot de passe doit être au moins de 6 caractères.",
@@ -65,7 +65,7 @@
       "lastNameRequired": "Last name is required.",
       "passwordShouldNotContainSpaces": "Le mot de passe ne doit pas contenir d'espaces."
     },
-
+    
     "transferOwnership": {
       "adminPanel": "Panneau d'Administration",
       "notFound": "Le lien de transfert de propriété n'est pas valide ou n'est pas actif depuis longtemps.",
@@ -80,7 +80,7 @@
         "message2": "S'il s'agissait d'une erreur, veuillez contacter le propriétaire de l'applet et lui demander de relancer le transfert."
       }
     },
-
+    
     "invitation": {
       "loadingInvitation": "Chargement de l'invitation",
       "invitationRemoved": "Invitation supprimée",
@@ -116,7 +116,7 @@
         "notFound": "The invite link is either invalid or no long active."
       }
     },
-
+    
     "Login": {
       "welcomeMessage": "Bienvenue sur l'application",
       "appType": "Web MindLogger",
@@ -130,9 +130,10 @@
       "create": " Créer une",
       "reset": " Réinitialisez-le",
       "errorMessage": "Mot de passe incorrect si cet utilisateur existe.",
-      "logging": "Se connecter..."
+      "logging": "Se connecter...",
+      "passwordResetSuccessful": "Votre mot de passe a été réinitialisé avec succès. Veuillez vous connecter avec votre nouveau mot de passe."
     },
-
+    
     "SignUp": {
       "title": "S'inscrire",
       "submit": "Nous faire parvenir",

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -1,11 +1,13 @@
-import { lazy, useEffect } from 'react';
+import { lazy, useEffect, useRef } from 'react';
 
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 
 import { LoginForm, useLoginTranslation } from '~/features/Login';
 import { ROUTES, Theme } from '~/shared/constants';
+import { useNotification } from '~/shared/ui';
+import { Notification } from '~/shared/ui/NotificationCenter/lib/types';
 import { Mixpanel } from '~/shared/utils';
 
 const DownloadMobileLinks = lazy(() => import('~/widgets/DownloadMobileLinks'));
@@ -13,13 +15,32 @@ const DownloadMobileLinks = lazy(() => import('~/widgets/DownloadMobileLinks'));
 function LoginPage() {
   const { t } = useLoginTranslation();
   const location = useLocation();
+  const navigate = useNavigate();
+  const { showSuccessNotification } = useNotification();
+  const notificationRef = useRef<Notification | null>(null);
 
   const onCreateAccountClick = () => {
     Mixpanel.track('Create account button on login screen click');
   };
 
+  // This hook only needs to run once, so we can ignore the dependency array
   useEffect(() => {
     Mixpanel.trackPageView('Login');
+
+    if (location.state?.isPasswordReset && !notificationRef.current) {
+      // Shown for 5 seconds
+      notificationRef.current = showSuccessNotification(t('passwordResetSuccessful'), 5000);
+
+      // Unset the state after showing the notification, so that it doesn't show again if the user navigates back to this page
+      navigate(window.location.pathname, {
+        state: {
+          ...location.state,
+          isPasswordReset: undefined,
+        },
+        replace: true,
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -1,4 +1,4 @@
-import { lazy, useEffect, useRef } from 'react';
+import { lazy, useRef } from 'react';
 
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
@@ -8,7 +8,7 @@ import { LoginForm, useLoginTranslation } from '~/features/Login';
 import { ROUTES, Theme } from '~/shared/constants';
 import { useNotification } from '~/shared/ui';
 import { Notification } from '~/shared/ui/NotificationCenter/lib/types';
-import { Mixpanel } from '~/shared/utils';
+import { Mixpanel, useOnceEffect } from '~/shared/utils';
 
 const DownloadMobileLinks = lazy(() => import('~/widgets/DownloadMobileLinks'));
 
@@ -23,8 +23,7 @@ function LoginPage() {
     Mixpanel.track('Create account button on login screen click');
   };
 
-  // This hook only needs to run once, so we can ignore the dependency array
-  useEffect(() => {
+  useOnceEffect(() => {
     Mixpanel.trackPageView('Login');
 
     if (location.state?.isPasswordReset && !notificationRef.current) {
@@ -40,8 +39,7 @@ function LoginPage() {
         replace: true,
       });
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  });
 
   return (
     <Box display="flex" flex={1} justifyContent="center" alignItems="center" textAlign="center">

--- a/src/shared/ui/NotificationCenter/lib/useNotification.ts
+++ b/src/shared/ui/NotificationCenter/lib/useNotification.ts
@@ -24,6 +24,8 @@ export const useNotification = () => {
     };
 
     notificationCenter.addNotification(notification);
+
+    return notification;
   };
 
   const showSuccessNotification = (msg: string, duration?: number) => {

--- a/src/shared/utils/hooks/index.ts
+++ b/src/shared/utils/hooks/index.ts
@@ -3,6 +3,7 @@ export { useCustomTranslation } from './useCustomTranslation';
 export { usePasswordType } from './usePasswordType';
 export { useCustomNavigation } from './useCustomNavigation';
 export { useEncryption } from './useEncryption';
+export { useOnceEffect } from './useOnceEffect';
 export * from './useModal';
 export * from './useCustomMediaQuery';
 export * from './useIsPublic';

--- a/src/shared/utils/hooks/useOnceEffect.ts
+++ b/src/shared/utils/hooks/useOnceEffect.ts
@@ -1,10 +1,11 @@
 import { useEffect } from "react"
+import type { EffectCallback } from "react"
 
 /**
  * A convenience hook that runs the effect only once, when the component mounts.
  * @param effect Some code that you'd normally put in a `useEffect` hook.
  */
-export const useOnceEffect = (effect: React.EffectCallback) => {
+export const useOnceEffect = (effect: EffectCallback) => {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(effect, [])
 }

--- a/src/shared/utils/hooks/useOnceEffect.ts
+++ b/src/shared/utils/hooks/useOnceEffect.ts
@@ -1,5 +1,5 @@
-import { useEffect } from "react"
-import type { EffectCallback } from "react"
+import { useEffect } from 'react';
+import type { EffectCallback } from 'react';
 
 /**
  * A convenience hook that runs the effect only once, when the component mounts.
@@ -7,5 +7,5 @@ import type { EffectCallback } from "react"
  */
 export const useOnceEffect = (effect: EffectCallback) => {
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  useEffect(effect, [])
-}
+  useEffect(effect, []);
+};

--- a/src/shared/utils/hooks/useOnceEffect.ts
+++ b/src/shared/utils/hooks/useOnceEffect.ts
@@ -1,4 +1,4 @@
-import React from "react"
+import { useEffect } from "react"
 
 /**
  * A convenience hook that runs the effect only once, when the component mounts.
@@ -6,5 +6,5 @@ import React from "react"
  */
 export const useOnceEffect = (effect: React.EffectCallback) => {
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  React.useEffect(effect, [])
+  useEffect(effect, [])
 }

--- a/src/shared/utils/hooks/useOnceEffect.ts
+++ b/src/shared/utils/hooks/useOnceEffect.ts
@@ -1,0 +1,10 @@
+import React from "react"
+
+/**
+ * A convenience hook that runs the effect only once, when the component mounts.
+ * @param effect Some code that you'd normally put in a `useEffect` hook.
+ */
+export const useOnceEffect = (effect: React.EffectCallback) => {
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  React.useEffect(effect, [])
+}


### PR DESCRIPTION
### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-4827](https://mindlogger.atlassian.net/browse/M2-4827)

I've redirected the user to the login page after successful password redirection and displayed a success banner on that page. I've also removed the `backToLogin` button, and the form success message.

### 📸 Screenshots

https://github.com/ChildMindInstitute/mindlogger-web-refactor/assets/14842108/ed8c47e1-7cb5-46b9-b415-4bc940dafb58

### 🪤 Peer Testing
Example test step:

- Start up the API and the webapp
- Navigate to the web app landing page
- Click the forgot password link
- Enter your email address and click *Get Reset It*
- Click on the link in your email (Go to http://localhost:8025/ for local testing)
- Enter the new password
  **Expected outcome:** You should be redirected to the login screen and see a banner displayed for 5 seconds

### ✏️ Notes

I'm using `useRef` as an escape hatch in the `LoginPage` component to prevent the banner from showing twice in strict mode. This is arguably a hack and should be generalised, but I don't know if it should be part of this ticket. I'd welcome some feedback on that