### PR TITLE
[No-task] The guard was added before access to store

### DIFF
--- a/src/features/PassSurvey/hooks/useSummaryData.ts
+++ b/src/features/PassSurvey/hooks/useSummaryData.ts
@@ -69,7 +69,7 @@ export const useSummaryData = (props: Props) => {
       return null;
     }
 
-    const flowSummaryData = flowProgress.context.summaryData;
+    const flowSummaryData = flowProgress.context?.summaryData ?? {};
 
     let activityIds = Object.keys(flowSummaryData);
 


### PR DESCRIPTION

### 📝 Description

The guard was added before accessing the store to make applications reliable when the user has an old version of the store

