### PR TITLE
feat: action plan download updates (M2-7207)

### DIFF
--- a/src/entities/activity/lib/downloadPhrasalTemplateItem.ts
+++ b/src/entities/activity/lib/downloadPhrasalTemplateItem.ts
@@ -100,10 +100,13 @@ export const downloadPhrasalTemplateItem: CardImageDownloader = async (options) 
 
       document.body.appendChild(downloadLink);
       downloadLink.click();
+
+      // Add some delay before removing the link so Safari wouldn't end up skipping items.
+      await new Promise((resolve) => setTimeout(resolve, 500));
       document.body.removeChild(downloadLink);
 
       if (dataUriIndex < dataUris.length - 1) {
-        await new Promise((resolve) => setTimeout(resolve, 1));
+        await new Promise((resolve) => setTimeout(resolve, 100));
       }
     }
   }

--- a/src/entities/activity/lib/downloadPhrasalTemplateItem.ts
+++ b/src/entities/activity/lib/downloadPhrasalTemplateItem.ts
@@ -1,0 +1,110 @@
+import html2canvas from 'html2canvas';
+
+type GetDocumentImageDataUrisOptions = {
+  documentId: string;
+  single: boolean;
+};
+
+type DocumentImageDataUrisGetter = (options: GetDocumentImageDataUrisOptions) => Promise<string[]>;
+
+const getDocumentImageDataUris: DocumentImageDataUrisGetter = async (options) => {
+  let nodes: HTMLElement[];
+  if (options.single) {
+    const documentNode = document.querySelector<HTMLElement>(
+      [
+        '[data-phrasal-template-document]',
+        `[data-phrasal-template-document-id="${options.documentId}"]`,
+      ].join(''),
+    );
+    nodes = documentNode ? [documentNode] : [];
+  } else {
+    nodes = Array.from(
+      document.querySelectorAll<HTMLElement>(
+        [
+          '[data-phrasal-template-page]',
+          `[data-phrasal-template-document-id="${options.documentId}"]`,
+        ].join(''),
+      ),
+    );
+  }
+
+  return Promise.all(
+    nodes.map(async (node) => {
+      const canvas = await html2canvas(node, {
+        useCORS: true,
+
+        // This value overrides `html2canvas`'s dpi scaling value.
+        // So, this is NOT saying "3x of whatever is rendered on screen", but instead this is
+        // saying "3x the normal dpi". So if the screen is already 2x (i.e. with OS-level UI
+        // scaling), then this would only make the image 50% larger.
+        scale: 3,
+      });
+      return canvas.toDataURL('image/jpeg');
+    }),
+  );
+};
+
+const dataUriToFile = (dataURI: string, filename: string): File => {
+  const byteString = atob(dataURI.split(',')[1]);
+  const mimeString = dataURI.split(',')[0].split(':')[1].split(';')[0];
+
+  const byteBuffer = new ArrayBuffer(byteString.length);
+  const byteArray = new Uint8Array(byteBuffer);
+
+  for (let byteIndex = 0; byteIndex < byteString.length; byteIndex++) {
+    // Convert each character in the data-uti string to the character's byte value.
+    byteArray[byteIndex] = byteString.charCodeAt(byteIndex);
+  }
+
+  return new File([byteArray], filename, { type: mimeString });
+};
+
+type CardImageDownloaderOptions = {
+  documentId: string;
+  filename: string;
+  single: boolean;
+  share: boolean;
+};
+
+type CardImageDownloader = (options: CardImageDownloaderOptions) => Promise<void>;
+
+export const downloadPhrasalTemplateItem: CardImageDownloader = async (options) => {
+  const dataUris = await getDocumentImageDataUris({
+    documentId: options.documentId,
+    single: options.single,
+  });
+
+  const getFilename = (index: number) => {
+    const filename =
+      dataUris.length <= 1
+        ? options.filename
+        : `${options.filename}_${index + 1}of${dataUris.length}`;
+    return `${filename}.jpg`;
+  };
+
+  if (options.share) {
+    const imageFiles: File[] = [];
+    for (let dataUriIndex = 0; dataUriIndex < dataUris.length; dataUriIndex++) {
+      imageFiles.push(dataUriToFile(dataUris[dataUriIndex], getFilename(dataUriIndex)));
+    }
+
+    if (imageFiles.length > 0) {
+      await navigator.share({ files: imageFiles });
+    }
+  } else {
+    for (let dataUriIndex = 0; dataUriIndex < dataUris.length; dataUriIndex++) {
+      const dataUri = dataUris[dataUriIndex];
+      const downloadLink = document.createElement('a');
+      downloadLink.setAttribute('href', dataUri);
+      downloadLink.setAttribute('download', getFilename(dataUriIndex));
+
+      document.body.appendChild(downloadLink);
+      downloadLink.click();
+      document.body.removeChild(downloadLink);
+
+      if (dataUriIndex < dataUris.length - 1) {
+        await new Promise((resolve) => setTimeout(resolve, 1));
+      }
+    }
+  }
+};

--- a/src/entities/activity/ui/items/ActionPlan/Document.tsx
+++ b/src/entities/activity/ui/items/ActionPlan/Document.tsx
@@ -21,7 +21,7 @@ type DocumentProps = {
   phrasalTemplateCardTitle: string;
 };
 
-type IdentifiblePhrasalTemplatePhrase = PhrasalTemplatePhrase & { id: string };
+type IdentifiablePhrasalTemplatePhrase = PhrasalTemplatePhrase & { id: string };
 
 export const Document = forwardRef<HTMLDivElement, DocumentProps>(
   ({ appletTitle, phrases, phrasalTemplateCardTitle }, ref) => {
@@ -32,9 +32,9 @@ export const Document = forwardRef<HTMLDivElement, DocumentProps>(
       [phrases],
     );
 
-    const identifiblePhrases = useMemo(
+    const identifiablePhrases = useMemo(
       () =>
-        phrases.map<IdentifiblePhrasalTemplatePhrase>((phrase) => {
+        phrases.map<IdentifiablePhrasalTemplatePhrase>((phrase) => {
           return {
             ...phrase,
             id: uuidV4(),
@@ -64,8 +64,8 @@ export const Document = forwardRef<HTMLDivElement, DocumentProps>(
       const renderedPages: React.ReactNode[] = [];
 
       const renderPage = async (
-        pagePhrases: IdentifiblePhrasalTemplatePhrase[],
-      ): Promise<[React.ReactNode, IdentifiblePhrasalTemplatePhrase[]]> => {
+        pagePhrases: IdentifiablePhrasalTemplatePhrase[],
+      ): Promise<[React.ReactNode, IdentifiablePhrasalTemplatePhrase[]]> => {
         const curPageNumber = renderedPages.length + 1;
 
         const curPage = (
@@ -103,7 +103,7 @@ export const Document = forwardRef<HTMLDivElement, DocumentProps>(
           // height, and there is only 1 phrase for the page, and that phrase
           // has more than 1 field, then split the fields into multiple phrases
           // with the same ID and re-render.
-          const splits: [IdentifiblePhrasalTemplatePhrase, IdentifiblePhrasalTemplatePhrase] = [
+          const splits: [IdentifiablePhrasalTemplatePhrase, IdentifiablePhrasalTemplatePhrase] = [
             {
               id: pagePhrase.id,
               image: pagePhrase.image,
@@ -137,12 +137,12 @@ export const Document = forwardRef<HTMLDivElement, DocumentProps>(
             acc.push(phrase);
           }
           return acc;
-        }, [] as IdentifiblePhrasalTemplatePhrase[]);
+        }, [] as IdentifiablePhrasalTemplatePhrase[]);
 
         return [newPage, recombinedLeftoverPhrases];
       };
 
-      const _renderPages = async (_pagePhrases: IdentifiblePhrasalTemplatePhrase[]) => {
+      const _renderPages = async (_pagePhrases: IdentifiablePhrasalTemplatePhrase[]) => {
         const [renderedPage, leftoverPhrases] = await renderPage(_pagePhrases);
         renderedPages.push(renderedPage);
 
@@ -151,7 +151,7 @@ export const Document = forwardRef<HTMLDivElement, DocumentProps>(
         }
       };
 
-      await _renderPages(identifiblePhrases);
+      await _renderPages(identifiablePhrases);
 
       setPages(renderedPages);
     }, [
@@ -160,7 +160,7 @@ export const Document = forwardRef<HTMLDivElement, DocumentProps>(
       availableWidth,
       pageMaxHeight,
       phrasalTemplateCardTitle,
-      identifiblePhrases,
+      identifiablePhrases,
       noImage,
     ]);
 

--- a/src/entities/activity/ui/items/ActionPlan/Document.tsx
+++ b/src/entities/activity/ui/items/ActionPlan/Document.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useEffect, useState, useContext, useMemo, useCallback } from 'react';
+import React, { useEffect, useState, useContext, useMemo, useCallback } from 'react';
 
 import { Box } from '@mui/material';
 import { v4 as uuidV4 } from 'uuid';
@@ -16,6 +16,7 @@ import { useAppSelector } from '~/shared/utils';
 import measureComponentHeight from '~/shared/utils/measureComponentHeight';
 
 type DocumentProps = {
+  documentId: string;
   phrases: PhrasalTemplatePhrase[];
   appletTitle: string;
   phrasalTemplateCardTitle: string;
@@ -23,159 +24,168 @@ type DocumentProps = {
 
 type IdentifiablePhrasalTemplatePhrase = PhrasalTemplatePhrase & { id: string };
 
-export const Document = forwardRef<HTMLDivElement, DocumentProps>(
-  ({ appletTitle, phrases, phrasalTemplateCardTitle }, ref) => {
-    const context = useContext(SurveyContext);
+export const Document = ({
+  documentId,
+  appletTitle,
+  phrases,
+  phrasalTemplateCardTitle,
+}: DocumentProps) => {
+  const context = useContext(SurveyContext);
 
-    const noImage = useMemo(
-      () => phrases.filter((phrase) => !!phrase.image).length <= 0,
-      [phrases],
-    );
+  const noImage = useMemo(() => phrases.filter((phrase) => !!phrase.image).length <= 0, [phrases]);
 
-    const identifiablePhrases = useMemo(
-      () =>
-        phrases.map<IdentifiablePhrasalTemplatePhrase>((phrase) => {
-          return {
-            ...phrase,
-            id: uuidV4(),
-          };
-        }),
-      [phrases],
-    );
+  const identifiablePhrases = useMemo(
+    () =>
+      phrases.map<IdentifiablePhrasalTemplatePhrase>((phrase) => {
+        return {
+          ...phrase,
+          id: uuidV4(),
+        };
+      }),
+    [phrases],
+  );
 
-    const activityProgress = useAppSelector((state) =>
-      appletModel.selectors.selectActivityProgress(
-        state,
-        getProgressId(context.activityId, context.eventId, context.targetSubject?.id),
-      ),
-    );
+  const activityProgress = useAppSelector((state) =>
+    appletModel.selectors.selectActivityProgress(
+      state,
+      getProgressId(context.activityId, context.eventId, context.targetSubject?.id),
+    ),
+  );
 
-    const activitiesPhrasalData = useMemo(
-      () => extractActivitiesPhrasalData(activityProgress.items),
-      [activityProgress],
-    );
+  const activitiesPhrasalData = useMemo(
+    () => extractActivitiesPhrasalData(activityProgress.items),
+    [activityProgress],
+  );
 
-    const availableWidth = useAvailableBodyWidth();
-    const correlatedPageMaxHeightLineCount = useCorrelatedPageMaxHeightLineCount();
-    const pageMaxHeight = correlatedPageMaxHeightLineCount.maxHeight;
-    const [pages, setPages] = useState<React.ReactNode[]>([]);
+  const availableWidth = useAvailableBodyWidth();
+  const correlatedPageMaxHeightLineCount = useCorrelatedPageMaxHeightLineCount();
+  const pageMaxHeight = correlatedPageMaxHeightLineCount.maxHeight;
+  const [pages, setPages] = useState<React.ReactNode[]>([]);
 
-    const renderPages = useCallback(async () => {
-      const renderedPages: React.ReactNode[] = [];
+  const renderPages = useCallback(async () => {
+    const renderedPages: React.ReactNode[] = [];
 
-      const renderPage = async (
-        pagePhrases: IdentifiablePhrasalTemplatePhrase[],
-      ): Promise<[React.ReactNode, IdentifiablePhrasalTemplatePhrase[]]> => {
-        const curPageNumber = renderedPages.length + 1;
+    const renderPage = async (
+      pagePhrases: IdentifiablePhrasalTemplatePhrase[],
+    ): Promise<[React.ReactNode, IdentifiablePhrasalTemplatePhrase[]]> => {
+      const curPageNumber = renderedPages.length + 1;
 
-        const curPage = (
-          <Page
-            key={`page-${curPageNumber}`}
-            pageNumber={curPageNumber}
-            appletTitle={appletTitle}
-            phrasalTemplateCardTitle={phrasalTemplateCardTitle}
-            phrases={pagePhrases}
-            phrasalData={activitiesPhrasalData}
-            noImage={noImage}
-          />
-        );
+      const curPage = (
+        <Page
+          key={`page-${curPageNumber}`}
+          documentId={documentId}
+          pageNumber={curPageNumber}
+          appletTitle={appletTitle}
+          phrasalTemplateCardTitle={phrasalTemplateCardTitle}
+          phrases={pagePhrases}
+          phrasalData={activitiesPhrasalData}
+          noImage={noImage}
+        />
+      );
 
-        const pageHeight = await measureComponentHeight(availableWidth, curPage);
-        if (pageHeight <= pageMaxHeight) {
-          // If the rendered page fits into the maximum allowed page height,
-          // then stop rendering.
+      const pageHeight = await measureComponentHeight(availableWidth, curPage);
+      if (pageHeight <= pageMaxHeight) {
+        // If the rendered page fits into the maximum allowed page height,
+        // then stop rendering.
+        return [curPage, []];
+      }
+
+      if (pagePhrases.length <= 1) {
+        const pagePhrase = pagePhrases[0];
+        const pagePhraseFields = pagePhrase.fields;
+
+        if (pagePhraseFields.length <= 1) {
+          // If the rendered page does not fit into the maximum allowed page
+          // height, and there is only 1 phrase for the page, but that phrase
+          // has on 1 field (this means there is nothing left to split), then
+          // stop rendering.
           return [curPage, []];
         }
 
-        if (pagePhrases.length <= 1) {
-          const pagePhrase = pagePhrases[0];
-          const pagePhraseFields = pagePhrase.fields;
-
-          if (pagePhraseFields.length <= 1) {
-            // If the rendered page does not fit into the maximum allowed page
-            // height, and there is only 1 phrase for the page, but that phrase
-            // has on 1 field (this means there is nothing left to split), then
-            // stop rendering.
-            return [curPage, []];
-          }
-
-          // If the rendered page does not fit into the maximum allowed page
-          // height, and there is only 1 phrase for the page, and that phrase
-          // has more than 1 field, then split the fields into multiple phrases
-          // with the same ID and re-render.
-          const splits: [IdentifiablePhrasalTemplatePhrase, IdentifiablePhrasalTemplatePhrase] = [
-            {
-              id: pagePhrase.id,
-              image: pagePhrase.image,
-              fields: pagePhraseFields.slice(0, pagePhraseFields.length - 1),
-            },
-            {
-              id: pagePhrase.id,
-              image: pagePhrase.image,
-              fields: pagePhraseFields.slice(pagePhraseFields.length - 1),
-            },
-          ];
-
-          const [newPage, newPageRestPhrases] = await renderPage([splits[0]]);
-          const leftoverPhrases = [...newPageRestPhrases, splits[1]];
-          return [newPage, leftoverPhrases];
-        }
-
         // If the rendered page does not fit into the maximum allowed page
-        // height, and the page has more than 1 phrase, then split the phrases
-        // and re-render.
-        const newPagePhrases = pagePhrases.slice(0, pagePhrases.length - 1);
-        const curPageRestPhrases = pagePhrases.slice(pagePhrases.length - 1);
-        const [newPage, newPageRestPhrases] = await renderPage(newPagePhrases);
-        const leftoverPhrases = [...newPageRestPhrases, ...curPageRestPhrases];
+        // height, and there is only 1 phrase for the page, and that phrase
+        // has more than 1 field, then split the fields into multiple phrases
+        // with the same ID and re-render.
+        const splits: [IdentifiablePhrasalTemplatePhrase, IdentifiablePhrasalTemplatePhrase] = [
+          {
+            id: pagePhrase.id,
+            image: pagePhrase.image,
+            fields: pagePhraseFields.slice(0, pagePhraseFields.length - 1),
+          },
+          {
+            id: pagePhrase.id,
+            image: pagePhrase.image,
+            fields: pagePhraseFields.slice(pagePhraseFields.length - 1),
+          },
+        ];
 
-        const recombinedLeftoverPhrases = leftoverPhrases.reduce((acc, phrase) => {
-          const existingPhrase = acc.find(({ id }) => id === phrase.id);
-          if (existingPhrase) {
-            existingPhrase.fields = [...existingPhrase.fields, ...phrase.fields];
-          } else {
-            acc.push(phrase);
-          }
-          return acc;
-        }, [] as IdentifiablePhrasalTemplatePhrase[]);
+        const [newPage, newPageRestPhrases] = await renderPage([splits[0]]);
+        const leftoverPhrases = [...newPageRestPhrases, splits[1]];
+        return [newPage, leftoverPhrases];
+      }
 
-        return [newPage, recombinedLeftoverPhrases];
-      };
+      // If the rendered page does not fit into the maximum allowed page
+      // height, and the page has more than 1 phrase, then split the phrases
+      // and re-render.
+      const newPagePhrases = pagePhrases.slice(0, pagePhrases.length - 1);
+      const curPageRestPhrases = pagePhrases.slice(pagePhrases.length - 1);
+      const [newPage, newPageRestPhrases] = await renderPage(newPagePhrases);
+      const leftoverPhrases = [...newPageRestPhrases, ...curPageRestPhrases];
 
-      const _renderPages = async (_pagePhrases: IdentifiablePhrasalTemplatePhrase[]) => {
-        const [renderedPage, leftoverPhrases] = await renderPage(_pagePhrases);
-        renderedPages.push(renderedPage);
-
-        if (leftoverPhrases.length > 0) {
-          await _renderPages(leftoverPhrases);
+      const recombinedLeftoverPhrases = leftoverPhrases.reduce((acc, phrase) => {
+        const existingPhrase = acc.find(({ id }) => id === phrase.id);
+        if (existingPhrase) {
+          existingPhrase.fields = [...existingPhrase.fields, ...phrase.fields];
+        } else {
+          acc.push(phrase);
         }
-      };
+        return acc;
+      }, [] as IdentifiablePhrasalTemplatePhrase[]);
 
-      await _renderPages(identifiablePhrases);
+      return [newPage, recombinedLeftoverPhrases];
+    };
 
-      setPages(renderedPages);
-    }, [
-      activitiesPhrasalData,
-      appletTitle,
-      availableWidth,
-      pageMaxHeight,
-      phrasalTemplateCardTitle,
-      identifiablePhrases,
-      noImage,
-    ]);
+    const _renderPages = async (_pagePhrases: IdentifiablePhrasalTemplatePhrase[]) => {
+      const [renderedPage, leftoverPhrases] = await renderPage(_pagePhrases);
+      renderedPages.push(renderedPage);
 
-    useEffect(() => {
-      void renderPages();
-    }, [renderPages]);
+      if (leftoverPhrases.length > 0) {
+        await _renderPages(leftoverPhrases);
+      }
+    };
 
-    return (
-      <Box gap="24px" display={'flex'} flexDirection={'column'} alignItems="center" ref={ref}>
-        <DocumentContext.Provider value={{ totalPages: pages.length }}>
-          {pages}
-        </DocumentContext.Provider>
-      </Box>
-    );
-  },
-);
+    await _renderPages(identifiablePhrases);
+
+    setPages(renderedPages);
+  }, [
+    documentId,
+    activitiesPhrasalData,
+    appletTitle,
+    availableWidth,
+    pageMaxHeight,
+    phrasalTemplateCardTitle,
+    identifiablePhrases,
+    noImage,
+  ]);
+
+  useEffect(() => {
+    void renderPages();
+  }, [renderPages]);
+
+  return (
+    <Box
+      data-phrasal-template-document={true}
+      data-phrasal-template-document-id={documentId}
+      gap="24px"
+      display={'flex'}
+      flexDirection={'column'}
+      alignItems="center"
+    >
+      <DocumentContext.Provider value={{ totalPages: pages.length }}>
+        {pages}
+      </DocumentContext.Provider>
+    </Box>
+  );
+};
 
 Document.displayName = 'Document';

--- a/src/entities/activity/ui/items/ActionPlan/Page.tsx
+++ b/src/entities/activity/ui/items/ActionPlan/Page.tsx
@@ -21,6 +21,7 @@ import { Theme } from '~/shared/constants';
 import Box from '~/shared/ui/Box';
 
 type PageProps = {
+  documentId: string;
   pageNumber: number;
   phrases: PhrasalTemplatePhrase[];
   phrasalData: ActivitiesPhrasalData;
@@ -30,6 +31,7 @@ type PageProps = {
 };
 
 export const Page = ({
+  documentId,
   appletTitle,
   phrasalTemplateCardTitle,
   phrases,
@@ -55,6 +57,8 @@ export const Page = ({
 
   return (
     <Box
+      data-phrasal-template-page={true}
+      data-phrasal-template-document-id={documentId}
       sx={{
         width: `${pageWidth}px`,
         padding: `0 ${scaledPadding}px ${scaledPadding}px`,

--- a/src/entities/activity/ui/items/PhrasalTemplateItem.tsx
+++ b/src/entities/activity/ui/items/PhrasalTemplateItem.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useContext, useCallback, useRef, useState } from 'react';
 
 import { Avatar, Button } from '@mui/material';
+import { format as formatDate } from 'date-fns';
 import { isMobile } from 'react-device-detect';
 import { v4 as uuidV4 } from 'uuid';
 
@@ -29,23 +30,20 @@ export const PhrasalTemplateItem = ({ item, replaceText }: PhrasalTemplateItemPr
   const documentIdRef = useRef<string>(uuidV4());
   const { t } = usePhrasalTemplateTranslation();
 
-  const handleDownloadImage = useCallback(async () => {
-    const now = new Date();
-    const filename = [
-      appletDisplayName,
-      phrasalTemplateCardTitle,
-      String(now.getMonth() + 1).padStart(2, '0'),
-      String(now.getDate()).padStart(2, '0'),
-      now.getFullYear(),
-    ].join('_');
-
-    await downloadPhrasalTemplateItem({
-      documentId: documentIdRef.current,
-      filename,
-      share: isMobile,
-      single: false,
-    });
-  }, [appletDisplayName, phrasalTemplateCardTitle]);
+  const handleDownloadImage = useCallback(
+    async () =>
+      await downloadPhrasalTemplateItem({
+        documentId: documentIdRef.current,
+        filename: [
+          appletDisplayName,
+          phrasalTemplateCardTitle,
+          formatDate(new Date(), 'MM_dd_yyyy'),
+        ].join('_'),
+        share: isMobile,
+        single: false,
+      }),
+    [appletDisplayName, phrasalTemplateCardTitle],
+  );
 
   return (
     <Box gap="24px" display={'flex'} flexDirection={'column'} alignItems="center">


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-7207](https://mindlogger.atlassian.net/browse/M2-7207)

This PR updates the "download" feature for Action Plan:

* Action Plan cards are now downloaded separately as individual files
* Downloaded images are now JPEG
* Downloaded images now have proper filename formatting
* Images are now downloaded with 3x magnification<sup>1</sup>
* The "download" button now triggers the share dialog on mobile devices<sup>2</sup>

### 📸 Screenshots

N/A

### 🪤 Peer Testing

Preparation

* Create an applet with a phrasal template that's long enough to result in truncation of Action Plan card content

On Desktop browser:

1. Start the applet and continue until the phrasal template step
2. Click the "Download" button
  * At this point, the browser should download multiple images as individual JPEG files<sup>3</sup>

On Mobile browser:

1. Start the applet and continue until the phrasal template step
2. Click the "Download" button
  * At this point, the "share" dialog should appear offering to share multiple images as individual JPEG files<sup>4</sup>

### ✏️ Notes

<sup>1</sup>: Due to the way the `scale` attribute works for `html2canvas`,  the `3x magnification` actually means `3x of normal dpi`, and not `3x of whatever is rendered on screen`. This means, if the device is already rendering the page at greater than 1x dpi (i.e. with OS-level scaling on high-dpi displays), then the downloaded images would only scale up to 3x dpi.

<sup>2</sup>: Mobile device detection relies on the `isMobile` flag from `react-device-detect`.

<sup>3</sup>: Different browser have different ways of facilitating this "multiple download in a single user action" feature: Firefox will simply allow it without question; Chrome will immediately download the first image, then ask permission to download the rest of them; And Safari will ask permission to download each image.

<sup>4</sup>: There is no way to view those shared images unless they are saved somewhere. So for test, one just have to save them to the device (or on iOS, saved to a "Note").