### PR TITLE
fix: Allow "Take Now" to start when respondent is not explicitly assigned (M2-7796)

### DIFF
--- a/src/features/PassSurvey/hooks/useStartSurvey.ts
+++ b/src/features/PassSurvey/hooks/useStartSurvey.ts
@@ -51,7 +51,7 @@ export const useStartSurvey = (props: Props) => {
 
     const { activityId, flowId, eventId, targetSubjectId, entityType } = params;
 
-    if (props.isPublic && props.publicAppletKey && appletId) {
+    if (props.isPublic && props.publicAppletKey) {
       return navigator.navigate(
         ROUTES.publicSurvey.navigateTo({
           appletId,

--- a/src/features/PassSurvey/hooks/useStartSurvey.ts
+++ b/src/features/PassSurvey/hooks/useStartSurvey.ts
@@ -1,4 +1,4 @@
-import { ActivityStatus, EntityType } from '~/abstract/lib/GroupBuilder';
+import { EntityType } from '~/abstract/lib/GroupBuilder';
 import { appletModel } from '~/entities/applet';
 import { AppletBaseDTO } from '~/shared/api';
 import ROUTES from '~/shared/constants/routes';
@@ -23,21 +23,19 @@ type OnActivityCardClickProps = {
   eventId: string;
   targetSubjectId: string | null;
   flowId: string | null;
-  status: ActivityStatus;
   shouldRestart: boolean;
 };
 
 type Props = {
-  applet: AppletBaseDTO;
+  applet?: AppletBaseDTO;
   isPublic: boolean;
   publicAppletKey: string | null;
 };
 
 export const useStartSurvey = (props: Props) => {
   const navigator = useCustomNavigation();
-
-  const appletId = props.applet.id;
-  const flows = props.applet.activityFlows;
+  const appletId = props.applet?.id;
+  const flows = props.applet?.activityFlows;
 
   const { removeGroupProgress } = appletModel.hooks.useGroupProgressStateManager();
 
@@ -47,9 +45,13 @@ export const useStartSurvey = (props: Props) => {
     appletModel.hooks.useMultiInformantState();
 
   function navigateToEntity(params: NavigateToEntityProps) {
+    if (!appletId) {
+      return;
+    }
+
     const { activityId, flowId, eventId, targetSubjectId, entityType } = params;
 
-    if (props.isPublic && props.publicAppletKey) {
+    if (props.isPublic && props.publicAppletKey && appletId) {
       return navigator.navigate(
         ROUTES.publicSurvey.navigateTo({
           appletId,
@@ -82,7 +84,7 @@ export const useStartSurvey = (props: Props) => {
     shouldRestart,
   }: OnActivityCardClickProps) {
     const analyticsPayload: MixpanelPayload = {
-      [MixpanelProps.AppletId]: props.applet.id,
+      [MixpanelProps.AppletId]: appletId,
       [MixpanelProps.ActivityId]: activityId,
     };
 
@@ -102,7 +104,7 @@ export const useStartSurvey = (props: Props) => {
     Mixpanel.track(MixpanelEvents.AssessmentStarted, analyticsPayload);
 
     if (flowId) {
-      const flow = flows.find((x) => x.id === flowId);
+      const flow = flows?.find((x) => x.id === flowId);
       const firstActivityId: string | null = flow?.activityIds[0] ?? null;
 
       if (!firstActivityId) {

--- a/src/widgets/ActivityGroups/model/hooks/useTakeNowRedirect.ts
+++ b/src/widgets/ActivityGroups/model/hooks/useTakeNowRedirect.ts
@@ -1,0 +1,87 @@
+import { useMemo } from 'react';
+
+import { openStoreLink } from '~/abstract/lib';
+import { isSupportedActivity } from '~/entities/activity';
+import { appletModel } from '~/entities/applet';
+import { useStartSurvey } from '~/features/PassSurvey';
+import { AppletBaseDTO, AppletEventsResponse, HydratedAssignmentDTO } from '~/shared/api';
+
+export function useTakeNowRedirect({
+  activityOrFlowId,
+  applet,
+  assignments = [],
+  events = [],
+  isPublic = false,
+  publicAppletKey = null,
+}: {
+  activityOrFlowId?: string | null;
+  applet?: AppletBaseDTO;
+  assignments?: HydratedAssignmentDTO[] | null;
+  events?: AppletEventsResponse['events'];
+  isPublic?: boolean;
+  publicAppletKey?: string | null;
+}) {
+  const { startSurvey } = useStartSurvey({ applet, isPublic, publicAppletKey });
+  const { getMultiInformantState } = appletModel.hooks.useMultiInformantState();
+
+  const handleTakeNowRedirect = useMemo(
+    () =>
+      ({
+        activityId,
+        eventId,
+        flowId = null,
+        isSupported = true,
+        targetSubjectId = null,
+      }: {
+        activityId: string;
+        eventId: string;
+        flowId?: string | null;
+        isSupported?: boolean;
+        targetSubjectId?: string | null;
+      }) => {
+        if (!isSupported) {
+          openStoreLink();
+          return;
+        }
+
+        startSurvey({ activityId, eventId, flowId, shouldRestart: true, targetSubjectId });
+      },
+    [startSurvey],
+  );
+
+  if (assignments && applet && events && activityOrFlowId) {
+    const activity = applet.activities.find(({ id }) => id === activityOrFlowId);
+    const flow = applet.activityFlows.find(({ id }) => id === activityOrFlowId);
+    const event = events.find(({ entityId }) => entityId === (activity?.id || flow?.id));
+    const { targetSubject } = getMultiInformantState();
+
+    if (!event) {
+      return;
+    }
+
+    if (activity) {
+      return handleTakeNowRedirect({
+        activityId: activity.id,
+        isSupported: isSupportedActivity(activity.containsResponseTypes),
+        eventId: event.id,
+        targetSubjectId: targetSubject?.id,
+      });
+    }
+
+    if (flow) {
+      const flowActivities = flow.activityIds.map((activityId) =>
+        applet.activities.find(({ id }) => activityId === id),
+      );
+
+      return handleTakeNowRedirect({
+        activityId: flow.activityIds[0],
+        isSupported: flowActivities.every(
+          (activity) => !!activity && isSupportedActivity(activity.containsResponseTypes),
+        ),
+        eventId: event.id,
+        flowId: flow.id,
+        targetSubjectId: targetSubject?.id,
+      });
+    }
+  }
+}

--- a/src/widgets/ActivityGroups/model/hooks/useTakeNowRedirect.ts
+++ b/src/widgets/ActivityGroups/model/hooks/useTakeNowRedirect.ts
@@ -2,7 +2,6 @@ import { useMemo } from 'react';
 
 import { openStoreLink } from '~/abstract/lib';
 import { isSupportedActivity } from '~/entities/activity';
-import { appletModel } from '~/entities/applet';
 import { useStartSurvey } from '~/features/PassSurvey';
 import { AppletBaseDTO, AppletEventsResponse, HydratedAssignmentDTO } from '~/shared/api';
 
@@ -22,7 +21,6 @@ export function useTakeNowRedirect({
   publicAppletKey?: string | null;
 }) {
   const { startSurvey } = useStartSurvey({ applet, isPublic, publicAppletKey });
-  const { getMultiInformantState } = appletModel.hooks.useMultiInformantState();
 
   const handleTakeNowRedirect = useMemo(
     () =>
@@ -31,20 +29,18 @@ export function useTakeNowRedirect({
         eventId,
         flowId = null,
         isSupported = true,
-        targetSubjectId = null,
       }: {
         activityId: string;
         eventId: string;
         flowId?: string | null;
         isSupported?: boolean;
-        targetSubjectId?: string | null;
       }) => {
         if (!isSupported) {
           openStoreLink();
           return;
         }
 
-        startSurvey({ activityId, eventId, flowId, shouldRestart: true, targetSubjectId });
+        startSurvey({ activityId, eventId, flowId, shouldRestart: true, targetSubjectId: null });
       },
     [startSurvey],
   );
@@ -53,7 +49,6 @@ export function useTakeNowRedirect({
     const activity = applet.activities.find(({ id }) => id === activityOrFlowId);
     const flow = applet.activityFlows.find(({ id }) => id === activityOrFlowId);
     const event = events.find(({ entityId }) => entityId === (activity?.id || flow?.id));
-    const { targetSubject } = getMultiInformantState();
 
     if (!event) {
       return;
@@ -64,7 +59,6 @@ export function useTakeNowRedirect({
         activityId: activity.id,
         isSupported: isSupportedActivity(activity.containsResponseTypes),
         eventId: event.id,
-        targetSubjectId: targetSubject?.id,
       });
     }
 
@@ -80,7 +74,6 @@ export function useTakeNowRedirect({
         ),
         eventId: event.id,
         flowId: flow.id,
-        targetSubjectId: targetSubject?.id,
       });
     }
   }

--- a/src/widgets/ActivityGroups/ui/ActivityCard/index.tsx
+++ b/src/widgets/ActivityGroups/ui/ActivityCard/index.tsx
@@ -24,7 +24,6 @@ import {
   useAppSelector,
   useCustomMediaQuery,
   MixpanelPayload,
-  useOnceLayoutEffect,
 } from '~/shared/utils';
 import { TargetSubjectLabel } from '~/widgets/TargetSubjectLabel';
 
@@ -107,7 +106,6 @@ export const ActivityCard = ({ activityListItem }: Props) => {
       activityId: activityListItem.activityId,
       eventId: activityListItem.eventId,
       targetSubjectId: activityListItem.targetSubject?.id ?? null,
-      status: activityListItem.status,
       flowId: activityListItem.flowId,
       shouldRestart,
     });
@@ -142,24 +140,6 @@ export const ActivityCard = ({ activityListItem }: Props) => {
 
     Mixpanel.track(MixpanelEvents.ActivityResumed, analyticsPayload);
   };
-
-  // Start activity on mount if doing Take Now on this activity.
-  useOnceLayoutEffect(() => {
-    if (
-      context.startActivityOrFlow &&
-      // TODO: This `!activityListItem.targetSubject` check is added to ensure that Take Now is
-      // only triggered once, on the singular self-report instance of ActivityCard. However, this
-      // causes Take Now to fail when there is no self-report card, which is a possible scenario
-      // with the introduction of MI assignments. Remove this check when Take Now is refactored in
-      // https://mindlogger.atlassian.net/browse/M2-7796
-      !activityListItem.targetSubject &&
-      ((!isFlow && context.startActivityOrFlow === activityListItem.activityId) ||
-        (isFlow && context.startActivityOrFlow === activityListItem.flowId))
-    ) {
-      // Pass `true` to ensure activity doesn't resume from a previous progress state.
-      onStartActivity(true);
-    }
-  });
 
   return (
     <ActivityCardBase isDisabled={isDisabled} isFlow={isFlow}>


### PR DESCRIPTION
### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [M2-7796](https://mindlogger.atlassian.net/browse/M2-7796): [R2][FE][MI Assign] Ensure Take Now takes priority over Assignments

This PR updates how "Take Now" activities/flows are started. Previously, this logic was handled via an effect hook rendered by the `ActivityCard` component, which was rendered as part of the list of activities/flows that appeared on page for the relevant applet.

The addition of activity/flow assignments (gated by the `enableActivityAssign` feature flag), changes the behaviour of this list so that only explicitly assigned activities/flows appear. 

This means that if Take Now was initiated for a respondent subject that did not have that the selected activity or flow assigned, it would fail to start. Additionally, if Take Now was initiated about a specific target subject, for a respondent subject that did not have that the selected activity or flow assigned _for that target subject_, it would fail to start.

This PR makes updates to change how "Take Now" is started, to address these scenarios.

I have done so my removing the hook from the `ActivityCard`, and adding a new hook, `useTakeNowRedirect`. This hook performs appropriate checks and will automatically call `startSurvey` (resulting in a navigation to the appropriate activity/flow route), when the appropriate parameters are provided.

This hook has been added to the `ActivityGroups` component, which is the highest-level component in the `AppletDetailsPage` that this hook could be easily placed in.

### 📸 Screenshots

#### When Take Now Activity/Flow is unassigned

| Before | After |
|-|-|
| ![unassigned-before](https://github.com/user-attachments/assets/af2eb10f-58a5-4ee7-bc19-d3c2741e6def) | ![unassigned-after](https://github.com/user-attachments/assets/e2f917cd-30f2-4ab2-8d2f-4a8dbe07c484) |

#### When Take Now Activity/Flow's target subject _differs_ from assigned

| Before | After |
|-|-|
| ![diff-target-before](https://github.com/user-attachments/assets/f9dc592e-16a5-4c96-914b-cf26c7ed2c9c) | ![diff-target-after](https://github.com/user-attachments/assets/7ba46d82-273f-4bf9-b4eb-eca5035b3d45) |

### 🪤 Peer Testing

The below notes have been copied from the Jira task for convenience — they describe the appropriate setup and relevant testing pretty clearly!

> #### Setup:
> * Create activities:
>   * Activity A: auto-assign is `true`
>   * Activity B: auto-assign is `false`
>   * Activity C: auto-assign is `false`
>   * Flow A: auto-assign is `true`
>   * Flow B: auto-assign is `false`
>   * Flow C: auto-assign is `false`
>
> * Ensure a User X exists on the applet, either a Full Account or Team Member
> * Ensure a Subject Y exists on the applet, a Limited Account
>
> * Set up assignments for respondent User X (either full account or team account):
>   * User X has no manual assignments for Activity A, Activity B, Flow A, and Flow B
>   * User X is assigned as a respondent on Subject Y for Activity C and for Flow C (and no self-report)
>
> #### Testing Steps:
> For each Activity (A, B, and C), and again for each Flow (A, B, and C):
>
> 1. From the Admin App, perform Take Now on that activity/flow with the User X as the source subject (respondent) and Subject Y as the target subject.
> 2. In the Web App, ensure that Take Now proceeds with the assessment, with the correct "ℹ️" tooltip UI showing in the upper-left corner, and no multi-informant assignment-related banners or badges should be rendered in the UI.



[M2-7796]: https://mindlogger.atlassian.net/browse/M2-7796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ