### PR TITLE
fix(mi): run Mixpanel callbacks when Mixpanel disabled (M2-7159)

### DIFF
--- a/src/shared/utils/analytics/mixpanel.ts
+++ b/src/shared/utils/analytics/mixpanel.ts
@@ -28,8 +28,12 @@ export const Mixpanel = {
     optionsOrCallback?: RequestOptions | Callback,
     callback?: Callback,
   ) {
-    if (shouldEnableMixpanel)
+    if (shouldEnableMixpanel) {
       mixpanel.track(`[Web] ${action}`, payload, optionsOrCallback, callback);
+    } else {
+      if (typeof optionsOrCallback === 'function') optionsOrCallback(0);
+      callback?.(0);
+    }
   },
   login(userId: string) {
     if (shouldEnableMixpanel) {


### PR DESCRIPTION
### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-7159](https://mindlogger.atlassian.net/browse/M2-7159)

This change ensures Mixpanel callbacks will work even when Mixpanel is disabled, which @ionyRojas and I think is responsible for the "Return to Admin App" button failing to close the Web App tab after Take Now. 🤞🏻 

### 🪤 Peer Testing

1. Comment out these lines in your Web App's `.env` file:
    ```env
    # VITE_MIXPANEL_TOKEN=c1e1e662f03d9f1363768731077ea000
    # VITE_MIXPANEL_FORCE_ENABLE=true
    ```
2. Perform Take Now in the Admin App, complete the assessment in the Web App, and press the **Return to Admin App** button.
    **Expected outcome:** Web App should close, and Admin App should be focused.
