### PR TITLE
M2-6350: Prevent duplicate notifications in Web App

### DIFF
--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -1,4 +1,4 @@
-import { lazy, useRef } from 'react';
+import { lazy } from 'react';
 
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 
@@ -6,7 +6,6 @@ import { LoginForm, useLoginTranslation } from '~/features/Login';
 import { ROUTES, Theme } from '~/shared/constants';
 import { useNotification } from '~/shared/ui';
 import Box from '~/shared/ui/Box';
-import { Notification } from '~/shared/ui/NotificationCenter/lib/types';
 import Text from '~/shared/ui/Text';
 import { Mixpanel, useOnceEffect } from '~/shared/utils';
 
@@ -17,7 +16,6 @@ function LoginPage() {
   const location = useLocation();
   const navigate = useNavigate();
   const { showSuccessNotification } = useNotification();
-  const notificationRef = useRef<Notification | null>(null);
 
   const onCreateAccountClick = () => {
     Mixpanel.track('Create account button on login screen click');
@@ -26,9 +24,12 @@ function LoginPage() {
   useOnceEffect(() => {
     Mixpanel.trackPageView('Login');
 
-    if (location.state?.isPasswordReset && !notificationRef.current) {
+    if (location.state?.isPasswordReset) {
       // Shown for 5 seconds
-      notificationRef.current = showSuccessNotification(t('passwordResetSuccessful'), 5000);
+      showSuccessNotification(t('passwordResetSuccessful'), {
+        duration: 5000,
+        allowDuplicate: false,
+      });
 
       // Unset the state after showing the notification, so that it doesn't show again if the user navigates back to this page
       navigate(window.location.pathname, {

--- a/src/shared/ui/NotificationCenter/lib/useNotification.ts
+++ b/src/shared/ui/NotificationCenter/lib/useNotification.ts
@@ -3,16 +3,34 @@ import { v4 as uuidv4 } from 'uuid';
 import { Notification, NotificationType } from './types';
 import { useNotificationCenter } from './useNotificationCenter';
 
+import { notificationCenterStore } from '~/shared/ui/NotificationCenter/lib/store';
+
 type NotificationParams = {
   message: string;
   type: NotificationType;
   duration?: number;
+
+  /**
+   * If false, prevents the same notification from being added multiple times. Default is true.
+   */
+  allowDuplicate?: boolean;
 };
+
+type ShowNotificationOptions = Omit<NotificationParams, 'type' | 'message'>;
 
 export const useNotification = () => {
   const notificationCenter = useNotificationCenter();
 
   const showNotification = (params: NotificationParams) => {
+    const existingNotification = notificationCenterStore.notifications.find(
+      (notification) =>
+        notification.message === params.message && notification.type === params.type,
+    );
+
+    if (existingNotification && !params.allowDuplicate) {
+      return;
+    }
+
     const defaultDuration = 3000;
 
     const notification: Notification = {
@@ -28,20 +46,20 @@ export const useNotification = () => {
     return notification;
   };
 
-  const showSuccessNotification = (msg: string, duration?: number) => {
-    return showNotification({ message: msg, type: 'success', duration });
+  const showSuccessNotification = (message: string, options?: ShowNotificationOptions) => {
+    return showNotification({ ...options, message, type: 'success' });
   };
 
-  const showWarningNotification = (msg: string, duration?: number) => {
-    return showNotification({ message: msg, type: 'warning', duration });
+  const showWarningNotification = (message: string, options?: ShowNotificationOptions) => {
+    return showNotification({ ...options, message, type: 'warning' });
   };
 
-  const showErrorNotification = (msg: string, duration?: number) => {
-    return showNotification({ message: msg, type: 'error', duration });
+  const showErrorNotification = (message: string, options?: ShowNotificationOptions) => {
+    return showNotification({ ...options, message, type: 'error' });
   };
 
-  const showInfoNotification = (msg: string, duration?: number) => {
-    return showNotification({ message: msg, type: 'info', duration });
+  const showInfoNotification = (message: string, options?: ShowNotificationOptions) => {
+    return showNotification({ ...options, message, type: 'info' });
   };
 
   return {


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-6350](https://mindlogger.atlassian.net/browse/M2-6350)

This PR updates the various `showXNotification` hooks to allow the caller to specify whether to allow duplicate notification objects to be added. Notification uniqueness is determined based on message content and type.

I also updated the Login page to remove the workaround this new option makes unnecessary.

### 📸 Screenshots

N/A

### 🪤 Peer Testing

N/A

### ✏️ Notes

N/A