### PR TITLE
M2-6272: [FE] [Web App] Take Now - After Submit - Provide Success Message

### DIFF
--- a/src/features/TakeNow/ui/MultiInformantBadgeTile.tsx
+++ b/src/features/TakeNow/ui/MultiInformantBadgeTile.tsx
@@ -11,12 +11,11 @@ type MultiInformantBadgeTileProps = {
 
 export const MultiInformantBadgeTile = ({ subject, type }: MultiInformantBadgeTileProps) => {
   const { id, secretId, nickname } = subject;
-  let text = secretId ?? id;
+  const text = secretId ?? id;
+  let tooltipText = `${type}: ${text}`;
   if (nickname) {
-    text += `, ${nickname}`;
+    tooltipText += `, ${nickname}`;
   }
-
-  const tooltipText = `${type}: ${text}`;
 
   const backgroundColor = type === 'Subject' ? Theme.colors.light.inverseOnSurface : 'transparent';
 

--- a/src/features/TakeNow/ui/TakeNowSuccessModal.tsx
+++ b/src/features/TakeNow/ui/TakeNowSuccessModal.tsx
@@ -29,7 +29,6 @@ export const TakeNowSuccessModal = () => {
   return (
     <MuiModal
       isOpen={isOpen}
-      onHide={() => {}}
       title={t('takeNow.successModalTitle')}
       label={t('takeNow.successModalLabel')}
       footerPrimaryButton={t('takeNow.successModalPrimaryAction')}

--- a/src/features/TakeNow/ui/TakeNowSuccessModal.tsx
+++ b/src/features/TakeNow/ui/TakeNowSuccessModal.tsx
@@ -1,0 +1,47 @@
+import { useState } from 'react';
+
+import { useLocation, useNavigate } from 'react-router-dom';
+
+import { MuiModal } from '~/shared/ui';
+import { useCustomTranslation, useOnceEffect } from '~/shared/utils';
+
+export const TakeNowSuccessModal = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const { t } = useCustomTranslation();
+
+  const [isOpen, setIsOpen] = useState(false);
+
+  useOnceEffect(() => {
+    if (location.state && location.state.showTakeNowSuccessModal && !isOpen) {
+      navigate(window.location.pathname, {
+        state: {
+          ...location.state,
+          showTakeNowSuccessModal: undefined,
+        } as unknown,
+        replace: true,
+      });
+
+      setIsOpen(true);
+    }
+  });
+
+  return (
+    <MuiModal
+      isOpen={isOpen}
+      onHide={() => {}}
+      title={t('takeNow.successModalTitle')}
+      label={t('takeNow.successModalLabel')}
+      footerPrimaryButton={t('takeNow.successModalPrimaryAction')}
+      onPrimaryButtonClick={() => {
+        window.close();
+        setIsOpen(false);
+      }}
+      footerSecondaryButton={t('takeNow.successModalSecondaryAction')}
+      onSecondaryButtonClick={() => setIsOpen(false)}
+      DialogProps={{
+        disableEscapeKeyDown: true,
+      }}
+    />
+  );
+};

--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -273,7 +273,11 @@
     "takeNow": {
       "invalidRespondent": "You are not authorized to complete this assessment on behalf of this subject.",
       "invalidSubject": "This subject does not exist.",
-      "invalidActivity": "This activity does not exist."
+      "invalidActivity": "This activity does not exist.",
+      "successModalTitle": "Activity Done",
+      "successModalLabel": "Your answers have been submitted. Please return to the Admin App to complete another activity or view results.",
+      "successModalPrimaryAction": "Return to Admin App",
+      "successModalSecondaryAction": "Dismiss"
     }
   }
 }

--- a/src/i18n/fr/translation.json
+++ b/src/i18n/fr/translation.json
@@ -280,7 +280,11 @@
     "takeNow": {
       "invalidRespondent": "Vous n'êtes pas autorisé à effectuer cette évaluation au nom de ce sujet.",
       "invalidSubject": "Ce sujet n'existe pas.",
-      "invalidActivity": "Cette activité n'existe pas."
+      "invalidActivity": "Cette activité n'existe pas.",
+      "successModalTitle": "Activité terminée",
+      "successModalLabel": "Vos réponses ont été soumises. Veuillez revenir à l'application d'administration pour terminer une autre activité ou afficher les résultats.",
+      "successModalPrimaryAction": "Revenir à l'application d'administration",
+      "successModalSecondaryAction": "Rejeter"
     }
   }
 }

--- a/src/shared/ui/MuiModal/index.tsx
+++ b/src/shared/ui/MuiModal/index.tsx
@@ -1,6 +1,9 @@
+import { DOMAttributes } from 'react';
+
 import CloseIcon from '@mui/icons-material/Close';
 import { Breakpoint } from '@mui/material';
 import Dialog from '@mui/material/Dialog';
+import { DialogProps } from '@mui/material/Dialog/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import DialogTitle from '@mui/material/DialogTitle';
@@ -14,7 +17,7 @@ import { Box } from '~/shared/ui';
 
 type Props = {
   isOpen: boolean;
-  onHide: () => void;
+  onHide: DOMAttributes<SVGSVGElement>['onClick'];
   title?: string | null;
   label?: string | null;
   footerPrimaryButton?: string | null;
@@ -31,6 +34,7 @@ type Props = {
   labelComponent?: JSX.Element;
   footerWrapperSXProps?: SxProps;
   maxWidth?: Breakpoint;
+  DialogProps?: Omit<DialogProps, 'open'>;
 };
 
 export const MuiModal = (props: Props) => {
@@ -53,6 +57,7 @@ export const MuiModal = (props: Props) => {
     labelComponent,
     footerWrapperSXProps,
     maxWidth = 'xs',
+    DialogProps,
   } = props;
 
   return (
@@ -80,6 +85,7 @@ export const MuiModal = (props: Props) => {
           paddingTop: '24px',
         },
       }}
+      {...DialogProps}
     >
       {showCloseIcon && (
         <CloseIcon

--- a/src/shared/ui/MuiModal/index.tsx
+++ b/src/shared/ui/MuiModal/index.tsx
@@ -10,14 +10,13 @@ import DialogTitle from '@mui/material/DialogTitle';
 import { SxProps } from '@mui/material/styles';
 import Typography, { TypographyProps } from '@mui/material/Typography';
 
-import { BaseButton } from '../BaseButton';
-
 import { Theme } from '~/shared/constants';
+import { BaseButton } from '~/shared/ui';
 import { Box } from '~/shared/ui';
 
 type Props = {
   isOpen: boolean;
-  onHide: DOMAttributes<SVGSVGElement>['onClick'];
+  onHide?: DOMAttributes<SVGSVGElement>['onClick'];
   title?: string | null;
   label?: string | null;
   footerPrimaryButton?: string | null;

--- a/src/widgets/ActivityGroups/ui/ActivityGroups.tsx
+++ b/src/widgets/ActivityGroups/ui/ActivityGroups.tsx
@@ -3,6 +3,7 @@ import { AppletDetailsContext } from '../lib';
 
 import { appletModel, useAppletBaseInfoByIdQuery } from '~/entities/applet';
 import { useEventsbyAppletIdQuery } from '~/entities/event';
+import { TakeNowSuccessModal } from '~/features/TakeNow/ui/TakeNowSuccessModal';
 import { Container } from '~/shared/ui';
 import Loader from '~/shared/ui/Loader';
 import { useCustomTranslation, useOnceEffect } from '~/shared/utils';
@@ -75,6 +76,7 @@ export const ActivityGroups = (props: Props) => {
   return (
     <AppletDetailsContext.Provider value={{ ...props, applet, events }}>
       <ActivityGroupList />
+      <TakeNowSuccessModal />
     </AppletDetailsContext.Provider>
   );
 };


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-6272](https://mindlogger.atlassian.net/browse/M2-6272)

This ticket implements a success modal that displays itself at the end of the Take Now flow. It presents a choice to the logged-in user of returning to the admin app, or staying in the web app.

### 📸 Screenshots

#### Regular flow

https://github.com/ChildMindInstitute/mindlogger-web-refactor/assets/14842108/6420be0d-6441-4d33-abab-f7b3b9029fcc

#### Take Now Flow

https://github.com/ChildMindInstitute/mindlogger-web-refactor/assets/14842108/a1957338-0e63-4746-8aef-dd601154cf78

### 🪤 Peer Testing

> [!NOTE]
> You will need to launch the take now flow from the admin app

You will need a workspace with the following:
- an owner
- a limited account participant
- an applet with a single activity

#### Regular flow

- Sign in to the participant web app as the owner
- Complete an activity within an applet and submit the answers
- Note that the success modal doesn't present

#### Take Now flow

- Sign in to the admin web app as the owner
- Navigate to the activities tab of the applet
- Select the take now menu option from the context menu of one of the activities
- Select the limited account participant in the **Who is this activity about?** dropdown
- Click the **Start Activity** button
- Complete the activity and submit the answers
- Note that the success modal is presented

Repeat this flow several times and evaluate the following scenarios while the modal is visible:
- Clicking the **Dismiss** button closes the modal with the tab still open, and refreshing the page does not reopen the modal
- Clicking the **Return to Admin App** button closes the tab
- Refreshing the page without clicking anything does the same as clicking the dismiss button

**Bonus Points**

- Manually enter the take now URL in the participant web app, in the format `https://localhost:5173/protected/applets/{appletId}?startActivityOrFlow={activityId}&subjectId={limitedAccountSubjectId}&respondentId={ownerUserId}`
- Complete the activity and submit the answers
- Note that the success modal is still presented, but this time also note that the tab [doesn't close](https://developer.mozilla.org/en-US/docs/Web/API/Window/close#:~:text=This%20method%20can%20only%20be%20called%20on%20windows%20that%20were%20opened%20by%20a%20script%20using%20the%20Window.open()%20method) when you click the **Return to Admin App** button. However, it should close the modal

### ✏️ Notes

N/A
