### PR TITLE
fix(mi): Close Web App tab after Take Now (M2-7159)

### DIFF
--- a/src/features/TakeNow/ui/TakeNowSuccessModal.tsx
+++ b/src/features/TakeNow/ui/TakeNowSuccessModal.tsx
@@ -45,8 +45,7 @@ export const TakeNowSuccessModal = ({
         const targetWindow = window.opener as Window;
 
         if (targetWindow) {
-          // message sent to the parent window that is opening the file into the new tab
-          // the file receiving the message in the admin panel is TakeNowModal.tsx
+          // Send message to the opening tab in the Admin App to close this tab (see its TakeNowModal component).
           targetWindow.postMessage('close-me', import.meta.env.VITE_ADMIN_PANEL_HOST);
         }
       },


### PR DESCRIPTION

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-7159](https://mindlogger.atlassian.net/browse/M2-7159)

Currently the application is window is unable to close itself for some security reason on browsers when using [window.close](https://developer.mozilla.org/en-US/docs/Web/API/Window/close) the solution is to create a message event and share that message event with the parent window whose open this window

Changes include:

- Delete the window.close statement
- sent a message event to the other tab

### 📸 Screenshots


https://github.com/ChildMindInstitute/mindlogger-web-refactor/assets/28871425/763761e3-d1e5-4cc5-94c6-39a8b645b102
