### PR TITLE
[M2-6237] Add the flex property for SelectBaseBox component

### DIFF
--- a/src/entities/activity/ui/items/Matrix/MatrixMultiSelectItem/CheckboxButton.tsx
+++ b/src/entities/activity/ui/items/Matrix/MatrixMultiSelectItem/CheckboxButton.tsx
@@ -24,6 +24,7 @@ export const CheckboxButton = ({ id, isChecked, text, onChange }: Props) => {
           checked={isChecked}
           justifyContent="center"
           padding={lessThanSM ? '12px 8px' : '16px'}
+          flex={1}
         >
           <CheckboxItem
             id={id}

--- a/src/entities/activity/ui/items/Matrix/MatrixSingleSelectItem/RadioButton.tsx
+++ b/src/entities/activity/ui/items/Matrix/MatrixSingleSelectItem/RadioButton.tsx
@@ -20,6 +20,7 @@ export const RadioButton = ({ id, text, isChecked, onChange }: Props) => {
           onHandleChange={onChange}
           checked={isChecked}
           justifyContent="center"
+          flex={1}
         >
           <RadioOption
             id={id}

--- a/src/shared/ui/Items/SelectBase/SelectBaseBox.tsx
+++ b/src/shared/ui/Items/SelectBase/SelectBaseBox.tsx
@@ -5,6 +5,7 @@ import { Box } from '~/shared/ui';
 
 type Props = PropsWithChildren<{
   padding?: string;
+  flex?: number;
   justifyContent?:
     | 'flex-start'
     | 'center'
@@ -35,7 +36,7 @@ export const SelectBaseBox = (props: Props) => {
   return (
     <Box
       display="flex"
-      flex={1}
+      flex={props.flex}
       alignItems="center"
       justifyContent={props.justifyContent ? props.justifyContent : 'space-between'}
       gap="12px"

--- a/src/shared/ui/Items/SelectBase/SelectBaseText.tsx
+++ b/src/shared/ui/Items/SelectBase/SelectBaseText.tsx
@@ -14,7 +14,7 @@ export const SelectBaseText = (props: Props) => {
       fontWeight="400"
       lineHeight="28px"
       data-testid="select-text"
-      sx={{ cursor: 'pointer' }}
+      sx={{ cursor: 'pointer', lineBreak: 'anywhere' }}
     >
       {props.text}
     </Text>


### PR DESCRIPTION
### 📝 Description
🔗 [Jira Ticket M2-6237](https://mindlogger.atlassian.net/browse/M2-6237)

Previously I have reused the SelectBaseBox as a wrapper for Single and Multi selection components. Since I have added matrix items I started reusing the SelectBaseBox for this as well. And for different components should be different behavior. I added the "flex" property to the wrapper.

Changes include:

- SelectBaseBox