### PR TITLE
fix(mi): update ownerId for TakeNow (M2-6948)

### DIFF
--- a/src/features/TakeNow/lib/useTakeNowValidation.tsx
+++ b/src/features/TakeNow/lib/useTakeNowValidation.tsx
@@ -71,7 +71,7 @@ export const useTakeNowValidation = ({
 
   useEffect(() => {
     if (!workspaceId && !isLoadingApplet && appletData) {
-      const localWorkspaceId = appletData?.data.result.encryption?.accountId;
+      const localWorkspaceId = appletData?.data.result.ownerId;
       setWorkspaceId(localWorkspaceId || null);
     }
   }, [appletData, isLoadingApplet, workspaceId]);

--- a/src/shared/api/types/applet.ts
+++ b/src/shared/api/types/applet.ts
@@ -45,6 +45,7 @@ export type AppletDTO = {
   about: string;
   image: string;
   watermark: string;
+  ownerId: string;
   activities: AppletDetailsActivityDTO[];
   activityFlows: ActivityFlowDTO[];
   encryption: EncryptionDTO | null;


### PR DESCRIPTION
### 📝 Description

Replaces how we obtain the workspace ID (`owner_id`) to use the new value from `/applets/{applet_id}` instead of using `encryption.account_id`

🔗 [Jira Ticket M2-6948](https://mindlogger.atlassian.net/browse/M2-6948)


### 🪤 Peer Testing

Ensure your local backend is using this branch https://github.com/ChildMindInstitute/mindlogger-backend-refactor/pull/1402

- Initiate TakeNow from Admin
- Log in to web app
- TakeNow should complete correctly


### ✏️ Notes

Merging blocked until BE PR is merged

