### PR TITLE
feat(mi): Update take now validation logic (M2-6480)

### DIFF
--- a/src/features/TakeNow/lib/TakeNowParams.types.ts
+++ b/src/features/TakeNow/lib/TakeNowParams.types.ts
@@ -1,6 +1,7 @@
 export type TakeNowParams = {
   appletId: string;
   startActivityOrFlow: string;
-  subjectId: string;
+  targetSubjectId: string;
+  sourceSubjectId: string;
   respondentId: string;
 };

--- a/src/features/TakeNow/ui/ValidateTakeNowParams.tsx
+++ b/src/features/TakeNow/ui/ValidateTakeNowParams.tsx
@@ -9,7 +9,8 @@ import { ActivityGroups } from '~/widgets/ActivityGroups';
 
 function ValidateTakeNowParams({
   appletId,
-  subjectId: targetSubjectId,
+  targetSubjectId,
+  sourceSubjectId,
   startActivityOrFlow,
   respondentId,
 }: TakeNowParams) {
@@ -19,7 +20,8 @@ function ValidateTakeNowParams({
 
   const { isError, isLoading, isSuccess, error, data } = useTakeNowValidation({
     appletId,
-    subjectId: targetSubjectId,
+    targetSubjectId,
+    sourceSubjectId,
     startActivityOrFlow,
     respondentId,
   });

--- a/src/pages/AppletDetailsPage/index.tsx
+++ b/src/pages/AppletDetailsPage/index.tsx
@@ -15,14 +15,21 @@ function AppletDetailsPage() {
 
   const queryParams = new URLSearchParams(location.search);
   const startActivityOrFlow = queryParams.get('startActivityOrFlow');
-  const subjectId = queryParams.get('subjectId');
+  const targetSubjectId = queryParams.get('targetSubjectId');
+  const sourceSubjectId = queryParams.get('sourceSubjectId');
   const respondentId = queryParams.get('respondentId');
 
   if (!appletId) {
     return <div>{t('wrondLinkParametrError')}</div>;
   }
 
-  if (!startActivityOrFlow || !subjectId || !respondentId || !featureFlags.enableMultiInformant) {
+  if (
+    !startActivityOrFlow ||
+    !sourceSubjectId ||
+    !targetSubjectId ||
+    !respondentId ||
+    !featureFlags.enableMultiInformant
+  ) {
     return (
       <AuthorizationGuard fallback={<LoginWithRedirect />}>
         <ActivityGroups isPublic={false} appletId={appletId} />
@@ -35,7 +42,8 @@ function AppletDetailsPage() {
       <ValidateTakeNowParams
         appletId={appletId}
         startActivityOrFlow={startActivityOrFlow}
-        subjectId={subjectId}
+        targetSubjectId={targetSubjectId}
+        sourceSubjectId={sourceSubjectId}
         respondentId={respondentId}
       />
     </AuthorizationGuard>


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-6480](https://mindlogger.atlassian.net/browse/M2-6480)

This PR updates the validation logic for the take now flow by allowing a source subject ID to be specified, instead of defaulting to the subject ID of the logged in user.

Consequently, the multi-informant badge now shows the provided source subject as the respondent

<img width="296" alt="image" src="https://github.com/ChildMindInstitute/mindlogger-web-refactor/assets/14842108/c3151688-61f8-4d10-a8f0-59c6b6e1f524">

>[!NOTE]
> This badge is replaced in https://github.com/ChildMindInstitute/mindlogger-web-refactor/pull/460

### 📸 Screenshots

N/A

### 🪤 Peer Testing

Follow the testing steps in https://github.com/ChildMindInstitute/mindlogger-admin/pull/1728

### ✏️ Notes

N/A