### PR TITLE
Update Jira Tickets 2

### DIFF
--- a/.github/workflows/update-jira-tickets.yaml
+++ b/.github/workflows/update-jira-tickets.yaml
@@ -95,6 +95,7 @@ jobs:
         run: |
           currentTag="${{ steps.get-tag.outputs.tag }}"
           previousTag="${{ steps.ping-jenkins.outputs.tagName }}"
+          git fetch --unshallow
           commitMessages=$(git log --pretty=%B $previousTag..$currentTag)
           echo "Commit messages since the last release: ${commitMessages}"
           jiraTickets=$(echo "$commitMessages" | grep -io 'M2-[0-9]\+' | tr '[:lower:]' '[:upper:]' | sort | uniq | tr '\n' ' ')


### PR DESCRIPTION
### 📝 Description

This PR updates the Update Jira Tickets GH Actions workflow to fetch all commits before determining JIRA tickets. 

The current behavior is only using the most recent commit on the branch because the checkout action does a shallow clone by default. Therefore, we have to unshallow the clone in order to get all the commit messages. I decided to do it this way, instead of doing a deep clone from the outset because there are several exit points for the job that would render the deep clone unnecessary. So I do it at the point where it's needed

### 🪤 Peer Testing

Compare the results of [the most recent release run](https://github.com/ChildMindInstitute/mindlogger-web-refactor/actions/runs/8660519735/job/23748618273#step:7:17) to [this manual run](https://github.com/ChildMindInstitute/mindlogger-web-refactor/actions/runs/8660542284/job/23748687560#step:7:18) I just did for this PR

### ✏️ Notes

There's no JIRA ticket for this. It was a quick fix, so I just decided to go for it 🤷