### PR TITLE
fix: Delay take now error message by 500ms

### DIFF
--- a/src/features/TakeNow/ui/ValidateTakeNowParams.tsx
+++ b/src/features/TakeNow/ui/ValidateTakeNowParams.tsx
@@ -72,11 +72,13 @@ function ValidateTakeNowParams({
         navigate(ROUTES.appletList.path);
       }
 
-      setTimeout(() =>
-        addErrorBanner({
-          children: error.error,
-          duration,
-        }),
+      setTimeout(
+        () =>
+          addErrorBanner({
+            children: error.error,
+            duration,
+          }),
+        500,
       );
     }
   }, [error, addErrorBanner]);


### PR DESCRIPTION
### 📝 Description

> [!NOTE]
> This is a quick PR for something I noticed while recording a loom. No ticket exists for this fix

When a participant mismatch happens, they're supposed to be shown an error message so they can re-initiate take now from the admin panel. The error message is being shown before the navigation happens, so it ends up disappearing very quickly (possibly before being seen).

We need to delay it a bit more, so it gets shown after navigation. I've addd a 500ms delay to achieve this.

### 📸 Screenshots

#### Before

Banner disappears quickly

https://github.com/user-attachments/assets/e3a322a9-214f-4213-845d-5bc8236856b9

#### After

Banner persists

https://github.com/user-attachments/assets/de2e6c68-6d23-4c0f-99d0-917a7e04e717

### ✏️ Notes

N/A