### PR TITLE
feat: Omit Report Scores with Scoring Type "Score" from the Report Summary Screen (M2-8097)

### DIFF
--- a/src/features/PassSurvey/model/ScoresExtractor.ts
+++ b/src/features/PassSurvey/model/ScoresExtractor.ts
@@ -42,6 +42,11 @@ class ScoresExtractor {
     const result: Array<ScoreRecord> = [];
 
     for (const scoreSettings of settings) {
+      if (scoreSettings.type === 'score' && scoreSettings.scoringType === 'score') {
+        // Skip report scores that are not configured as raw scores
+        continue;
+      }
+
       try {
         const score: ScoreRecord | null = this.extractInternal(items, scoreSettings);
 

--- a/src/shared/api/types/activity.ts
+++ b/src/shared/api/types/activity.ts
@@ -57,6 +57,10 @@ export type ScoreAndReports = {
 
 export type ReportDTO = ReportScoreDTO | ReportSectionDTO;
 
+export const ScoreReportScoringType = ['score', 'raw_score'] as const;
+
+export type ScoreReportScoringType = (typeof ScoreReportScoringType)[number];
+
 export type ReportScoreDTO = {
   type: 'score';
   id: string;
@@ -66,6 +70,11 @@ export type ReportScoreDTO = {
   itemsPrint: string[]; // Name of items to print
   itemsScore: string[]; // Name of items to calculates
   conditionalLogic: Array<ScoreConditionalLogic>;
+
+  /** Whether to show raw score or T scores in the report */
+  scoringType: ScoreReportScoringType;
+  /** The name of a subscale to use for a lookup table, if `scoringType` is set to "score" */
+  subscaleName?: string;
 };
 
 export type ReportSectionDTO = {


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-8097](https://mindlogger.atlassian.net/browse/M2-8097)

This PR updates the Report Summary screen to omit report scores configured with scoring type `score`. These are scores that are linked to a subscale and are currently not supported as part of the report summary screen.

### 📸 Screenshots

N/A

### 🪤 Peer Testing

> [!NOTE]
> This PR depends on https://github.com/ChildMindInstitute/mindlogger-admin/pull/1935 in order to configure the activity from the admin app

In the admin app
1. Create an activity with a subscale containing a lookup table and an activity item (in its "Elements within Subscale" list)
2. Create a report score and set the score type to "Score"
3. Select the subscale from the dropdown list
4. Create another report score and set the score type to "Raw Score"
5. Save the activity

In the web app
1. Complete the activity you created above
2. Confirm that the report summary screen does not include the report score with score type set to "Score"

### ✏️ Notes

N/A
