### PR TITLE
feat: Persistent activity success banner (M2-7281)

### DIFF
--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -3,6 +3,7 @@ import { RenderOptions } from '@testing-library/react';
 import persistReducer from 'redux-persist/es/persistReducer';
 import persistStore from 'redux-persist/es/persistStore';
 import storage from 'redux-persist/lib/storage';
+import sessionStorage from 'redux-persist/lib/storage/session';
 
 import { appletModel } from '~/entities/applet';
 import { bannerModel } from '~/entities/banner';
@@ -13,12 +14,18 @@ import { RootState } from '~/shared/utils';
 const persistConfig = {
   key: 'root',
   storage,
+  blacklist: ['banners'],
+};
+
+const bannerPersistConfig = {
+  key: 'banners',
+  storage: sessionStorage,
 };
 
 export const rootReducer = combineReducers({
   user: userModel.reducer,
   applets: appletModel.reducer,
-  banners: bannerModel.reducer,
+  banners: persistReducer(bannerPersistConfig, bannerModel.reducer),
   autoCompletion: AutoCompletionModel.reducer,
 });
 

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -1,4 +1,4 @@
-import { PreloadedState, combineReducers, configureStore } from '@reduxjs/toolkit';
+import { PreloadedState, combineReducers, configureStore, Reducer } from '@reduxjs/toolkit';
 import { RenderOptions } from '@testing-library/react';
 import persistReducer from 'redux-persist/es/persistReducer';
 import persistStore from 'redux-persist/es/persistStore';
@@ -7,6 +7,7 @@ import sessionStorage from 'redux-persist/lib/storage/session';
 
 import { appletModel } from '~/entities/applet';
 import { bannerModel } from '~/entities/banner';
+import { BannersStore } from '~/entities/banner/model';
 import { userModel } from '~/entities/user';
 import { AutoCompletionModel } from '~/features/AutoCompletion';
 import { RootState } from '~/shared/utils';
@@ -25,7 +26,10 @@ const bannerPersistConfig = {
 export const rootReducer = combineReducers({
   user: userModel.reducer,
   applets: appletModel.reducer,
-  banners: persistReducer(bannerPersistConfig, bannerModel.reducer),
+  banners: persistReducer(
+    bannerPersistConfig,
+    bannerModel.reducer,
+  ) as unknown as Reducer<BannersStore>,
   autoCompletion: AutoCompletionModel.reducer,
 });
 

--- a/src/entities/banner/model/slice.ts
+++ b/src/entities/banner/model/slice.ts
@@ -2,7 +2,7 @@ import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 
 import { BannerPayload } from './types';
 
-type BannersStore = {
+export type BannersStore = {
   banners: Array<BannerPayload>;
 };
 

--- a/src/widgets/Survey/ui/PassingScreen.tsx
+++ b/src/widgets/Survey/ui/PassingScreen.tsx
@@ -143,7 +143,7 @@ const PassingScreen = () => {
     if (isFlowGroup && !isLastActivity) {
       addSuccessBanner(t('toast.next_activity'));
     } else {
-      addSuccessBanner(t('toast.answers_submitted'));
+      addSuccessBanner({ children: t('toast.answers_submitted'), duration: null });
     }
 
     if (isFlowGroup && context.flow) {


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-7281](https://mindlogger.atlassian.net/browse/M2-7281)

This PR updates the success banner shown at the end of an activity to be persistent, requiring user action to dismiss it. This banner previously auto-dismissed after 5s.

I've also taken the opportunity to make the banner infrastructure session-local, which means that banners will no longer persist across tabs.

### 📸 Screenshots

N/A

### 🪤 Peer Testing

#### Requires user action

1. Complete an activity
2. Confirm that the success banner is shown for more than 5s
3. Navigate to the applets page
4. Confirm that the banner is still present
5. Click the X icon
6. Confirm that the banner is dismissed

#### Dismissed by new activity

1. Complete an activity
2. Observe that the success banner is shown for more than 5s
3. Start a new activity **without** clicking the X icon
4. Click the **Save & exit** button
7. Confirm that the banner has been dismissed

#### Dismissed by new tab

1. Complete an activity
2. Open the web app in a new tab while the banner is still showing
3. Confirm that the banner is not shown in the new tab

> [!NOTE]
> Because of the way browsers handle session resumption, reopening a closed tab that had a visible banner when it was closed will have the banner still being visible in the reopened tab. I believe this is ok behaviour

### ✏️ Notes

N/A
