### PR TITLE
fix: restore support for markdown in banners (M2-6987)

### DIFF
--- a/src/shared/ui/Banners/Banner/Banner.test.tsx
+++ b/src/shared/ui/Banners/Banner/Banner.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 
 import { Banner } from './Banner';
 
@@ -18,13 +18,16 @@ describe('Banner', () => {
     jest.resetAllMocks();
   });
 
-  test('should render component', () => {
+  test('should render component', async () => {
     render(<Banner {...props} />);
 
-    expect(screen.queryByText(props.children)).toBeVisible();
-    const closeButton = screen.getByRole('button');
-    expect(closeButton).toBeVisible();
-    expect(closeButton).toHaveAccessibleName('Close');
+    // Wait for markdown to be processed asynchronously
+    await waitFor(() => {
+      expect(screen.queryByText(props.children)).toBeVisible();
+      const closeButton = screen.getByRole('button');
+      expect(closeButton).toBeVisible();
+      expect(closeButton).toHaveAccessibleName('Close');
+    });
   });
 
   test('clicking the close button calls onClose callback', () => {
@@ -63,14 +66,17 @@ describe('Banner', () => {
     ${'error'}   | ${'error banner'}
   `(
     'has text that matches severity $severity',
-    ({ severity, text }: { severity: BannerProps['severity']; text: string }) => {
+    async ({ severity, text }: { severity: BannerProps['severity']; text: string }) => {
       render(
         <Banner {...props} severity={severity}>
           {text}
         </Banner>,
       );
 
-      expect(screen.getByText(text)).toBeInTheDocument();
+      // Wait for markdown to be processed asynchronously
+      await waitFor(() => {
+        expect(screen.getByText(text)).toBeInTheDocument();
+      });
     },
   );
 });

--- a/src/shared/ui/Banners/Banner/Banner.tsx
+++ b/src/shared/ui/Banners/Banner/Banner.tsx
@@ -5,6 +5,7 @@ import { Alert } from '@mui/material';
 import { BANNER_ICONS } from './lib/const';
 import { BannerProps } from './lib/types';
 
+import { Markdown } from '~/shared/ui/Markdown';
 import Text from '~/shared/ui/Text';
 import { useWindowFocus } from '~/shared/utils';
 
@@ -39,7 +40,7 @@ export const Banner = ({
       severity={severity}
       data-testid={`${severity}-banner`}
     >
-      <Text>{children}</Text>
+      <Text>{typeof children === 'string' ? <Markdown markdown={children} /> : children}</Text>
     </Alert>
   );
 };

--- a/src/shared/ui/Banners/Banners.test.tsx
+++ b/src/shared/ui/Banners/Banners.test.tsx
@@ -14,10 +14,13 @@ const preloadedState: PreloadedState<RootState> = {
 };
 
 describe('Banners', () => {
-  test('should render test banner', () => {
+  test('should render test banner', async () => {
     renderWithProviders(<Banners />, { preloadedState });
 
-    expect(screen.getByText('test message')).toBeInTheDocument();
+    // Wait for markdown to be processed asynchronously
+    await waitFor(() => {
+      expect(screen.getByText('test message')).toBeInTheDocument();
+    });
   });
 
   test('should no longer render banner when its close button clicked', async () => {


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-6987](https://mindlogger.atlassian.net/browse/M2-6987)

This change fixes a regression identified when migrating from Notifications infra to Banners (#477) where markdown passed to the Banner component was not properly converted to rich text.

### 📸 Screenshots

| Before                      | After                                 |
| -------------------------------------- | ------------------------------------- |
| <img width="459" alt="Screenshot 2024-06-11 at 3 01 43 PM" src="https://github.com/ChildMindInstitute/mindlogger-web-refactor/assets/1282772/1a4291b0-0f79-476b-bb1c-0e8025741600"> | <img width="429" alt="Screenshot 2024-06-11 at 3 01 55 PM" src="https://github.com/ChildMindInstitute/mindlogger-web-refactor/assets/1282772/c77aaa53-b197-4473-a070-6b2a9ba3691d"> |

### 🪤 Peer Testing

- Log into the Web App and complete an activity.
    **Expected outcome:** Banner shows formatted text: **Done!** We received your answers.