### PR TITLE
[M2-6239] Missing data-testid attributs for some elements starting from v2.1.7

### DIFF
--- a/src/features/TransferOwnershipAccept/ui/TransferOwnershipAccept.tsx
+++ b/src/features/TransferOwnershipAccept/ui/TransferOwnershipAccept.tsx
@@ -47,7 +47,7 @@ export const TransferOwnershipAccept = ({ appletId, keyParam }: TransferOwnershi
         variant="body1"
         fontSize="30px"
         margin="16px 0px"
-        data-testid="transfer-ownership-accepted-title"
+        testid="transfer-ownership-accepted-title"
       >
         {t('accepted.title')}
       </Text>

--- a/src/features/TransferOwnershipDecline/ui/TransfetOwnershipDecline.tsx
+++ b/src/features/TransferOwnershipDecline/ui/TransfetOwnershipDecline.tsx
@@ -45,7 +45,7 @@ export const TransferOwnershipDecline = ({ appletId, keyParam }: TransferOwnersh
         variant="body1"
         fontSize="30px"
         margin="16px 0px"
-        data-testid="transfer-ownership-declined-title"
+        testid="transfer-ownership-declined-title"
       >
         {t('declined.title')}
       </Text>

--- a/src/shared/ui/CardItem/CardItem.tsx
+++ b/src/shared/ui/CardItem/CardItem.tsx
@@ -38,7 +38,7 @@ export const CardItem = ({ children, markdown, isOptional, testId }: CardItemPro
           <Text
             variant="body1"
             color={Theme.colors.light.outline}
-            data-testid={'optional-item-label'}
+            testid="optional-item-label"
             fontWeight="400"
             fontSize="18px"
             lineHeight="28px"

--- a/src/shared/ui/DisplaySystemMessage/index.tsx
+++ b/src/shared/ui/DisplaySystemMessage/index.tsx
@@ -21,7 +21,7 @@ export const DisplaySystemMessage = ({ errorMessage, successMessage }: ErrorLabe
         <Text
           fontSize="14px"
           color={Theme.colors.light.accentGreen}
-          data-testid="system-success-message"
+          testid="system-success-message"
         >
           {successMessage}
         </Text>

--- a/src/shared/ui/DisplaySystemMessage/index.tsx
+++ b/src/shared/ui/DisplaySystemMessage/index.tsx
@@ -12,7 +12,7 @@ export const DisplaySystemMessage = ({ errorMessage, successMessage }: ErrorLabe
   return (
     <Box minHeight="8px" maxHeight="64px" padding="4px 0">
       {errorMessage && (
-        <Text fontSize="14px" color={Theme.colors.light.error} data-testid="system-error-message">
+        <Text fontSize="14px" color={Theme.colors.light.error} testid="system-error-message">
           {errorMessage}
         </Text>
       )}

--- a/src/shared/ui/Items/SelectBase/SelectBaseText.tsx
+++ b/src/shared/ui/Items/SelectBase/SelectBaseText.tsx
@@ -13,7 +13,7 @@ export const SelectBaseText = (props: Props) => {
       fontSize="18px"
       fontWeight="400"
       lineHeight="28px"
-      data-testid="select-text"
+      testid="select-text"
       sx={{ cursor: 'pointer', lineBreak: 'anywhere' }}
     >
       {props.text}

--- a/src/widgets/ActivityGroups/ui/ActivityGroupList.tsx
+++ b/src/widgets/ActivityGroups/ui/ActivityGroupList.tsx
@@ -64,7 +64,7 @@ export const ActivityGroupList = () => {
         <Text
           variant="h4"
           onClick={onCardAboutClick}
-          data-testid="applet-name"
+          testid="applet-name"
           sx={{
             fontFamily: 'Atkinson',
             fontSize: '22px',


### PR DESCRIPTION
### 📝 Description
🔗 [Jira Ticket M2-6239](https://mindlogger.atlassian.net/browse/M2-6239)

The root issue was an incorrect property name. The data-testid property was provided for the Text component instead of the correct one.