### PR TITLE
M2-6044: Submit Take Now Params

### DIFF
--- a/src/features/TakeNow/ui/ValidateTakeNowParams.tsx
+++ b/src/features/TakeNow/ui/ValidateTakeNowParams.tsx
@@ -14,7 +14,8 @@ function ValidateTakeNowParams({
   respondentId,
 }: TakeNowParams) {
   const { showErrorNotification } = useNotification();
-  const { initiateTakeNow, isInMultiInformantFlow } = appletModel.hooks.useMultiInformantState();
+  const { initiateTakeNow, isInMultiInformantFlow, getMultiInformantState } =
+    appletModel.hooks.useMultiInformantState();
 
   const { isError, isLoading, isSuccess, error, data } = useTakeNowValidation({
     appletId,
@@ -27,7 +28,12 @@ function ValidateTakeNowParams({
     if (isSuccess && data) {
       const { sourceSubjectId, targetSubjectId } = data;
 
-      if (!isInMultiInformantFlow()) {
+      const multiInformantState = getMultiInformantState();
+      if (
+        !isInMultiInformantFlow() ||
+        sourceSubjectId !== multiInformantState.sourceSubjectId ||
+        targetSubjectId !== multiInformantState.targetSubjectId
+      ) {
         initiateTakeNow({ sourceSubjectId, targetSubjectId });
       }
     }

--- a/src/shared/api/types/activity.ts
+++ b/src/shared/api/types/activity.ts
@@ -92,6 +92,8 @@ export type AnswerPayload = {
     localEndDate: string;
     localEndTime: string;
   };
+  sourceSubjectId?: ID | null;
+  targetSubjectId?: ID | null;
 };
 
 export type AlertDTO = {


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-6044](https://mindlogger.atlassian.net/browse/M2-6044)

This PR updates the code that submits the activity responses to `/answers` to include the values for `target_subject_id` and `source_subject_id`. The values are only included if the `enableMultiInformant` feature flag is enabled.

### 📸 Screenshots

N/A

### 🪤 Peer Testing

> [!NOTE]
> This feature depends on the `enableMultiInformant` feature flag. If it it not already enabled, you can manually enable it [here](https://github.com/ChildMindInstitute/mindlogger-web-refactor/blob/9ec96b45196bf8f1eb377850d8d225e51323b559/src/shared/utils/hooks/useLaunchDarkly.ts#L22-L30) like so:
>
> `features.enableMultiInformant = true;`

> [!NOTE]
> There's an in-progress API patch that this PR depends on. If https://github.com/ChildMindInstitute/mindlogger-backend-refactor/pull/1264 is still open when you are reviewing this PR, please use that branch as the basis for your API. Otherwise, you should use the `feature/multiinformant-metapod` branch

Follow the peer testing steps in #438 and complete the activity that is opened with the network tab of dev tools open.
Look for the answer submission request and confirm that it includes the two fields `sourceSubjectId` and `targetSubjectId`:

<img width="420" alt="Screenshot 2024-04-22 at 3 44 33 PM" src="https://github.com/ChildMindInstitute/mindlogger-web-refactor/assets/14842108/0a81cc10-923d-40b5-b49b-389d56b69773">

### ✏️ Notes

N/A