### PR TITLE
refactor: Remove release 1 feature flags (M2-6992)

### DIFF
--- a/src/entities/applet/model/hooks/useEntityComplete.ts
+++ b/src/entities/applet/model/hooks/useEntityComplete.ts
@@ -7,7 +7,6 @@ import { appletModel } from '~/entities/applet';
 import { ActivityFlowDTO } from '~/shared/api';
 import ROUTES from '~/shared/constants/routes';
 import { useCustomNavigation } from '~/shared/utils';
-import { useFeatureFlags } from '~/shared/utils/hooks/useFeatureFlags';
 
 type CompletionType = 'regular' | 'autoCompletion';
 
@@ -28,8 +27,6 @@ type CompleteOptions = {
 
 export const useEntityComplete = (props: Props) => {
   const navigator = useCustomNavigation();
-
-  const { featureFlags } = useFeatureFlags();
 
   const { isInMultiInformantFlow } = appletModel.hooks.useMultiInformantState();
 
@@ -61,7 +58,7 @@ export const useEntityComplete = (props: Props) => {
         replace: true,
       };
 
-      if (featureFlags.enableMultiInformant && isInMultiInformantFlow()) {
+      if (isInMultiInformantFlow()) {
         navigateOptions.state = { showTakeNowSuccessModal: true };
       }
 
@@ -69,7 +66,6 @@ export const useEntityComplete = (props: Props) => {
     },
     [
       entityCompleted,
-      featureFlags.enableMultiInformant,
       isInMultiInformantFlow,
       navigator,
       props.activityId,

--- a/src/features/PassSurvey/hooks/useAnswers.ts
+++ b/src/features/PassSurvey/hooks/useAnswers.ts
@@ -5,7 +5,6 @@ import AnswersConstructService from '../model/AnswersConstructService';
 
 import { appletModel } from '~/entities/applet';
 import { ActivityFlowDTO, AnswerPayload, EncryptionDTO, ScheduleEventDto } from '~/shared/api';
-import { useFeatureFlags } from '~/shared/utils/hooks/useFeatureFlags';
 
 export type BuildAnswerParams = {
   activityId: string;
@@ -36,8 +35,6 @@ export const useAnswerBuilder = (): AnswerBuilder => {
 
   const { getMultiInformantState, isInMultiInformantFlow } =
     appletModel.hooks.useMultiInformantState();
-
-  const { featureFlags } = useFeatureFlags();
 
   const build = useCallback(
     (params: BuildAnswerParams): AnswerPayload => {
@@ -74,12 +71,10 @@ export const useAnswerBuilder = (): AnswerBuilder => {
         answer.consentToShare = true;
       }
 
-      if (featureFlags.enableMultiInformant) {
-        const multiInformantState = getMultiInformantState();
-        if (isInMultiInformantFlow()) {
-          answer.sourceSubjectId = multiInformantState?.sourceSubject?.id;
-          answer.targetSubjectId = multiInformantState?.targetSubject?.id;
-        }
+      const multiInformantState = getMultiInformantState();
+      if (isInMultiInformantFlow()) {
+        answer.sourceSubjectId = multiInformantState?.sourceSubject?.id;
+        answer.targetSubjectId = multiInformantState?.targetSubject?.id;
       }
 
       return answer;
@@ -93,7 +88,6 @@ export const useAnswerBuilder = (): AnswerBuilder => {
       context.encryption,
       context.publicAppletKey,
       context.integrations,
-      featureFlags.enableMultiInformant,
       getMultiInformantState,
       isInMultiInformantFlow,
     ],

--- a/src/features/TakeNow/ui/MultiInformantTooltip.tsx
+++ b/src/features/TakeNow/ui/MultiInformantTooltip.tsx
@@ -9,13 +9,11 @@ import { useMultiInformantState } from '~/entities/applet/model/hooks';
 import { MultiInformantTooltipText } from '~/features/TakeNow/ui/MultiInformantTooltipText';
 import { Theme } from '~/shared/constants';
 import { useCustomTranslation } from '~/shared/utils';
-import { useFeatureFlags } from '~/shared/utils/hooks/useFeatureFlags';
 
 export const MultiInformantTooltip = () => {
   const { t } = useCustomTranslation();
   const { getMultiInformantState, isInMultiInformantFlow } = useMultiInformantState();
-  const { featureFlags } = useFeatureFlags();
-  if (!isInMultiInformantFlow() || !featureFlags.enableMultiInformant) {
+  if (!isInMultiInformantFlow()) {
     return null;
   }
 

--- a/src/pages/AppletDetailsPage/index.tsx
+++ b/src/pages/AppletDetailsPage/index.tsx
@@ -2,7 +2,6 @@ import { useLocation, useParams } from 'react-router-dom';
 
 import ValidateTakeNowParams from '~/features/TakeNow/ui/ValidateTakeNowParams';
 import { useCustomTranslation } from '~/shared/utils';
-import { useFeatureFlags } from '~/shared/utils/hooks/useFeatureFlags';
 import { ActivityGroups } from '~/widgets/ActivityGroups';
 import { AuthorizationGuard } from '~/widgets/AuthorizationGuard';
 import { LoginWithRedirect } from '~/widgets/LoginWithRedirect';
@@ -11,7 +10,6 @@ function AppletDetailsPage() {
   const { appletId } = useParams();
   const location = useLocation();
   const { t } = useCustomTranslation();
-  const { featureFlags } = useFeatureFlags();
 
   const queryParams = new URLSearchParams(location.search);
   const startActivityOrFlow = queryParams.get('startActivityOrFlow');
@@ -24,13 +22,7 @@ function AppletDetailsPage() {
     return <div>{t('wrondLinkParametrError')}</div>;
   }
 
-  if (
-    !startActivityOrFlow ||
-    !sourceSubjectId ||
-    !targetSubjectId ||
-    !respondentId ||
-    !featureFlags.enableMultiInformant
-  ) {
+  if (!startActivityOrFlow || !sourceSubjectId || !targetSubjectId || !respondentId) {
     return (
       <AuthorizationGuard fallback={<LoginWithRedirect />}>
         <ActivityGroups isPublic={false} appletId={appletId} />

--- a/src/shared/utils/types/featureFlags.ts
+++ b/src/shared/utils/types/featureFlags.ts
@@ -2,9 +2,6 @@ import { LDFlagValue } from 'launchdarkly-react-client-sdk';
 
 // These keys use the camelCase representation of the feature flag value
 // e.g. enable-multi-informant in LaunchDarky becomes enableMultiInformant
-export const FeatureFlagsKeys = {
-  enableMultiInformant: 'enableMultiInformant',
-  enableMultiInformantTakeNow: 'enableMultiInformantTakeNow',
-};
+export const FeatureFlagsKeys = {};
 
 export type FeatureFlags = Partial<Record<keyof typeof FeatureFlagsKeys, LDFlagValue>>;

--- a/src/shared/utils/types/featureFlags.ts
+++ b/src/shared/utils/types/featureFlags.ts
@@ -1,7 +1,9 @@
 import { LDFlagValue } from 'launchdarkly-react-client-sdk';
 
 // These keys use the camelCase representation of the feature flag value
-// e.g. enable-multi-informant in LaunchDarky becomes enableMultiInformant
-export const FeatureFlagsKeys = {};
+// e.g. enable-participant-multi-informant in LaunchDarky becomes enableParticipantMultiInformant
+export const FeatureFlagsKeys = {
+  enableParticipantMultiInformant: 'enableParticipantMultiInformant',
+};
 
 export type FeatureFlags = Partial<Record<keyof typeof FeatureFlagsKeys, LDFlagValue>>;

--- a/src/widgets/ActivityGroups/ui/index.tsx
+++ b/src/widgets/ActivityGroups/ui/index.tsx
@@ -12,7 +12,6 @@ import { TakeNowSuccessModal } from '~/features/TakeNow/ui/TakeNowSuccessModal';
 import Box from '~/shared/ui/Box';
 import Loader from '~/shared/ui/Loader';
 import { useCustomTranslation, useOnceEffect } from '~/shared/utils';
-import { useFeatureFlags } from '~/shared/utils/hooks/useFeatureFlags';
 
 type PublicAppletDetails = {
   isPublic: true;
@@ -51,8 +50,6 @@ export const ActivityGroups = (props: Props) => {
     select: (data) => data.data.result,
   });
 
-  const { featureFlags } = useFeatureFlags();
-
   const {
     isInMultiInformantFlow,
     getMultiInformantState,
@@ -62,23 +59,21 @@ export const ActivityGroups = (props: Props) => {
 
   useOnceEffect(() => {
     ensureMultiInformantStateExists();
-    if (featureFlags.enableMultiInformant) {
-      if (isInMultiInformantFlow() && !props.startActivityOrFlow) {
-        resetMultiInformantState();
-      }
+    if (isInMultiInformantFlow() && !props.startActivityOrFlow) {
+      resetMultiInformantState();
+    }
 
-      // We rely on location state to evaluate whether to show the modal so that it only displays
-      // after the activity is complete (and not when it's paused). See useEntityComplete hook.
-      if (location.state?.showTakeNowSuccessModal && !takeNowSuccessModalState.isOpen) {
-        navigate(window.location.pathname, {
-          state: {
-            ...location.state,
-            showTakeNowSuccessModal: undefined,
-          } as unknown,
-          replace: true,
-        });
-        setTakeNowSuccessModalState({ isOpen: true, ...getMultiInformantState() });
-      }
+    // We rely on location state to evaluate whether to show the modal so that it only displays
+    // after the activity is complete (and not when it's paused). See useEntityComplete hook.
+    if (location.state?.showTakeNowSuccessModal && !takeNowSuccessModalState.isOpen) {
+      navigate(window.location.pathname, {
+        state: {
+          ...location.state,
+          showTakeNowSuccessModal: undefined,
+        } as unknown,
+        replace: true,
+      });
+      setTakeNowSuccessModalState({ isOpen: true, ...getMultiInformantState() });
     }
   });
 


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-6992](https://mindlogger.atlassian.net/browse/M2-6992)

This PR removes all references to the `enableMultiInformant` and `enableMultiInformantTakeNow` feature flags. The code was modified to assume they are enabled.

### 📸 Screenshots

N/A

### 🪤 Peer Testing

Sanity checks and regression testing.

Specifically the take now flow

### ✏️ Notes

N/A
