### PR TITLE
M2-6109: [FE] [Web App] Header - Update to Include Subject and Respondent

### DIFF
--- a/src/abstract/lib/types/multiInformant.ts
+++ b/src/abstract/lib/types/multiInformant.ts
@@ -1,4 +1,10 @@
+export type MultiInformantSubject = {
+  id: string;
+  secretId: string | null;
+  nickname: string | null;
+};
+
 export type MultiInformantState = {
-  sourceSubjectId?: string;
-  targetSubjectId?: string;
+  sourceSubject?: MultiInformantSubject;
+  targetSubject?: MultiInformantSubject;
 };

--- a/src/entities/applet/model/hooks/useMultiInformantState.ts
+++ b/src/entities/applet/model/hooks/useMultiInformantState.ts
@@ -21,7 +21,7 @@ export const useMultiInformantState = (): Return => {
   const getMultiInformantState = useCallback(() => multiInformantState, [multiInformantState]);
 
   const isInMultiInformantFlow = useCallback(() => {
-    return !!multiInformantState.sourceSubjectId && !!multiInformantState.targetSubjectId;
+    return !!multiInformantState.sourceSubject?.id && !!multiInformantState.targetSubject?.id;
   }, [multiInformantState]);
 
   const initiateTakeNow = useCallback(

--- a/src/entities/applet/model/types.ts
+++ b/src/entities/applet/model/types.ts
@@ -1,4 +1,5 @@
 import { GroupProgress } from '~/abstract/lib';
+import { MultiInformantState } from '~/abstract/lib/types/multiInformant';
 import {
   Answer,
   AudioPlayerItem,
@@ -174,7 +175,4 @@ export type InProgressFlow = {
   pipelineActivityOrder: number;
 };
 
-export type MultiInformantPayload = {
-  sourceSubjectId: string;
-  targetSubjectId: string;
-};
+export type MultiInformantPayload = Required<MultiInformantState>;

--- a/src/features/TakeNow/lib/useTakeNowValidation.tsx
+++ b/src/features/TakeNow/lib/useTakeNowValidation.tsx
@@ -121,6 +121,9 @@ export const useTakeNowValidation = ({
     return errorState(t('takeNow.invalidSubject'));
   }
 
+  const { nickname: targetSubjectNickname, secretUserId: targetSecretUserId } =
+    subjectData.data.result;
+
   if (isActivityError) {
     return errorState(t('takeNow.invalidActivity'));
   }
@@ -161,15 +164,27 @@ export const useTakeNowValidation = ({
     return errorState(null);
   }
 
-  const { subjectId: sourceSubjectId } = respondentData.data.result;
+  const {
+    subjectId: sourceSubjectId,
+    nickname: sourceSubjectNickname,
+    secretUserId: sourceSecretUserId,
+  } = respondentData.data.result;
 
   return {
     isLoading: false,
     isError: false,
     isSuccess: true,
     data: {
-      sourceSubjectId,
-      targetSubjectId,
+      sourceSubject: {
+        id: sourceSubjectId,
+        nickname: sourceSubjectNickname,
+        secretId: sourceSecretUserId,
+      },
+      targetSubject: {
+        id: targetSubjectId,
+        nickname: targetSubjectNickname,
+        secretId: targetSecretUserId,
+      },
     },
   };
 };

--- a/src/features/TakeNow/ui/MultiInformantBadge.tsx
+++ b/src/features/TakeNow/ui/MultiInformantBadge.tsx
@@ -1,0 +1,36 @@
+import { useMultiInformantState } from '~/entities/applet/model/hooks';
+import { MultiInformantBadgeTile } from '~/features/TakeNow/ui/MultiInformantBadgeTile';
+import { Theme } from '~/shared/constants';
+import { Box } from '~/shared/ui';
+
+export const MultiInformantBadge = () => {
+  const { getMultiInformantState } = useMultiInformantState();
+
+  const multiInformantState = getMultiInformantState();
+
+  if (
+    multiInformantState.sourceSubject === undefined ||
+    multiInformantState.targetSubject === undefined ||
+    multiInformantState.sourceSubject.id === multiInformantState.targetSubject.id
+  ) {
+    return null;
+  }
+
+  const { sourceSubject, targetSubject } = multiInformantState;
+
+  return (
+    <Box
+      display="flex"
+      padding="4px"
+      alignItems="center"
+      gap="4px"
+      width="192px"
+      height="40px"
+      borderRadius="8px"
+      border={`1px solid ${Theme.colors.light.surfaceVariant}`}
+    >
+      <MultiInformantBadgeTile type="Respondent" subject={sourceSubject} />
+      <MultiInformantBadgeTile type="Subject" subject={targetSubject} />
+    </Box>
+  );
+};

--- a/src/features/TakeNow/ui/MultiInformantBadge.tsx
+++ b/src/features/TakeNow/ui/MultiInformantBadge.tsx
@@ -2,16 +2,19 @@ import { useMultiInformantState } from '~/entities/applet/model/hooks';
 import { MultiInformantBadgeTile } from '~/features/TakeNow/ui/MultiInformantBadgeTile';
 import { Theme } from '~/shared/constants';
 import { Box } from '~/shared/ui';
+import { useLaunchDarkly } from '~/shared/utils/hooks/useLaunchDarkly';
 
 export const MultiInformantBadge = () => {
   const { getMultiInformantState } = useMultiInformantState();
+  const { flags: featureFlags } = useLaunchDarkly();
 
   const multiInformantState = getMultiInformantState();
 
   if (
     multiInformantState.sourceSubject === undefined ||
     multiInformantState.targetSubject === undefined ||
-    multiInformantState.sourceSubject.id === multiInformantState.targetSubject.id
+    multiInformantState.sourceSubject.id === multiInformantState.targetSubject.id ||
+    !featureFlags.enableMultiInformant
   ) {
     return null;
   }

--- a/src/features/TakeNow/ui/MultiInformantBadge.tsx
+++ b/src/features/TakeNow/ui/MultiInformantBadge.tsx
@@ -4,6 +4,8 @@ import { Theme } from '~/shared/constants';
 import { Box } from '~/shared/ui';
 import { useLaunchDarkly } from '~/shared/utils/hooks/useLaunchDarkly';
 
+const borderSize = 1;
+
 export const MultiInformantBadge = () => {
   const { getMultiInformantState, isInMultiInformantFlow } = useMultiInformantState();
   const { flags: featureFlags } = useLaunchDarkly();
@@ -21,13 +23,13 @@ export const MultiInformantBadge = () => {
   return (
     <Box
       display="flex"
-      padding="4px"
+      padding={`${4 - borderSize}px`}
       alignItems="center"
       gap="4px"
       width="192px"
       height="40px"
       borderRadius="8px"
-      border={`1px solid ${Theme.colors.light.surfaceVariant}`}
+      border={`${borderSize}px solid ${Theme.colors.light.surfaceVariant}`}
     >
       <MultiInformantBadgeTile type="Respondent" subject={sourceSubject} />
       <MultiInformantBadgeTile type="Subject" subject={targetSubject} />

--- a/src/features/TakeNow/ui/MultiInformantBadge.tsx
+++ b/src/features/TakeNow/ui/MultiInformantBadge.tsx
@@ -27,7 +27,6 @@ export const MultiInformantBadge = () => {
       alignItems="center"
       gap="4px"
       width="192px"
-      height="40px"
       borderRadius="8px"
       border={`${borderSize}px solid ${Theme.colors.light.surfaceVariant}`}
     >

--- a/src/features/TakeNow/ui/MultiInformantBadge.tsx
+++ b/src/features/TakeNow/ui/MultiInformantBadge.tsx
@@ -5,21 +5,18 @@ import { Box } from '~/shared/ui';
 import { useLaunchDarkly } from '~/shared/utils/hooks/useLaunchDarkly';
 
 export const MultiInformantBadge = () => {
-  const { getMultiInformantState } = useMultiInformantState();
+  const { getMultiInformantState, isInMultiInformantFlow } = useMultiInformantState();
   const { flags: featureFlags } = useLaunchDarkly();
 
-  const multiInformantState = getMultiInformantState();
-
-  if (
-    multiInformantState.sourceSubject === undefined ||
-    multiInformantState.targetSubject === undefined ||
-    multiInformantState.sourceSubject.id === multiInformantState.targetSubject.id ||
-    !featureFlags.enableMultiInformant
-  ) {
+  if (!isInMultiInformantFlow() || !featureFlags.enableMultiInformant) {
     return null;
   }
 
-  const { sourceSubject, targetSubject } = multiInformantState;
+  const { sourceSubject, targetSubject } = getMultiInformantState();
+
+  if (!sourceSubject || !targetSubject) {
+    return null;
+  }
 
   return (
     <Box

--- a/src/features/TakeNow/ui/MultiInformantBadgeTile.tsx
+++ b/src/features/TakeNow/ui/MultiInformantBadgeTile.tsx
@@ -1,0 +1,55 @@
+import Tooltip from '@mui/material/Tooltip';
+
+import { MultiInformantSubject } from '~/abstract/lib/types/multiInformant';
+import { Theme } from '~/shared/constants';
+import { Box } from '~/shared/ui';
+
+type MultiInformantBadgeTileProps = {
+  type: 'Subject' | 'Respondent';
+  subject: MultiInformantSubject;
+};
+
+export const MultiInformantBadgeTile = ({ subject, type }: MultiInformantBadgeTileProps) => {
+  const { id, secretId, nickname } = subject;
+  let text = secretId ?? id;
+  if (nickname) {
+    text += `, ${nickname}`;
+  }
+
+  const tooltipText = `${type}: ${text}`;
+
+  const backgroundColor = type === 'Subject' ? Theme.colors.light.inverseOnSurface : 'transparent';
+
+  return (
+    <Box
+      display="flex"
+      padding="8px"
+      alignItems="center"
+      gap="8px"
+      flex="1 0 0"
+      borderRadius="4px"
+      width="78px"
+      height="100%"
+      sx={{ backgroundColor, cursor: 'default' }}
+    >
+      <Tooltip title={tooltipText}>
+        <p
+          style={{
+            overflow: 'hidden',
+            color: Theme.colors.light.onSurface,
+            textOverflow: 'ellipsis',
+
+            fontSize: '16px',
+            fontStyle: 'normal',
+            fontWeight: 400,
+            lineHeight: '24px',
+            letterSpacing: '0.5px',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {text}
+        </p>
+      </Tooltip>
+    </Box>
+  );
+};

--- a/src/features/TakeNow/ui/ValidateTakeNowParams.tsx
+++ b/src/features/TakeNow/ui/ValidateTakeNowParams.tsx
@@ -31,8 +31,8 @@ function ValidateTakeNowParams({
       const multiInformantState = getMultiInformantState();
       if (
         !isInMultiInformantFlow() ||
-        sourceSubject.id !== multiInformantState.sourceSubject.id ||
-        targetSubjectId !== multiInformantState.targetSubject.id
+        sourceSubject.id !== multiInformantState.sourceSubject?.id ||
+        targetSubject.id !== multiInformantState.targetSubject?.id
       ) {
         initiateTakeNow({ sourceSubject, targetSubject });
       }

--- a/src/features/TakeNow/ui/ValidateTakeNowParams.tsx
+++ b/src/features/TakeNow/ui/ValidateTakeNowParams.tsx
@@ -26,15 +26,15 @@ function ValidateTakeNowParams({
 
   useEffect(() => {
     if (isSuccess && data) {
-      const { sourceSubjectId, targetSubjectId } = data;
+      const { sourceSubject, targetSubject } = data;
 
       const multiInformantState = getMultiInformantState();
       if (
         !isInMultiInformantFlow() ||
-        sourceSubjectId !== multiInformantState.sourceSubjectId ||
-        targetSubjectId !== multiInformantState.targetSubjectId
+        sourceSubject.id !== multiInformantState.sourceSubject.id ||
+        targetSubjectId !== multiInformantState.targetSubject.id
       ) {
-        initiateTakeNow({ sourceSubjectId, targetSubjectId });
+        initiateTakeNow({ sourceSubject, targetSubject });
       }
     }
   }, [data, initiateTakeNow, isInMultiInformantFlow, isSuccess]);

--- a/src/features/TakeNow/ui/index.ts
+++ b/src/features/TakeNow/ui/index.ts
@@ -1,1 +1,3 @@
 export * from './ValidateTakeNowParams';
+export * from './MultiInformantBadge';
+export * from './MultiInformantBadgeTile';

--- a/src/widgets/ActivityDetails/model/hooks/useAnswers.ts
+++ b/src/widgets/ActivityDetails/model/hooks/useAnswers.ts
@@ -142,8 +142,8 @@ export const useAnswer = (props: Props) => {
       if (featureFlags.enableMultiInformant) {
         const multiInformantState = getMultiInformantState();
         if (isInMultiInformantFlow()) {
-          answer.sourceSubjectId = multiInformantState.sourceSubjectId;
-          answer.targetSubjectId = multiInformantState.targetSubjectId;
+          answer.sourceSubjectId = multiInformantState.sourceSubject?.id;
+          answer.targetSubjectId = multiInformantState.targetSubject?.id;
         }
       }
 

--- a/src/widgets/ActivityDetails/ui/AssessmentLayoutHeader.tsx
+++ b/src/widgets/ActivityDetails/ui/AssessmentLayoutHeader.tsx
@@ -1,7 +1,7 @@
 import { SaveAndExitButton } from '~/features/SaveAssessmentAndExit';
+import { MultiInformantBadge } from '~/features/TakeNow';
 import { ROUTES, Theme } from '~/shared/constants';
-import { Box } from '~/shared/ui';
-import { BaseProgressBar, Text } from '~/shared/ui';
+import { BaseProgressBar, Box, Text } from '~/shared/ui';
 import { useCustomMediaQuery, useCustomNavigation } from '~/shared/utils';
 
 type Props = {
@@ -40,12 +40,15 @@ export const AssessmentLayoutHeader = (props: Props) => {
       justifyContent="center"
       gridTemplateColumns="1fr minmax(300px, 900px) 1fr"
       padding={greaterThanSM ? '19px 24px' : '15px 16px'}
+      height={87}
       gap={1.5}
       sx={{
         backgroundColor: Theme.colors.light.surface,
         borderBottom: `1px solid ${Theme.colors.light.surfaceVariant}`,
       }}
     >
+      <MultiInformantBadge />
+
       <Box sx={{ gridColumn: '2 / 3' }}>
         <Box
           display="flex"


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-6109](https://mindlogger.atlassian.net/browse/M2-6109)

This PR creates a `MultiInformantBadge` component that is shown during the completion of an activity in a multi-informant context. The component displays itself when the following are true:
- The `enableMultiInformant` feature flag is turned on
- The multi-informant state has been set. This state is set during the validation of multi-informant parameters in the `ValidateTakeNowParams` component.

### 📸 Screenshots

#### Header badge with respondent hovered

<img width="1153" alt="multi-informant-badge-respondent" src="https://github.com/ChildMindInstitute/mindlogger-web-refactor/assets/14842108/7a11530e-0750-4a17-b503-56c40ac71327">

#### Header badge with subject hovered

<img width="1153" alt="multi-informant-badge-subject" src="https://github.com/ChildMindInstitute/mindlogger-web-refactor/assets/14842108/604ff7dd-5dda-4615-b7a9-c4e408b5e025">

### 🪤 Peer Testing

> [!NOTE]
> This feature depends on the `enableMultiInformant` feature flag. If it it not already enabled, you can manually enable it [here](https://github.com/ChildMindInstitute/mindlogger-web-refactor/blob/9ec96b45196bf8f1eb377850d8d225e51323b559/src/shared/utils/hooks/useLaunchDarkly.ts#L22-L30) like so:
>
> `features.enableMultiInformant = true;`

For this test, you'll need the following set up in your workspace:

An owner
A limited account participant
You will also need at least one applet with at least one activity.

#### Multi-Informant case

Make note of the owner **user ID** and the limited account participant **subject ID**, as well as the applet ID and activity ID. Then format them according to this URL template:

https://localhost:5173/protected/applets/{appletId}/?startActivityOrFlow={activityId}&respondentId={ownerUserId}&subjectId={limitedAccountSubjectId}

Launch that URL (and authenticate if required), then observe the activity layout. You should see the badge displayed as expected.

#### Regular flow

From the list of activities in the applet, launch one of the activities. You should observe that the badge is not displayed.

### ✏️ Notes

N/A
