### PR TITLE
[M2-3437] Change the regex for extracting params from media link

### DIFF
--- a/src/shared/ui/Markdown/lib/extractDataFromMediaLink.ts
+++ b/src/shared/ui/Markdown/lib/extractDataFromMediaLink.ts
@@ -1,0 +1,22 @@
+type Return = {
+  url: string;
+  name: string;
+};
+
+export const extractDataFromMediaLink = (link: string): Return | null => {
+  const pattern = new RegExp(/!\[(.*?)\]\((.*?)\)/);
+
+  const data = link.match(pattern);
+
+  if (!data) {
+    return null;
+  }
+
+  const name = data[1];
+  const url = data[2];
+
+  return {
+    url,
+    name,
+  };
+};

--- a/src/shared/ui/Markdown/lib/markdown-builder.ts
+++ b/src/shared/ui/Markdown/lib/markdown-builder.ts
@@ -1,3 +1,4 @@
+import { extractDataFromMediaLink } from './extractDataFromMediaLink';
 import { validateImage } from './validate-image';
 import { validateAudio } from './validateAudio';
 import { VimeoBuilder } from './Vimeo.builder';
@@ -41,18 +42,13 @@ class MarkdownBuilder {
 
     // Take first element of the match group - it's the whole match
     for (const [item] of mediaItems) {
-      const urlRule = new RegExp(/\((.*?)\)/g);
-      const nameRule = new RegExp(/\[(.*?)\]/g);
+      const data = extractDataFromMediaLink(item);
 
-      const urlMatchGroup = item.match(urlRule);
-      const nameMatchGroup = item.match(nameRule);
-
-      if (!urlMatchGroup || !nameMatchGroup) {
+      if (!data) {
         continue;
       }
 
-      const url = urlMatchGroup.map((el) => el.slice(1, -1))[0];
-      const name = nameMatchGroup.map((el) => el.slice(1, -1))[0];
+      const { url, name } = data;
 
       const youtubeBuilder = new YoutubeBuilder();
 

--- a/src/shared/ui/Markdown/lib/useMarkdownExtender.ts
+++ b/src/shared/ui/Markdown/lib/useMarkdownExtender.ts
@@ -15,7 +15,11 @@ export const useMarkdownExtender = (markdown: string) => {
   }, [markdown]);
 
   useEffect(() => {
-    extendMarkdown().then(setExtendedMarkdown);
+    extendMarkdown()
+      .then(setExtendedMarkdown)
+      .catch(() => {
+        throw new Error('Failed to extend markdown');
+      });
   }, [extendMarkdown]);
 
   return {


### PR DESCRIPTION
- [ ] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [ ] OSS packages added to MindLogger [open source credit page](https://mindlogger.atlassian.net/jira/servicedesk/projects/MLA/knowledge/articles/340623543?spaceKey=MLA)

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-3437](https://mindlogger.atlassian.net/browse/M2-3437)

We have a clear format of the media link. It looks like "![file_name](file_url)". To extract the params from the link we use regex. And in the ticket 3437, the tester team found the edge case when the regex works incorrectly.

Changes include:

- Class MarkdownExtender