### PR TITLE
Update the link to the Google Play Store

### DIFF
--- a/src/abstract/lib/constants.ts
+++ b/src/abstract/lib/constants.ts
@@ -1,6 +1,6 @@
 export const APPSTORE_LINK = 'https://apps.apple.com/app/mindlogger/id1299242097';
 export const GOOGLEPLAY_LINK =
-  'https://play.google.com/store/apps/details?id=lab.childmindinstitute.data';
+  'https://play.google.com/store/apps/details?id=lab.childmindinstitute.data.production';
 
 export const supportableResponseTypes = [
   'text',


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-6989](https://mindlogger.atlassian.net/browse/M2-6989)

Changed the Google Play Store link from https://play.google.com/store/apps/details?id=lab.childmindinstitute.data to https://play.google.com/store/apps/details?id=lab.childmindinstitute.data.production

### 📸 Screenshots

N/A

### 🪤 Peer Testing

Open the web app and click the Google Play Store link on the login screen. It should take you to the URL above (albeit to a not found page)

<img width="1552" alt="image" src="https://github.com/ChildMindInstitute/mindlogger-web-refactor/assets/14842108/9e549c0c-6dda-42ac-b6d8-132eba38f38e">

### ✏️ Notes

>[!WARNING]
> This PR should not be merged until the new Android app has been published to the Play Store
