### PR TITLE
[M2-6292] Fix the onHandleChange for the SliderRows item

### DIFF
--- a/src/entities/activity/ui/items/Matrix/Slider/index.tsx
+++ b/src/entities/activity/ui/items/Matrix/Slider/index.tsx
@@ -14,16 +14,14 @@ type Props = {
 export const SliderRows = (props: Props) => {
   const onHandleValueChange = useCallback(
     (value: string, index: number) => {
-      if (props.values.length === 0) {
-        props.onValueChange(
-          Array.from({ length: props.item.responseValues.rows.length }, () => null),
-        );
-        return;
+      let values = [...props.values];
+
+      if (values.length === 0) {
+        values = Array.from({ length: props.item.responseValues.rows.length }, () => null);
       }
 
-      const newValues = [...props.values];
-      newValues[index] = Number(value);
-      return props.onValueChange(newValues);
+      values[index] = Number(value);
+      return props.onValueChange(values);
     },
     [props],
   );


### PR DESCRIPTION
### 📝 Description
🔗 [Jira Ticket M2-6292](https://mindlogger.atlassian.net/browse/M2-6292)

The onHandleChange method for the SliderRow item had the incorrect logic of updating the current values. The bug appears when you have tried to choose the value for the first time. The first try was ignored. Now it works correctly.

