### PR TITLE
M2-5548 [Web app 2.5] Public link without the required account: error when sending responses for Activity Flow

### DIFF
--- a/src/shared/constants/routes.ts
+++ b/src/shared/constants/routes.ts
@@ -44,7 +44,7 @@ export const ROUTES = {
     }) =>
       `/public/applets/${appletId}/activityId/${activityId}/event/${eventId}/entityType/${entityType}/publicAppletKey/${publicAppletKey}?${
         flowId ? `flowId=${flowId}` : ''
-      }}`,
+      }`,
   },
 
   // Protected routes


### PR DESCRIPTION
resolves: M2-5548

Removed wrong symbol at the end of the path