### PR TITLE
fix: Add missing Submit ID to MixPanel event (M2-7289)

### DIFF
--- a/src/abstract/lib/types/multiInformant.ts
+++ b/src/abstract/lib/types/multiInformant.ts
@@ -12,4 +12,5 @@ export type MultiInformantState = {
   activityId?: string | null;
   activityFlowId?: string | null;
   multiInformantAssessmentId?: string | null;
+  submitId?: string | null;
 };

--- a/src/entities/applet/model/hooks/useMultiInformantState.ts
+++ b/src/entities/applet/model/hooks/useMultiInformantState.ts
@@ -11,6 +11,7 @@ type Return = {
   getMultiInformantState: () => MultiInformantState;
   isInMultiInformantFlow: () => boolean;
   initiateTakeNow: (payload: MultiInformantPayload) => void;
+  updateMultiInformantState: (payload: Partial<MultiInformantPayload>) => void;
   resetMultiInformantState: () => void;
   ensureMultiInformantStateExists: () => void;
 };
@@ -32,6 +33,13 @@ export const useMultiInformantState = (): Return => {
     [dispatch],
   );
 
+  const updateMultiInformantState = useCallback(
+    (payload: Partial<MultiInformantPayload>) => {
+      dispatch(actions.updateMultiInformantState(payload));
+    },
+    [dispatch],
+  );
+
   const resetMultiInformantState = useCallback(() => {
     dispatch(actions.resetMultiInformantState());
   }, [dispatch]);
@@ -44,6 +52,7 @@ export const useMultiInformantState = (): Return => {
     getMultiInformantState,
     isInMultiInformantFlow,
     initiateTakeNow,
+    updateMultiInformantState,
     resetMultiInformantState,
     ensureMultiInformantStateExists,
   };

--- a/src/entities/applet/model/slice.ts
+++ b/src/entities/applet/model/slice.ts
@@ -308,6 +308,13 @@ const appletsSlice = createSlice({
       state.multiInformantState = action.payload;
     },
 
+    updateMultiInformantState: (state, action: PayloadAction<Partial<MultiInformantPayload>>) => {
+      state.multiInformantState = {
+        ...state.multiInformantState,
+        ...action.payload,
+      };
+    },
+
     ensureMultiInformantStateExists: (state) => {
       if (!state.multiInformantState) {
         state.multiInformantState = {};

--- a/src/features/PassSurvey/hooks/useSubmitAnswersMutation.ts
+++ b/src/features/PassSurvey/hooks/useSubmitAnswersMutation.ts
@@ -11,7 +11,7 @@ type Props = {
 };
 
 export const useSubmitAnswersMutations = ({ isPublic, onSubmitSuccess }: Props) => {
-  const { isInMultiInformantFlow, getMultiInformantState } =
+  const { isInMultiInformantFlow, getMultiInformantState, updateMultiInformantState } =
     appletModel.hooks.useMultiInformantState();
 
   const onSuccess = (_: AxiosResponse, variables: AnswerPayload) => {
@@ -28,9 +28,15 @@ export const useSubmitAnswersMutations = ({ isPublic, onSubmitSuccess }: Props) 
     if (isInMultiInformantFlow()) {
       analyticsPayload[MixpanelProps.Feature] = 'Multi-informant';
 
-      const { multiInformantAssessmentId } = getMultiInformantState();
+      const { multiInformantAssessmentId, submitId } = getMultiInformantState();
       if (multiInformantAssessmentId) {
         analyticsPayload[MixpanelProps.MultiInformantAssessmentId] = multiInformantAssessmentId;
+      }
+
+      if (submitId === null) {
+        updateMultiInformantState({
+          submitId: variables.submitId,
+        });
       }
     }
 

--- a/src/features/TakeNow/lib/useTakeNowValidation.tsx
+++ b/src/features/TakeNow/lib/useTakeNowValidation.tsx
@@ -277,6 +277,7 @@ export const useTakeNowValidation = ({
       activityId,
       activityFlowId,
       multiInformantAssessmentId,
+      submitId: null,
     },
   };
 };

--- a/src/features/TakeNow/ui/TakeNowSuccessModal.tsx
+++ b/src/features/TakeNow/ui/TakeNowSuccessModal.tsx
@@ -16,12 +16,14 @@ export const TakeNowSuccessModal = ({
   multiInformantAssessmentId,
   activityId,
   activityFlowId,
+  submitId,
 }: TakeNowSuccessModalProps) => {
   const { t } = useCustomTranslation();
 
   const handleReturnToAdminAppClick = () => {
     const analyticsPayload: MixpanelPayload = {
       [MixpanelProps.AppletId]: appletId,
+      [MixpanelProps.SubmitId]: submitId,
     };
 
     if (activityId) {


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-7289](https://mindlogger.atlassian.net/browse/M2-7289)

This PR adds the `Submit ID` property to the _Return to Admin App button clicked_ MixPanel event

### 📸 Screenshots

#### Before

<img width="1287" alt="image" src="https://github.com/user-attachments/assets/531ac268-04b6-4b90-b90c-a887be326d97">

#### After

<img width="1280" alt="Screenshot 2024-07-18 at 9 31 19 AM" src="https://github.com/user-attachments/assets/a9931dc2-fa7c-47ce-b2f0-eacdfb49f469">

### 🪤 Peer Testing

1. Complete the take now flow
2. Go to https://mixpanel.com/project/3333580/view/3841316/app/events
3. Check for the _Return to Admin App button clicked_ event and confirm that it has a `Submit ID`

### ✏️ Notes

N/A