### PR TITLE
fix: hide warnings when proceeding to next step (M2-7014)

### DIFF
--- a/src/widgets/Survey/model/validateItem.ts
+++ b/src/widgets/Survey/model/validateItem.ts
@@ -94,6 +94,7 @@ function validateResponseCorrectness(item: appletModel.ItemRecord): boolean {
 type ValidateItemProps = {
   item: appletModel.ItemRecord;
   showWarning: (translationKey: string) => void;
+  hideWarning: () => void;
   activity: ActivityDTO;
 };
 
@@ -101,10 +102,12 @@ export function validateBeforeMoveForward({
   item,
   activity,
   showWarning,
+  hideWarning,
 }: ValidateItemProps): boolean {
   const isSkippable = item.config.skippableItem || activity.isSkippable;
 
   if (isSkippable) {
+    hideWarning();
     return true;
   }
 
@@ -145,5 +148,7 @@ export function validateBeforeMoveForward({
     showWarning('pleaseListenToAudio');
     return false;
   }
+
+  hideWarning();
   return true;
 }

--- a/src/widgets/Survey/ui/PassingScreen.tsx
+++ b/src/widgets/Survey/ui/PassingScreen.tsx
@@ -24,7 +24,7 @@ const PassingScreen = () => {
 
   const [isModalOpen, setIsModalOpen] = useState(false);
 
-  const { addWarningBanner, addSuccessBanner } = useBanners();
+  const { addWarningBanner, addSuccessBanner, removeWarningBanner } = useBanners();
 
   const surveyBasicContext = useContext(SurveyBasicContext); // This is basic context with { eventId, appletId, activityId, isPublic, publicAppletKey }
   const surveyContext = useContext(SurveyContext); // This is full context with { applet, activity, events, respondentMeta }
@@ -233,6 +233,7 @@ const PassingScreen = () => {
       item,
       activity,
       showWarning: (key: string) => addWarningBanner(t(key)),
+      hideWarning: removeWarningBanner,
     });
 
     if (!isValid) {
@@ -249,6 +250,7 @@ const PassingScreen = () => {
   }, [
     item,
     activity,
+    removeWarningBanner,
     conditionallyHiddenItemIds,
     removeItemAnswer,
     hasNextStep,

--- a/src/widgets/Survey/ui/index.tsx
+++ b/src/widgets/Survey/ui/index.tsx
@@ -6,10 +6,15 @@ import { ScreenManager } from './ScreenManager';
 import { SurveyBasicContext, SurveyContext } from '../lib';
 import { useSurveyDataQuery } from '../model/hooks';
 
-import { useCustomTranslation } from '~/shared/utils';
+import { useBanners } from '~/entities/banner/model';
+import { useCustomTranslation, useOnceEffect } from '~/shared/utils';
 
 export const SurveyWidget = () => {
   const { t } = useCustomTranslation();
+  const { removeAllBanners } = useBanners();
+
+  // Remove any stale banners on mount
+  useOnceEffect(() => removeAllBanners());
 
   const context = useContext(SurveyBasicContext);
 


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-7014](https://mindlogger.atlassian.net/browse/M2-7014)

A regression was introduced with the transition from `Notifications` to `Banners`: while taking an activity, if the step failed validation to proceed to the next step, then you corrected the issue and proceeded successfully, the stale warning would linger even adjacent to a success message. This PR fixes that.

I also noticed that the assessment completion success banner was remaining visible when the next activity was started. I fixed that by clearing all banners when an assessment begins.

### 📸 Screenshots


https://github.com/ChildMindInstitute/mindlogger-web-refactor/assets/1282772/dbbf7245-6c79-4bea-a322-195876096dfd



### 🪤 Peer Testing

> [!NOTE]
> The `metapod` version of the BE is currently not accepting answer submissions with the latest version of the Web App due to a breaking change related to the `isDataShare` prop sent by the Web App. To work around this, temporarily change `false` to `undefined` on [line 145](https://github.com/ChildMindInstitute/mindlogger-web-refactor/blob/fix/M2-7014-stale-banner-during-assessment/src/widgets/Survey/model/hooks/useAnswers.ts#L145) of `useAnswers.ts`.

1. Start an activity assessment that has items that are required to proceed.
2. Try to proceed past a required item without answering it.
    **Expected outcome:** Warning banner is shown and you cannot proceed.
3. Answer the question and proceed to the next step before the warning banner times out.
    **Expected outcome:** Warning banner is hidden.
4. Successfully complete the activity.
    **Expected outcome:** Success banner is shown.
5. Start another activity before the success banner times out.
    **Expected outcome:** Success banner is hidden.