### PR TITLE
Log the admin out if there is a mismatched respondent ID

### DIFF
--- a/src/features/TakeNow/lib/TakeNowParams.types.ts
+++ b/src/features/TakeNow/lib/TakeNowParams.types.ts
@@ -1,7 +1,0 @@
-export type TakeNowParams = {
-  appletId: string;
-  startActivityOrFlow: string;
-  targetSubjectId: string;
-  sourceSubjectId: string;
-  respondentId: string;
-};

--- a/src/features/TakeNow/lib/types.ts
+++ b/src/features/TakeNow/lib/types.ts
@@ -1,0 +1,30 @@
+import { MultiInformantState } from '~/abstract/lib/types/multiInformant';
+
+export type TakeNowParams = {
+  appletId: string;
+  startActivityOrFlow: string;
+  targetSubjectId: string;
+  sourceSubjectId: string;
+  respondentId: string;
+};
+
+export type TakeNowValidationErrorType =
+  | 'mismatchedRespondent'
+  | 'invalidRespondent'
+  | 'invalidApplet'
+  | 'invalidActivity'
+  | 'invalidSubject'
+  | 'common_loading_error';
+
+export type TakeNowValidationError = {
+  type: TakeNowValidationErrorType;
+  error: string;
+};
+
+export type TakeNowValidatedState = {
+  isLoading: boolean;
+  isError: boolean;
+  isSuccess: boolean;
+  error?: TakeNowValidationError | null;
+  data?: Required<MultiInformantState>;
+};

--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -289,7 +289,7 @@
         "subjectOfResponses": "Subject of Responses"
       },
       "invalidRespondent": "You are not authorized to complete this assessment on behalf of this subject.",
-      "mismatchedRespondent": "There's a mismatch between the expected responder and the signed-in web app user. Log out of the web app and log in with the responder’s login, then re-initiate Take Now from the Admin App.",
+      "mismatchedRespondent": "There's a mismatch between the expected responder and the signed-in web app user. Please login as the correct responder to continue with Take Now.",
       "invalidSubject": "This subject does not exist.",
       "invalidActivity": "This activity does not exist.",
       "invalidApplet": "This applet does not exist.",

--- a/src/i18n/fr/translation.json
+++ b/src/i18n/fr/translation.json
@@ -297,7 +297,7 @@
         "subjectOfResponses": "Objet des réponses"
       },
       "invalidRespondent": "Vous n'êtes pas autorisé à effectuer cette évaluation au nom de ce sujet.",
-      "mismatchedRespondent": "Il existe une incohérence entre le répondeur attendu et l’utilisateur connecté de l’application Web. Déconnectez-vous de l'application Web et connectez-vous avec l'identifiant du répondeur, puis relancez Take Now à partir de l'application Admin.",
+      "mismatchedRespondent": "Il existe une incompatibilité entre le répondeur attendu et l’utilisateur connecté de l’application Web. Veuillez vous connecter en tant que bon répondeur pour continuer avec Take Now.",
       "invalidSubject": "Ce sujet n'existe pas.",
       "invalidActivity": "Cette activité n'existe pas.",
       "invalidApplet": "Cette applet n'existe pas.",


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-6844](https://mindlogger.atlassian.net/browse/M2-6844)

This PR updates the behaviour of the "mismatched respondent" take now validation scenario. The current behaviour shows an error message instructing the admin user to log out, log back in as the correct user, and re-initiate take now from the admin app

<img width="1552" alt="image" src="https://github.com/ChildMindInstitute/mindlogger-web-refactor/assets/14842108/6ace7a7a-8ab9-4b98-8777-f6e8fbf1f293">

The updated behaviour automatically logs the admin out, and shows a persistent error message instructing them to log in as the correct user to initiate take now. The multi-informant take now context is retained in the tab as long as it remains open.

<img width="1552" alt="image" src="https://github.com/ChildMindInstitute/mindlogger-web-refactor/assets/14842108/04b86002-8b39-453a-a864-80438bf409bc">

### 📸 Screenshots

#### Before

<img width="1552" alt="image" src="https://github.com/ChildMindInstitute/mindlogger-web-refactor/assets/14842108/6ace7a7a-8ab9-4b98-8777-f6e8fbf1f293">

#### After

<img width="1552" alt="image" src="https://github.com/ChildMindInstitute/mindlogger-web-refactor/assets/14842108/04b86002-8b39-453a-a864-80438bf409bc">

### 🪤 Peer Testing

- Construct a take-now URL in the following format: `https://localhost:5173/protected/applets/{appletId}?startActivityOrFlow={activityId}&sourceSubjectId={sourceSubjectId}&targetSubjectId={targetSubjectId}&respondentId={randomUUID}`, where `randomUUID` is a random v4 UUID.
- Enter the URL in the browser and log in with valid credentials
- Observe and confirm:
  - The error message matches the expected message
  - The error message persists until you dismiss it (it is enough to confirm it lasts longer than 15s)
  - You are logged back out
- Log in again and confirm the same as above

### ✏️ Notes

There is a known defect that the error message will persist into a separate tab unless you dismiss it. A fix for this is coming in a separate PR
