### PR TITLE
fix: Warning banner & post-login redirect both fail when starting `Take Now` while already logged into Web App as wrong respondent (M2-8029) 

### DIFF
--- a/src/entities/user/model/hooks/useOnLogin.ts
+++ b/src/entities/user/model/hooks/useOnLogin.ts
@@ -41,7 +41,7 @@ export const useOnLogin = (params: Params) => {
     secureTokensStorage.setTokens(tokens);
 
     if (params.backRedirectPath !== undefined) {
-      navigate(params.backRedirectPath);
+      navigate(params.backRedirectPath, { replace: true });
     } else {
       Mixpanel.track('Login Successful');
       Mixpanel.login(user.id);

--- a/src/features/Logout/lib/useLogout.ts
+++ b/src/features/Logout/lib/useLogout.ts
@@ -1,5 +1,7 @@
 import { useCallback } from 'react';
 
+import { useLocation } from 'react-router-dom';
+
 import { appletModel } from '~/entities/applet';
 import { useLogoutMutation, userModel } from '~/entities/user';
 import { AutoCompletionModel } from '~/features/AutoCompletion';
@@ -14,6 +16,7 @@ type UseLogoutReturn = {
 
 export const useLogout = (): UseLogoutReturn => {
   const navigator = useCustomNavigation();
+  const location = useLocation();
 
   const { clearUser } = userModel.hooks.useUserState();
   const { clearStore } = appletModel.hooks.useClearStore();
@@ -37,8 +40,18 @@ export const useLogout = (): UseLogoutReturn => {
     Mixpanel.track('logout');
     Mixpanel.logout();
     FeatureFlags.logout();
-    return navigator.navigate(ROUTES.login.path);
-  }, [clearUser, clearStore, clearAutoCompletionState, navigator, logoutMutation]);
+
+    const backRedirectPath = `${location.pathname}${location.search}`;
+    return navigator.navigate(ROUTES.login.path, { state: { backRedirectPath } });
+  }, [
+    clearUser,
+    clearStore,
+    clearAutoCompletionState,
+    location.pathname,
+    location.search,
+    navigator,
+    logoutMutation,
+  ]);
 
   return {
     logout,

--- a/src/pages/AuthorizedRoutes.tsx
+++ b/src/pages/AuthorizedRoutes.tsx
@@ -48,10 +48,10 @@ function AuthorizedRoutes({ refreshToken }: Props) {
             <Route path={ROUTES.privateJoin.path} element={<PrivateJoinPage />} />
             <Route path={ROUTES.publicJoin.path} element={<PublicAppletDetailsPage />} />
             <Route path={ROUTES.transferOwnership.path} element={<TransferOwnershipPage />} />
-
-            <Route path="*" element={<Navigate to={ROUTES.appletList.path} />} />
           </Route>
         </Route>
+
+        <Route path="*" element={<Navigate to={ROUTES.appletList.path} />} />
       </Routes>
     </LogoutTracker>
   );

--- a/src/pages/AuthorizedRoutes.tsx
+++ b/src/pages/AuthorizedRoutes.tsx
@@ -5,6 +5,7 @@ import { Navigate, Route, Routes } from 'react-router-dom';
 import AppletDetailsPage from './AppletDetailsPage';
 import AppletListPage from './AppletListPage';
 import AutoCompletion from './AutoCompletion';
+import LoginPage from './Login';
 import ProfilePage from './Profile';
 import PublicAutoCompletion from './PublicAutoCompletion';
 import SettingsPage from './Settings';
@@ -50,7 +51,7 @@ function AuthorizedRoutes({ refreshToken }: Props) {
             <Route path={ROUTES.transferOwnership.path} element={<TransferOwnershipPage />} />
           </Route>
         </Route>
-
+        <Route path={ROUTES.login.path} element={<LoginPage />} />
         <Route path="*" element={<Navigate to={ROUTES.appletList.path} />} />
       </Routes>
     </LogoutTracker>

--- a/src/shared/utils/hooks/useSessionBanners/useSessionBanners.ts
+++ b/src/shared/utils/hooks/useSessionBanners/useSessionBanners.ts
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from 'react';
+import { useRef } from 'react';
 
 import { useBanners } from '~/entities/banner/model';
 import { userModel } from '~/entities/user';
@@ -9,11 +9,9 @@ export const useSessionBanners = () => {
 
   const prevIsAuthorized = useRef(isAuthorized);
 
-  useMemo(() => {
-    if (prevIsAuthorized.current !== isAuthorized && !isAuthorized) {
-      removeAllBanners();
-    }
+  if (prevIsAuthorized.current !== isAuthorized && !isAuthorized) {
+    removeAllBanners();
+  }
 
-    prevIsAuthorized.current = isAuthorized;
-  }, [isAuthorized, removeAllBanners]);
+  prevIsAuthorized.current = isAuthorized;
 };

--- a/src/shared/utils/hooks/useSessionBanners/useSessionBanners.ts
+++ b/src/shared/utils/hooks/useSessionBanners/useSessionBanners.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useMemo, useRef } from 'react';
 
 import { useBanners } from '~/entities/banner/model';
 import { userModel } from '~/entities/user';
@@ -9,7 +9,7 @@ export const useSessionBanners = () => {
 
   const prevIsAuthorized = useRef(isAuthorized);
 
-  useEffect(() => {
+  useMemo(() => {
     if (prevIsAuthorized.current !== isAuthorized && !isAuthorized) {
       removeAllBanners();
     }


### PR DESCRIPTION

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-8029](https://mindlogger.atlassian.net/browse/M2-8029)

- Fix to the  `useSessionBanners` hook to ensure that logic such as banner removal only occurs after authorization has changed. Replacing the `useEffect` with `useMemo` should ensure that any side effects that get triggered are due the state of the application once any further auth logic has been resolved.
- Fix to redirecting the user after correct authentication to navigate them to the 'Take Now' route.

### 📸 Screenshots

<!--
If your work here contains visual changes, provide before (optional) and after screenshots, GIFs, or videos.

If not, then delete this section
-->

Before:

https://github.com/user-attachments/assets/8e5149f7-6291-4c96-956f-b24ef8f725c1

After:

https://github.com/user-attachments/assets/6102dd21-54d2-4405-9fde-5238354dabbe

### 🪤 Peer Testing

<!-- If peer testing is not needed, then delete this section -->
<!-- Uncomment out any of the following as needed:           -->
<!-- **Requires `yarn install`**     -->

<!--
Replace this with a series of test steps & expected outcomes.

Example test step:

- This is a test step.  Highlight actions **in bold**.

    **Expected outcome:** This is what to expect after the step
-->

𝐏𝐫𝐞𝐜𝐨𝐧𝐝𝐢𝐭𝐢𝐨𝐧𝐬:
- Have an applet with at least one Team Member and one Full Account participant.
- Be already logged into the Web App as the Team Member.

𝐒𝐭𝐞𝐩𝐬 𝐭𝐨 𝐫𝐞𝐩𝐫𝐨𝐝𝐮𝐜𝐞:
- Perform Take Now on any activity, specifying the Full Account as the respondent, and anyone as the subject (self-report is otherwise).
- Observe the banner briefly shown at the top of the Web App when redirected to login screen.
- Log into Web App as the Full Account.
- Observe the next page you are led to in the Web App.