### PR TITLE
M2-no-ticket: add sourcemap to deployed dev mode

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -47,7 +47,7 @@ export default defineConfig(async ({ command, mode }): Promise<UserConfig> => {
     },
     build: {
       sourcemap: env.VITE_ENV === 'dev',
-    }
+    },
   };
 
   if (command === 'serve') {


### PR DESCRIPTION
### 📝 Description

No - Ticket 

Changes include:

- Added Sourcemap for the deployed dev environment to be able to test better

### 📸 Screenshots
dist folder serve from local
![image](https://github.com/ChildMindInstitute/mindlogger-web-refactor/assets/28871425/498b584e-80c0-415a-af97-
c368a610a12c)

<img width="1519" alt="image" src="https://github.com/ChildMindInstitute/mindlogger-web-refactor/assets/28871425/dea75621-1860-42bd-8af2-40f6a9bf30b2">


## Screenshot from the Amplify feature branch
<img width="1376" alt="image" src="https://github.com/ChildMindInstitute/mindlogger-web-refactor/assets/28871425/623a567a-d110-4e31-8568-66ff9795e7ee">
