### PR TITLE
feat(mi): Consume API take now validation endpoint (M2-6746) (M2-6856)

### DIFF
--- a/src/entities/answer/api/index.ts
+++ b/src/entities/answer/api/index.ts
@@ -1,0 +1,1 @@
+export * from './useValidateMultiInformantAssessmentQuery';

--- a/src/entities/answer/api/useValidateMultiInformantAssessmentQuery.ts
+++ b/src/entities/answer/api/useValidateMultiInformantAssessmentQuery.ts
@@ -1,0 +1,23 @@
+import { answerService, QueryOptions, ReturnAwaited, useBaseQuery } from '~/shared/api';
+
+type FetchFn = typeof answerService.validateMultiInformantAssessment;
+type Options<TData> = QueryOptions<FetchFn, TData>;
+type OptionalArgs<TData = ReturnAwaited<FetchFn>> = {
+  sourceSubjectId?: string;
+  targetSubjectId?: string;
+  activityOrFlowId?: string;
+  options?: Options<TData>;
+};
+
+export const useValidateMultiInformantAssessmentQuery = <TData = ReturnAwaited<FetchFn>>(
+  appletId: string,
+  optionalArgs?: OptionalArgs<TData>,
+) => {
+  const { options, ...queryParams } = optionalArgs || {};
+
+  return useBaseQuery(
+    ['multiInformantAssessmentDetails', { appletId }],
+    () => answerService.validateMultiInformantAssessment({ appletId, ...queryParams }),
+    options,
+  );
+};

--- a/src/entities/answer/api/useValidateMultiInformantAssessmentQuery.ts
+++ b/src/entities/answer/api/useValidateMultiInformantAssessmentQuery.ts
@@ -1,21 +1,27 @@
+import { AxiosError } from 'axios';
+
 import { answerService, QueryOptions, ReturnAwaited, useBaseQuery } from '~/shared/api';
 
 type FetchFn = typeof answerService.validateMultiInformantAssessment;
-type Options<TData> = QueryOptions<FetchFn, TData>;
-type OptionalArgs<TData = ReturnAwaited<FetchFn>> = {
+type ReturnType = ReturnAwaited<FetchFn>;
+type OptionalArgs = {
   sourceSubjectId?: string;
   targetSubjectId?: string;
   activityOrFlowId?: string;
-  options?: Options<TData>;
+  options?: QueryOptions<FetchFn, ReturnType, ReturnType, AxiosError>;
 };
 
-export const useValidateMultiInformantAssessmentQuery = <TData = ReturnAwaited<FetchFn>>(
+export const useValidateMultiInformantAssessmentQuery = (
   appletId: string,
-  optionalArgs?: OptionalArgs<TData>,
+  optionalArgs?: OptionalArgs,
 ) => {
   const { options, ...queryParams } = optionalArgs || {};
 
-  return useBaseQuery(
+  return useBaseQuery<
+    ReturnAwaited<typeof answerService.validateMultiInformantAssessment>,
+    AxiosError,
+    ReturnAwaited<typeof answerService.validateMultiInformantAssessment>
+  >(
     ['multiInformantAssessmentDetails', { appletId }],
     () => answerService.validateMultiInformantAssessment({ appletId, ...queryParams }),
     options,

--- a/src/entities/answer/index.ts
+++ b/src/entities/answer/index.ts
@@ -1,0 +1,1 @@
+export * from './api';

--- a/src/features/TakeNow/lib/useTakeNowValidation.tsx
+++ b/src/features/TakeNow/lib/useTakeNowValidation.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
 
 import { MultiInformantState } from '~/abstract/lib/types/multiInformant';
-import { useActivityByIdQuery } from '~/entities/activity';
 import { useValidateMultiInformantAssessmentQuery } from '~/entities/answer';
 import { useAppletByIdQuery } from '~/entities/applet';
 import { useSubjectQuery } from '~/entities/subject';
@@ -66,11 +65,6 @@ export const useTakeNowValidation = ({
     isLoading: isLoadingApplet,
   } = useAppletByIdQuery({ isPublic: false, appletId });
 
-  const { isError: isActivityError, isLoading: isLoadingActivity } = useActivityByIdQuery({
-    isPublic: false,
-    activityId: startActivityOrFlow,
-  });
-
   useEffect(() => {
     if (!workspaceId && !isLoadingApplet && appletData) {
       const localWorkspaceId = appletData?.data.result.encryption?.accountId;
@@ -133,7 +127,7 @@ export const useTakeNowValidation = ({
     return errorState(null);
   }
 
-  if (isLoadingTargetSubject || isLoadingSourceSubject || isLoadingActivity) {
+  if (isLoadingTargetSubject || isLoadingSourceSubject) {
     return loadingState;
   }
 
@@ -169,10 +163,6 @@ export const useTakeNowValidation = ({
 
   const { nickname: sourceSubjectNickname, secretUserId: sourceSecretUserId } =
     sourceSubjectData.data.result;
-
-  if (isActivityError) {
-    return errorState(t('takeNow.invalidActivity'));
-  }
 
   // At this point we have the subject, applet, and activity data
   // We can't fetch the workspace roles before we have the applet data

--- a/src/features/TakeNow/lib/useTakeNowValidation.tsx
+++ b/src/features/TakeNow/lib/useTakeNowValidation.tsx
@@ -1,4 +1,7 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { useEffect, useState } from 'react';
+
+import { AxiosError } from 'axios';
 
 import { MultiInformantState } from '~/abstract/lib/types/multiInformant';
 import { useValidateMultiInformantAssessmentQuery } from '~/entities/answer';
@@ -102,6 +105,19 @@ export const useTakeNowValidation = ({
     } else if (validationError.response?.status === 404) {
       // Invalid applet ID
       return errorState(null);
+    } else if (validationError.response?.status === 422) {
+      const axiosError = validationError as AxiosError<any, any>;
+      const param = axiosError.response?.data?.result?.[0]?.path?.[1] as string | undefined;
+
+      if (!param) return errorState(null);
+
+      switch (param) {
+        case 'activityOrFlowId':
+          return errorState(t('takeNow.invalidActivity'));
+        case 'sourceSubjectId':
+        case 'targetSubjectId':
+          return errorState(t('takeNow.invalidSubject'));
+      }
     }
   }
 

--- a/src/features/TakeNow/lib/useTakeNowValidation.tsx
+++ b/src/features/TakeNow/lib/useTakeNowValidation.tsx
@@ -10,7 +10,8 @@ import { useSubjectQuery } from '~/entities/subject';
 import { useUserState } from '~/entities/user/model/hooks';
 import { useWorkspaceAppletRespondent } from '~/entities/workspace';
 import { TakeNowParams } from '~/features/TakeNow/lib/TakeNowParams.types';
-import { useCustomTranslation } from '~/shared/utils';
+import { ROUTES } from '~/shared/constants';
+import { useCustomNavigation, useCustomTranslation } from '~/shared/utils';
 
 type TakeNowValidatedState = {
   isLoading: boolean;
@@ -76,6 +77,7 @@ export const useTakeNowValidation = ({
   }, [appletData, isLoadingApplet, workspaceId]);
 
   const { t } = useCustomTranslation();
+  const { navigate } = useCustomNavigation();
   const { user } = useUserState();
 
   const loadingState: TakeNowValidatedState = {
@@ -104,7 +106,8 @@ export const useTakeNowValidation = ({
       return errorState(t('takeNow.invalidRespondent'));
     } else if (validationError.response?.status === 404) {
       // Invalid applet ID
-      return errorState(null);
+      setTimeout(() => navigate(ROUTES.appletList.path));
+      return errorState(t('takeNow.invalidApplet'));
     } else if (validationError.response?.status === 422) {
       const axiosError = validationError as AxiosError<any, any>;
       const param = axiosError.response?.data?.result?.[0]?.path?.[1] as string | undefined;
@@ -140,7 +143,8 @@ export const useTakeNowValidation = ({
   }
 
   if (isAppletError || !appletData?.data?.result) {
-    return errorState(null);
+    setTimeout(() => navigate(ROUTES.appletList.path));
+    return errorState(t('takeNow.invalidApplet'));
   }
 
   if (isLoadingTargetSubject || isLoadingSourceSubject) {

--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -291,6 +291,7 @@
       "invalidRespondent": "You are not authorized to complete this assessment on behalf of this subject.",
       "invalidSubject": "This subject does not exist.",
       "invalidActivity": "This activity does not exist.",
+      "invalidApplet": "This applet does not exist.",
       "successModalTitle": "Activity Done",
       "successModalLabel": "Your answers have been submitted. Please return to the Admin App to complete another activity or view results.",
       "successModalPrimaryAction": "Return to Admin App",

--- a/src/i18n/fr/translation.json
+++ b/src/i18n/fr/translation.json
@@ -299,6 +299,7 @@
       "invalidRespondent": "Vous n'êtes pas autorisé à effectuer cette évaluation au nom de ce sujet.",
       "invalidSubject": "Ce sujet n'existe pas.",
       "invalidActivity": "Cette activité n'existe pas.",
+      "invalidApplet": "Cette applet n'existe pas.",
       "successModalTitle": "Activité terminée",
       "successModalLabel": "Vos réponses ont été soumises. Veuillez revenir à l'application d'administration pour terminer une autre activité ou afficher les résultats.",
       "successModalPrimaryAction": "Revenir à l'application d'administration",

--- a/src/shared/api/services/answer.service.ts
+++ b/src/shared/api/services/answer.service.ts
@@ -1,0 +1,24 @@
+import { axiosService } from '~/shared/api';
+import {
+  ValidateMultiInformantAssessmentPayload,
+  ValidateMultiInformantAssessmentResponse,
+} from '~/shared/api/types/answer';
+
+function answerService() {
+  return {
+    validateMultiInformantAssessment(payload: ValidateMultiInformantAssessmentPayload) {
+      return axiosService.get<ValidateMultiInformantAssessmentResponse>(
+        `/answers/applet/${payload.appletId}/multiinformant-assessment/validate`,
+        {
+          params: {
+            sourceSubjectId: payload.sourceSubjectId,
+            targetSubjectId: payload.targetSubjectId,
+            activityOrFlowId: payload.activityOrFlowId,
+          },
+        },
+      );
+    },
+  };
+}
+
+export default answerService();

--- a/src/shared/api/services/index.ts
+++ b/src/shared/api/services/index.ts
@@ -5,4 +5,5 @@ export { default as invitationService } from './invitation.service';
 export { default as activityService } from './activity.service';
 export { default as eventsService } from './events.service';
 export { default as subjectService } from './subject.service';
+export { default as answerService } from './answer.service';
 export { default as workspaceService } from './workspace.service';

--- a/src/shared/api/types/answer.ts
+++ b/src/shared/api/types/answer.ts
@@ -1,0 +1,23 @@
+import { BaseSuccessResponse } from '~/shared/api';
+
+export interface ValidateMultiInformantAssessmentPayload {
+  appletId: string;
+  sourceSubjectId?: string;
+  targetSubjectId?: string;
+  activityOrFlowId?: string;
+}
+
+export type MultiInformantAssessmentValidationCode =
+  | 'invalid_source_subject'
+  | 'invalid_target_subject'
+  | 'invalid_activity_or_flow_id'
+  | 'no_access_to_applet';
+
+export type MultiInformantAssessmentValidationDTO = {
+  valid: boolean;
+  message?: string;
+  code?: MultiInformantAssessmentValidationCode;
+};
+
+export type ValidateMultiInformantAssessmentResponse =
+  BaseSuccessResponse<MultiInformantAssessmentValidationDTO>;

--- a/src/widgets/ActivityGroups/ui/ActivityCard/index.tsx
+++ b/src/widgets/ActivityGroups/ui/ActivityCard/index.tsx
@@ -130,7 +130,8 @@ export const ActivityCard = ({ activityListItem }: Props) => {
   useOnceEffect(() => {
     if (
       context.startActivityOrFlow &&
-      context.startActivityOrFlow === activityListItem.activityId
+      ((!isFlow && context.startActivityOrFlow === activityListItem.activityId) ||
+        (isFlow && context.startActivityOrFlow === activityListItem.flowId))
     ) {
       restartActivity();
     }


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-6746](https://mindlogger.atlassian.net/browse/M2-6746)
🔗 [Jira Ticket M2-6856](https://mindlogger.atlassian.net/browse/M2-6856)

This PR adds the `useValidateMultiInformantAssessmentQuery` query, which is based on the `/answers/applet/{applet_id}/multiinformant-assessment/validate` API endpoint implemented in https://github.com/ChildMindInstitute/mindlogger-backend-refactor/pull/1316. This moves the majority of the take-now parameter validation to the API instead of being done solely on the frontend.

There is no functional difference between the two implementations, so you may refer to https://github.com/ChildMindInstitute/mindlogger-admin/pull/1728 for testing guidance

### 📸 Screenshots

N/A

### 🪤 Peer Testing

Please refer to https://github.com/ChildMindInstitute/mindlogger-admin/pull/1728 (specifically the table at the end of the description) for testing the existing functionality.

In addition, please use the URL template `https://localhost:5173/protected/applets/{appletId}?startActivityOrFlow={activityId}&sourceSubjectId={sourceSubjectId}&targetSubjectId={targetSubjectId}&respondentId={ownerUserId}` to test the following scenarios:
- Invalid applet ID
- Invalid activity ID
- Invalid source subject
- Invalid target subject
- User with insufficient permission (e.g. coordinator user)

### ✏️ Notes

The issue [M2-6856](https://mindlogger.atlassian.net/browse/M2-6856) was raised after this PR was up for review. This PR inadvertently fixes it, so I'm adding the issue number to the PR title and description.


[M2-6856]: https://mindlogger.atlassian.net/browse/M2-6856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ