### PR TITLE
bugfix: 🔥[Web app] The blank page is displaying in web app if start an Activity execution (M2-6534)

### DIFF
--- a/src/entities/applet/model/hooks/useMultiInformantState.ts
+++ b/src/entities/applet/model/hooks/useMultiInformantState.ts
@@ -22,7 +22,7 @@ export const useMultiInformantState = (): Return => {
   const getMultiInformantState = useCallback(() => multiInformantState, [multiInformantState]);
 
   const isInMultiInformantFlow = useCallback(() => {
-    return !!multiInformantState.sourceSubject?.id && !!multiInformantState.targetSubject?.id;
+    return !!multiInformantState?.sourceSubject?.id && !!multiInformantState.targetSubject?.id;
   }, [multiInformantState]);
 
   const initiateTakeNow = useCallback(

--- a/src/entities/applet/model/hooks/useMultiInformantState.ts
+++ b/src/entities/applet/model/hooks/useMultiInformantState.ts
@@ -12,6 +12,7 @@ type Return = {
   isInMultiInformantFlow: () => boolean;
   initiateTakeNow: (payload: MultiInformantPayload) => void;
   resetMultiInformantState: () => void;
+  ensureMultiInformantStateExists: () => void;
 };
 
 export const useMultiInformantState = (): Return => {
@@ -35,10 +36,15 @@ export const useMultiInformantState = (): Return => {
     dispatch(actions.resetMultiInformantState());
   }, [dispatch]);
 
+  const ensureMultiInformantStateExists = useCallback(() => {
+    dispatch(actions.ensureMultiInformantStateExists());
+  }, [dispatch]);
+
   return {
     getMultiInformantState,
     isInMultiInformantFlow,
     initiateTakeNow,
     resetMultiInformantState,
+    ensureMultiInformantStateExists,
   };
 };

--- a/src/entities/applet/model/slice.ts
+++ b/src/entities/applet/model/slice.ts
@@ -225,6 +225,12 @@ const appletsSlice = createSlice({
       state.multiInformantState = action.payload;
     },
 
+    ensureMultiInformantStateExists: (state) => {
+      if (!state.multiInformantState) {
+        state.multiInformantState = {};
+      }
+    },
+
     resetMultiInformantState: (state) => {
       state.multiInformantState = {};
     },

--- a/src/features/TakeNow/ui/ValidateTakeNowParams.tsx
+++ b/src/features/TakeNow/ui/ValidateTakeNowParams.tsx
@@ -31,8 +31,8 @@ function ValidateTakeNowParams({
       const multiInformantState = getMultiInformantState();
       if (
         !isInMultiInformantFlow() ||
-        sourceSubject.id !== multiInformantState.sourceSubject?.id ||
-        targetSubject.id !== multiInformantState.targetSubject?.id
+        sourceSubject.id !== multiInformantState?.sourceSubject?.id ||
+        targetSubject.id !== multiInformantState?.targetSubject?.id
       ) {
         initiateTakeNow({ sourceSubject, targetSubject });
       }

--- a/src/widgets/ActivityDetails/model/hooks/useAnswers.ts
+++ b/src/widgets/ActivityDetails/model/hooks/useAnswers.ts
@@ -142,8 +142,8 @@ export const useAnswer = (props: Props) => {
       if (featureFlags.enableMultiInformant) {
         const multiInformantState = getMultiInformantState();
         if (isInMultiInformantFlow()) {
-          answer.sourceSubjectId = multiInformantState.sourceSubject?.id;
-          answer.targetSubjectId = multiInformantState.targetSubject?.id;
+          answer.sourceSubjectId = multiInformantState?.sourceSubject?.id;
+          answer.targetSubjectId = multiInformantState?.targetSubject?.id;
         }
       }
 
@@ -155,17 +155,17 @@ export const useAnswer = (props: Props) => {
       return answer;
     },
     [
-      encryptPayload,
-      generateUserPrivateKey,
-      getGroupProgress,
-      props.activityId,
-      props.applet.activityFlows,
       props.applet.encryption,
+      props.applet.activityFlows,
       props.applet.id,
       props.applet.version,
+      props.flowId,
+      props.activityId,
       props.eventId,
       props.eventsRawData,
-      props.flowId,
+      encryptPayload,
+      getGroupProgress,
+      generateUserPrivateKey,
       getMultiInformantState,
     ],
   );

--- a/src/widgets/ActivityGroups/ui/ActivityGroups.tsx
+++ b/src/widgets/ActivityGroups/ui/ActivityGroups.tsx
@@ -42,10 +42,11 @@ export const ActivityGroups = (props: Props) => {
 
   const { featureFlags } = useFeatureFlags();
 
-  const { isInMultiInformantFlow, resetMultiInformantState } =
+  const { isInMultiInformantFlow, resetMultiInformantState, ensureMultiInformantStateExists } =
     appletModel.hooks.useMultiInformantState();
 
   useOnceEffect(() => {
+    ensureMultiInformantStateExists();
     if (featureFlags.enableMultiInformant) {
       if (isInMultiInformantFlow() && !props.startActivityOrFlow) {
         resetMultiInformantState();


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-6534](https://mindlogger.atlassian.net/browse/M2-6534)

This PR fixes the blank page bug encountered when a user with existing Redux state tries to initiate an activity outside of both the multi-informant flow and the proper feature flagged context.

### 📸 Screenshots

N/A

### 🪤 Peer Testing

To reproduce the issue, follow these steps on the `release/v2.1.9` branch:

- Check out the a4970aae0470e4b0164871fe3cba08f457e64fe7 revision
- Install dependencies with `yarn`
- Start the vite server and load the respondent web app
- Clear application data in dev tools and refresh the page
- Log in to the app and complete an activity
- Stop the vite server (keep the browser window open)
- Check out the ac7c5639e1f071ecd12eb8b65125d626169abb56 revision
- Install dependencies with `yarn`
- Start the vite server
- Log in to the respondent web app
- Attempt an activity

At this point you should see the error referenced in the ticket. To observe the fix, now follow these steps:

- Stop the vite server
- Check out the `bugfix/redux-state-access` branch
- Start the vite server
- Log in to the respondent web app
- Attempt an activity

The error should no longer be present

### ✏️ Notes

N/A