### PR TITLE
M2-5011 Feature: Update year in the footer

### DIFF
--- a/src/entities/applet/model/hooks/useSaveActivityItemAnswer.ts
+++ b/src/entities/applet/model/hooks/useSaveActivityItemAnswer.ts
@@ -44,7 +44,7 @@ export const useSaveItemAnswer = ({ activityId, eventId }: Props) => {
     (itemId: string) => {
       saveItemAnswer(itemId, [])
     },
-    [saveItemAdditionalText, saveItemAnswer],
+    [saveItemAnswer],
   )
 
   return {

--- a/src/widgets/ActivityGroups/ui/ActivityCard/ActivityCardBase.tsx
+++ b/src/widgets/ActivityGroups/ui/ActivityCard/ActivityCardBase.tsx
@@ -26,6 +26,7 @@ export const ActivityCardBase = (props: Props) => {
         minHeight: "122px",
         flex: 1,
         opacity: props.isDisabled ? 0.65 : 1,
+        alignItems: "center",
       }}>
       {props.children}
     </Box>

--- a/src/widgets/Footer/index.tsx
+++ b/src/widgets/Footer/index.tsx
@@ -23,7 +23,7 @@ export default function Footer() {
             <a href="https://childmind.org" target="_blank" rel="noreferrer">
               Child Mind Institute
             </a>{" "}
-            &#169; 2023
+            &#169; 2024
           </span>
         )}
         <a href="https://mindlogger.org/terms" target="_blank" rel="noreferrer">


### PR DESCRIPTION
📝 Description
🔗 [Jira Ticket M2-5011](https://mindlogger.atlassian.net/browse/M2-5011)

I`ve changed year in the footer section. It was 2023, it is 2024.

📸 Screenshots
<img width="934" alt="Screenshot 2024-02-20 at 17 03 33" src="https://github.com/ChildMindInstitute/mindlogger-web-refactor/assets/45964820/c75d9a5b-b6cc-45ad-8f66-3a40c69707e9">

🪤 Peer Testing
Example test step:

Start up the API and the webapp
Open any page in desktop mode
Expected outcome: The 2024 year should appears in the footer section
✏️ Notes
