### PR TITLE
(No-task) The condition was added to prevent access to undefined state

### DIFF
--- a/src/widgets/ActivityGroups/model/hooks/useIntegrationsSync.ts
+++ b/src/widgets/ActivityGroups/model/hooks/useIntegrationsSync.ts
@@ -14,8 +14,10 @@ export const useIntegrationsSync = ({ appletDetails }: Props) => {
   const consents = useAppSelector(appletModel.selectors.selectConsents);
 
   useEffect(() => {
-    const appletIntegrationService = new AppletIntegrationsService(consents, dispatch);
+    if (consents) {
+      const appletIntegrationService = new AppletIntegrationsService(consents, dispatch);
 
-    appletIntegrationService.applyIntegrations(appletDetails);
+      appletIntegrationService.applyIntegrations(appletDetails);
+    }
   }, [appletDetails, dispatch, consents]);
 };


### PR DESCRIPTION

### 📝 Description

The small bug was fixed without a ticket. The cause of the bug is that the application tried to access the undefined part of the loris integration state.

Changes include:

- useIntegrationSync
