### PR TITLE
feat: implement content truncation for Action Plan cards (M2-7861)

### DIFF
--- a/src/abstract/lib/constants.ts
+++ b/src/abstract/lib/constants.ts
@@ -27,6 +27,7 @@ export const phrasalTemplateCompatibleResponseTypes = [
   'singleSelect',
   'slider',
   'text',
+  'paragraphText',
   'time',
   'timeRange',
   'multiSelectRows',

--- a/src/entities/activity/ui/items/ActionPlan/Document.tsx
+++ b/src/entities/activity/ui/items/ActionPlan/Document.tsx
@@ -1,19 +1,25 @@
-import React, { useEffect, useState, useContext, useMemo, useCallback } from 'react';
+import React, { useCallback, useContext, useMemo, useState } from 'react';
 
 import { Box } from '@mui/material';
 import { v4 as uuidV4 } from 'uuid';
 
-import { DocumentContext } from './DocumentContext';
-import { useAvailableBodyWidth, useCorrelatedPageMaxHeightLineCount } from './hooks';
-import { Page } from './Page';
+import {
+  DocumentContext,
+  DocumentData,
+  IdentifiablePhrasalTemplatePhrase,
+  PageComponent,
+} from './Document.type';
+import { useAvailableBodyWidth, usePageMaxHeight } from './hooks';
+import { buildDocumentData, buildPageComponents } from './pageComponent';
+import { pageRenderer, pagesRenderer } from './pageRenderer';
 import { extractActivitiesPhrasalData } from './phrasalData';
 
 import { getProgressId } from '~/abstract/lib';
 import { PhrasalTemplatePhrase } from '~/entities/activity/lib';
+import { useActionPlanTranslation } from '~/entities/activity/lib/useActionPlanTranslation';
 import { appletModel } from '~/entities/applet';
 import { SurveyContext } from '~/features/PassSurvey';
-import { useAppSelector } from '~/shared/utils';
-import measureComponentHeight from '~/shared/utils/measureComponentHeight';
+import { useAppSelector, useOnceEffect } from '~/shared/utils';
 
 type DocumentProps = {
   documentId: string;
@@ -22,28 +28,14 @@ type DocumentProps = {
   phrasalTemplateCardTitle: string;
 };
 
-type IdentifiablePhrasalTemplatePhrase = PhrasalTemplatePhrase & { id: string };
-
 export const Document = ({
   documentId,
   appletTitle,
   phrases,
   phrasalTemplateCardTitle,
 }: DocumentProps) => {
+  const { t } = useActionPlanTranslation();
   const context = useContext(SurveyContext);
-
-  const noImage = useMemo(() => phrases.filter((phrase) => !!phrase.image).length <= 0, [phrases]);
-
-  const identifiablePhrases = useMemo(
-    () =>
-      phrases.map<IdentifiablePhrasalTemplatePhrase>((phrase) => {
-        return {
-          ...phrase,
-          id: uuidV4(),
-        };
-      }),
-    [phrases],
-  );
 
   const activityProgress = useAppSelector((state) =>
     appletModel.selectors.selectActivityProgress(
@@ -57,120 +49,48 @@ export const Document = ({
     [activityProgress],
   );
 
+  const identifiablePhrases = useMemo(
+    () => phrases.map<IdentifiablePhrasalTemplatePhrase>((phrase) => ({ ...phrase, id: uuidV4() })),
+    [phrases],
+  );
+
+  const documentData = useMemo<DocumentData>(
+    () => buildDocumentData(identifiablePhrases),
+    [identifiablePhrases],
+  );
+
+  const pageComponents = useMemo<PageComponent[]>(
+    () => buildPageComponents(t, activitiesPhrasalData, identifiablePhrases),
+    [t, activitiesPhrasalData, identifiablePhrases],
+  );
+
   const availableWidth = useAvailableBodyWidth();
-  const correlatedPageMaxHeightLineCount = useCorrelatedPageMaxHeightLineCount();
-  const pageMaxHeight = correlatedPageMaxHeightLineCount.maxHeight;
+  const pageMaxHeight = usePageMaxHeight();
   const [pages, setPages] = useState<React.ReactNode[]>([]);
 
-  const renderPages = useCallback(async () => {
-    const renderedPages: React.ReactNode[] = [];
+  const renderOnePage = useMemo(
+    () =>
+      pageRenderer(availableWidth, {
+        documentId,
+        documentData,
+        appletTitle,
+        phrasalTemplateCardTitle,
+      }),
+    [appletTitle, availableWidth, documentData, documentId, phrasalTemplateCardTitle],
+  );
 
-    const renderPage = async (
-      pagePhrases: IdentifiablePhrasalTemplatePhrase[],
-    ): Promise<[React.ReactNode, IdentifiablePhrasalTemplatePhrase[]]> => {
-      const curPageNumber = renderedPages.length + 1;
+  const renderMorePage = useMemo(
+    () => pagesRenderer(renderOnePage, pageMaxHeight),
+    [pageMaxHeight, renderOnePage],
+  );
 
-      const curPage = (
-        <Page
-          key={`page-${curPageNumber}`}
-          documentId={documentId}
-          pageNumber={curPageNumber}
-          appletTitle={appletTitle}
-          phrasalTemplateCardTitle={phrasalTemplateCardTitle}
-          phrases={pagePhrases}
-          phrasalData={activitiesPhrasalData}
-          noImage={noImage}
-        />
-      );
-
-      const pageHeight = await measureComponentHeight(availableWidth, curPage);
-      if (pageHeight <= pageMaxHeight) {
-        // If the rendered page fits into the maximum allowed page height,
-        // then stop rendering.
-        return [curPage, []];
-      }
-
-      if (pagePhrases.length <= 1) {
-        const pagePhrase = pagePhrases[0];
-        const pagePhraseFields = pagePhrase.fields;
-
-        if (pagePhraseFields.length <= 1) {
-          // If the rendered page does not fit into the maximum allowed page
-          // height, and there is only 1 phrase for the page, but that phrase
-          // has on 1 field (this means there is nothing left to split), then
-          // stop rendering.
-          return [curPage, []];
-        }
-
-        // If the rendered page does not fit into the maximum allowed page
-        // height, and there is only 1 phrase for the page, and that phrase
-        // has more than 1 field, then split the fields into multiple phrases
-        // with the same ID and re-render.
-        const splits: [IdentifiablePhrasalTemplatePhrase, IdentifiablePhrasalTemplatePhrase] = [
-          {
-            id: pagePhrase.id,
-            image: pagePhrase.image,
-            fields: pagePhraseFields.slice(0, pagePhraseFields.length - 1),
-          },
-          {
-            id: pagePhrase.id,
-            image: pagePhrase.image,
-            fields: pagePhraseFields.slice(pagePhraseFields.length - 1),
-          },
-        ];
-
-        const [newPage, newPageRestPhrases] = await renderPage([splits[0]]);
-        const leftoverPhrases = [...newPageRestPhrases, splits[1]];
-        return [newPage, leftoverPhrases];
-      }
-
-      // If the rendered page does not fit into the maximum allowed page
-      // height, and the page has more than 1 phrase, then split the phrases
-      // and re-render.
-      const newPagePhrases = pagePhrases.slice(0, pagePhrases.length - 1);
-      const curPageRestPhrases = pagePhrases.slice(pagePhrases.length - 1);
-      const [newPage, newPageRestPhrases] = await renderPage(newPagePhrases);
-      const leftoverPhrases = [...newPageRestPhrases, ...curPageRestPhrases];
-
-      const recombinedLeftoverPhrases = leftoverPhrases.reduce((acc, phrase) => {
-        const existingPhrase = acc.find(({ id }) => id === phrase.id);
-        if (existingPhrase) {
-          existingPhrase.fields = [...existingPhrase.fields, ...phrase.fields];
-        } else {
-          acc.push(phrase);
-        }
-        return acc;
-      }, [] as IdentifiablePhrasalTemplatePhrase[]);
-
-      return [newPage, recombinedLeftoverPhrases];
-    };
-
-    const _renderPages = async (_pagePhrases: IdentifiablePhrasalTemplatePhrase[]) => {
-      const [renderedPage, leftoverPhrases] = await renderPage(_pagePhrases);
-      renderedPages.push(renderedPage);
-
-      if (leftoverPhrases.length > 0) {
-        await _renderPages(leftoverPhrases);
-      }
-    };
-
-    await _renderPages(identifiablePhrases);
-
+  const renderAllPages = useCallback(async () => {
+    const renderedPages = await renderMorePage(1, pageComponents);
     setPages(renderedPages);
-  }, [
-    documentId,
-    activitiesPhrasalData,
-    appletTitle,
-    availableWidth,
-    pageMaxHeight,
-    phrasalTemplateCardTitle,
-    identifiablePhrases,
-    noImage,
-  ]);
-
-  useEffect(() => {
-    void renderPages();
-  }, [renderPages]);
+  }, [pageComponents, renderMorePage]);
+  useOnceEffect(() => {
+    void renderAllPages();
+  });
 
   return (
     <Box

--- a/src/entities/activity/ui/items/ActionPlan/Document.type.ts
+++ b/src/entities/activity/ui/items/ActionPlan/Document.type.ts
@@ -1,0 +1,69 @@
+import React from 'react';
+
+import { PhrasalTemplatePhrase } from '~/entities/activity';
+
+export type IdentifiablePhrasalTemplatePhrase = PhrasalTemplatePhrase & { id: string };
+
+// This should be kept in a separate file from `Document` because both `Document` and `Page` need
+// this context, but `Document` also needs `Page`. So keeping this context in this separate file
+// avoids a circular import path.
+export const DocumentContext = React.createContext<{
+  totalPages: number;
+}>({
+  totalPages: 0,
+});
+
+export type FieldValueTransformer = (value: string) => string;
+
+export type FieldValueItemsJoiner = (values: string[]) => string;
+
+type BasePageComponent = {
+  phraseIndex: number;
+  phraseId: string;
+};
+
+export type SentencePageComponent = BasePageComponent & {
+  componentType: 'sentence';
+  text: string;
+};
+
+type BaseItemResponsePageComponent = BasePageComponent & {
+  componentType: 'item_response';
+};
+
+export type ListItemResponsePageComponent = BaseItemResponsePageComponent & {
+  componentType: 'item_response';
+  itemResponseType: 'list';
+  items: string[];
+};
+
+export type TextItemResponsePageComponent = BaseItemResponsePageComponent & {
+  componentType: 'item_response';
+  itemResponseType: 'text';
+  text: string;
+};
+
+type ItemResponsePageComponent = ListItemResponsePageComponent | TextItemResponsePageComponent;
+
+export type LineBreakPageComponent = BasePageComponent & {
+  componentType: 'line_break';
+};
+
+export type PageComponent =
+  | SentencePageComponent
+  | ItemResponsePageComponent
+  | LineBreakPageComponent;
+
+export type DocumentData = {
+  imageUrlByPhraseId: Record<string, string>;
+  hasImage: boolean;
+};
+
+export type FlatComponentIndex = [number] | [number, number];
+
+export type PageRenderer = (
+  pageNumber: number,
+  components: PageComponent[],
+  flatIndices: FlatComponentIndex[],
+  inclusivePivot: number,
+) => Promise<{ page: React.ReactNode; pageHeight: number; restComponents: PageComponent[] }>;

--- a/src/entities/activity/ui/items/ActionPlan/Document.type.ts
+++ b/src/entities/activity/ui/items/ActionPlan/Document.type.ts
@@ -49,10 +49,19 @@ export type LineBreakPageComponent = BasePageComponent & {
   componentType: 'line_break';
 };
 
+/**
+ * Newline is a special component that is used to force a new line in the document, used when
+ * rendering the `paragraphText` item type.
+ */
+export type NewlinePageComponent = BasePageComponent & {
+  componentType: 'newline';
+};
+
 export type PageComponent =
   | SentencePageComponent
   | ItemResponsePageComponent
-  | LineBreakPageComponent;
+  | LineBreakPageComponent
+  | NewlinePageComponent;
 
 export type DocumentData = {
   imageUrlByPhraseId: Record<string, string>;

--- a/src/entities/activity/ui/items/ActionPlan/DocumentContext.ts
+++ b/src/entities/activity/ui/items/ActionPlan/DocumentContext.ts
@@ -1,7 +1,0 @@
-import React from 'react';
-
-export const DocumentContext = React.createContext<{
-  totalPages: number;
-}>({
-  totalPages: 0,
-});

--- a/src/entities/activity/ui/items/ActionPlan/Phrase.tsx
+++ b/src/entities/activity/ui/items/ActionPlan/Phrase.tsx
@@ -1,27 +1,30 @@
-import React from 'react';
+import React, { ComponentProps, useMemo } from 'react';
 
 import Avatar from '@mui/material/Avatar';
 
-import {
-  useCorrelatedPageMaxHeightLineCount,
-  useXScaledDimension,
-  useYScaledDimension,
-} from './hooks';
-import { ActivitiesPhrasalData } from './phrasalData';
+import { DocumentData, PageComponent } from './Document.type';
+import { useXScaledDimension, useYScaledDimension } from './hooks';
 import { ResponseSegment } from './ResponseSegment';
 import { TextSegment } from './TextSegment';
 
-import { PhrasalTemplatePhrase, PhrasalTemplateField } from '~/entities/activity';
 import { Theme } from '~/shared/constants';
 import Box from '~/shared/ui/Box';
 
 export type PhraseProps = {
-  phrase: PhrasalTemplatePhrase;
-  phrasalData: ActivitiesPhrasalData;
-  noImage: boolean;
+  phraseId: string;
+  documentData: DocumentData;
+  pageComponents: PageComponent[];
+  isFirstOnPage: boolean;
+  isLastOnPage: boolean;
 };
 
-export const Phrase = ({ phrase, phrasalData, noImage }: PhraseProps) => {
+export const Phrase = ({
+  phraseId,
+  documentData,
+  pageComponents,
+  isFirstOnPage,
+  isLastOnPage,
+}: PhraseProps) => {
   const gap = useXScaledDimension(24);
   const minHeight = useXScaledDimension(72);
   const imageWidth = useXScaledDimension(67);
@@ -29,35 +32,67 @@ export const Phrase = ({ phrase, phrasalData, noImage }: PhraseProps) => {
   const imagePadding = useXScaledDimension(2);
   const fontSize = useXScaledDimension(16);
   const lineHeight = useYScaledDimension(24);
-  const correlatedPageMaxHeightLineCount = useCorrelatedPageMaxHeightLineCount();
-  const maxLineCount = correlatedPageMaxHeightLineCount.lineCount;
 
-  const { components } = phrase.fields.reduce(
-    (acc, field, fieldIndex) => {
-      const isLineStart = fieldIndex === 0 || acc.prevField?.type === 'line_break';
+  const phraseComponents = useMemo(
+    () =>
+      pageComponents.reduce((acc, component, componentIndex) => {
+        if (component.phraseId === phraseId) {
+          if (
+            (isFirstOnPage && componentIndex === 0) ||
+            (isLastOnPage && componentIndex === pageComponents.length - 1)
+          ) {
+            // Remove leading and trailing line-break components.
+            if (component.componentType !== 'line_break') {
+              acc.push(component);
+            }
+          } else {
+            acc.push(component);
+          }
+        }
+        return acc;
+      }, [] as PageComponent[]),
+    [pageComponents, phraseId, isFirstOnPage, isLastOnPage],
+  );
 
-      if (field.type === 'sentence') {
-        acc.components.push(<TextSegment text={field.text} isAtStart={isLineStart} />);
-      } else if (field.type === 'item_response') {
-        acc.components.push(
-          <ResponseSegment phrasalData={phrasalData} field={field} isAtStart={isLineStart} />,
-        );
-      } else if (field.type === 'line_break') {
-        acc.components.push(<br />);
+  const renderedComponents = useMemo(() => {
+    const rendered: React.ReactNode[] = [];
+
+    let previousComponentType: PageComponent['componentType'] | undefined;
+    phraseComponents.forEach((component, componentIndex) => {
+      const componentType = component.componentType;
+      const isAtStart = componentIndex === 0 || previousComponentType === 'line_break';
+
+      if (componentType === 'sentence') {
+        rendered.push(<TextSegment text={component.text} isAtStart={isAtStart} />);
+      } else if (componentType === 'item_response') {
+        let itemResponse: ComponentProps<typeof ResponseSegment>['itemResponse'];
+        if (component.itemResponseType === 'list') {
+          itemResponse = {
+            itemResponseType: 'list',
+            items: component.items,
+          };
+        } else {
+          itemResponse = {
+            itemResponseType: 'text',
+            text: component.text,
+          };
+        }
+        rendered.push(<ResponseSegment itemResponse={itemResponse} isAtStart={isAtStart} />);
+      } else if (componentType === 'line_break') {
+        rendered.push(<br />);
       }
 
-      acc.prevField = field;
-      return acc;
-    },
-    { components: [], prevField: undefined } as {
-      components: React.ReactNode[];
-      prevField?: PhrasalTemplateField;
-    },
-  );
+      previousComponentType = componentType;
+    });
+
+    return rendered;
+  }, [phraseComponents]);
+
+  const imageUrl = documentData.imageUrlByPhraseId[phraseId];
 
   return (
     <Box display="flex" gap={`${gap}px`} minHeight={minHeight}>
-      {!noImage && (
+      {documentData.hasImage && (
         <Box
           display="flex"
           justifyContent="center"
@@ -67,9 +102,9 @@ export const Phrase = ({ phrase, phrasalData, noImage }: PhraseProps) => {
             height: imageHeight,
           }}
         >
-          {phrase.image && (
+          {imageUrl && (
             <Avatar
-              src={phrase.image}
+              src={imageUrl}
               variant="square"
               sx={{
                 width: imageWidth,
@@ -82,20 +117,8 @@ export const Phrase = ({ phrase, phrasalData, noImage }: PhraseProps) => {
           )}
         </Box>
       )}
-      <Box
-        fontSize={`${fontSize}px`}
-        lineHeight={`${lineHeight}px`}
-        display="-webkit-inline-box"
-        maxHeight="100%"
-        overflow="hidden"
-        sx={{
-          lineClamp: `${maxLineCount}`,
-          '-webkit-line-clamp': `${maxLineCount}`,
-          boxOrient: 'vertical',
-          '-webkit-box-orient': 'vertical',
-        }}
-      >
-        {React.Children.toArray(components)}
+      <Box fontSize={`${fontSize}px`} lineHeight={`${lineHeight}px`}>
+        {React.Children.toArray(renderedComponents)}
       </Box>
     </Box>
   );

--- a/src/entities/activity/ui/items/ActionPlan/Phrase.tsx
+++ b/src/entities/activity/ui/items/ActionPlan/Phrase.tsx
@@ -79,7 +79,7 @@ export const Phrase = ({
         }
         rendered.push(<ResponseSegment itemResponse={itemResponse} isAtStart={isAtStart} />);
       } else if (componentType === 'line_break') {
-        rendered.push(<br />);
+        rendered.push(<Box component="hr" sx={{ m: 0, height: 32, border: 'none' }} />);
       }
 
       previousComponentType = componentType;

--- a/src/entities/activity/ui/items/ActionPlan/Phrase.tsx
+++ b/src/entities/activity/ui/items/ActionPlan/Phrase.tsx
@@ -42,7 +42,7 @@ export const Phrase = ({
             (isLastOnPage && componentIndex === pageComponents.length - 1)
           ) {
             // Remove leading and trailing line-break components.
-            if (component.componentType !== 'line_break') {
+            if (component.componentType !== 'line_break' && component.componentType !== 'newline') {
               acc.push(component);
             }
           } else {
@@ -60,7 +60,10 @@ export const Phrase = ({
     let previousComponentType: PageComponent['componentType'] | undefined;
     phraseComponents.forEach((component, componentIndex) => {
       const componentType = component.componentType;
-      const isAtStart = componentIndex === 0 || previousComponentType === 'line_break';
+      const isAtStart =
+        componentIndex === 0 ||
+        previousComponentType === 'line_break' ||
+        previousComponentType === 'newline';
 
       if (componentType === 'sentence') {
         rendered.push(<TextSegment text={component.text} isAtStart={isAtStart} />);
@@ -80,6 +83,8 @@ export const Phrase = ({
         rendered.push(<ResponseSegment itemResponse={itemResponse} isAtStart={isAtStart} />);
       } else if (componentType === 'line_break') {
         rendered.push(<Box component="hr" sx={{ m: 0, height: 32, border: 'none' }} />);
+      } else if (componentType === 'newline') {
+        rendered.push(<br />);
       }
 
       previousComponentType = componentType;

--- a/src/entities/activity/ui/items/ActionPlan/ResponseSegment.tsx
+++ b/src/entities/activity/ui/items/ActionPlan/ResponseSegment.tsx
@@ -1,135 +1,29 @@
 import { useXScaledDimension } from './hooks';
-import { ActivitiesPhrasalData, ActivityPhrasalDataSliderRowContext } from './phrasalData';
 
-import { PhrasalTemplateItemResponseField } from '~/entities/activity';
-import { useActionPlanTranslation } from '~/entities/activity/lib/useActionPlanTranslation';
 import Box from '~/shared/ui/Box';
 import Text from '~/shared/ui/Text';
 
-const isAnswersSkipped = (answers: string[]): boolean => {
-  if (!answers || answers.length <= 0) {
-    return true;
-  }
-
-  let allFalsy = true;
-  for (const answer of answers) {
-    if (answer !== null && answer !== undefined && answer.trim().length > 0) {
-      allFalsy = false;
-    }
-  }
-
-  return allFalsy;
+type ItemResponseText = {
+  itemResponseType: 'text';
+  text: string;
 };
 
-type FieldValueTransformer = (value: string) => string;
-const identity: FieldValueTransformer = (value) => value;
-
-type FieldValuesJoiner = (values: string[]) => string | JSX.Element[];
-const joinWithComma: FieldValuesJoiner = (values) => values.join(', ');
+type ItemResponseList = {
+  itemResponseType: 'list';
+  items: string[];
+};
 
 type ResponseSegmentProps = {
-  phrasalData: ActivitiesPhrasalData;
-  field: PhrasalTemplateItemResponseField;
-  isAtStart?: boolean;
+  itemResponse: ItemResponseText | ItemResponseList;
+  isAtStart: boolean;
 };
 
-export const ResponseSegment = ({ phrasalData, field, isAtStart }: ResponseSegmentProps) => {
-  const { t } = useActionPlanTranslation();
+export const ResponseSegment = ({ itemResponse, isAtStart }: ResponseSegmentProps) => {
   const listPadding = useXScaledDimension(40);
-
-  const fieldDisplayMode = field.displayMode;
-  const fieldPhrasalData = phrasalData[field.itemName];
-
-  if (!fieldPhrasalData) {
-    // This really shouldn't happen. But we should still eliminate the logical
-    // path for nil/falsy values anyway.
-    return null;
-  }
-
-  const fieldPhrasalDataType = fieldPhrasalData.type;
-
-  let transformValue = identity;
-  let joinSentenceWords = joinWithComma;
-
-  if (fieldPhrasalData.context.itemResponseType === 'sliderRows') {
-    const ctx = fieldPhrasalData.context as ActivityPhrasalDataSliderRowContext;
-    transformValue = (value) => {
-      return t('sliderValue', { value, total: ctx.maxValues[field.itemIndex] });
-    };
-  } else if (fieldPhrasalData.context.itemResponseType === 'timeRange') {
-    joinSentenceWords = (values) => values.join(' - ');
-  } else if (fieldPhrasalData.context.itemResponseType === 'paragraphText') {
-    joinSentenceWords = (values) =>
-      values.map((item, index) => <div key={index}>{item || ' '}</div>);
-  }
-
-  let words: string[];
-  if (fieldPhrasalDataType === 'array') {
-    words = isAnswersSkipped(fieldPhrasalData.values)
-      ? [t('questionSkipped')]
-      : fieldPhrasalData.values.map(transformValue);
-  } else if (fieldPhrasalDataType === 'paragraph') {
-    words = isAnswersSkipped(fieldPhrasalData.values)
-      ? [t('questionSkipped')]
-      : fieldPhrasalData.values
-          .flatMap((value) => value.split(/\r?\n/)) // Split each paragraph by newlines
-          .map(transformValue);
-  } else if (fieldPhrasalDataType === 'indexed-array') {
-    const indexedAnswers = fieldPhrasalData.values[field.itemIndex] || [];
-    words = isAnswersSkipped(indexedAnswers)
-      ? [t('questionSkipped')]
-      : indexedAnswers.map(transformValue);
-  } else if (fieldPhrasalDataType === 'matrix') {
-    let renderByRowValues: boolean;
-
-    if (
-      fieldDisplayMode === 'sentence_option_row' ||
-      fieldDisplayMode === 'bullet_list_option_row'
-    ) {
-      renderByRowValues = false;
-    } else if (
-      fieldDisplayMode === 'sentence_row_option' ||
-      fieldDisplayMode === 'bullet_list_text_row'
-    ) {
-      renderByRowValues = true;
-    } else {
-      // The admin UI actually allows matrix type items to have `sentence` as
-      // their display mode. So in this case, we're just going to assume the
-      // effective render order for the values to be "by row".
-      renderByRowValues = true;
-    }
-
-    if (renderByRowValues) {
-      words = fieldPhrasalData.values.byRow
-        .map(({ label, values }) => {
-          const transformedValues = isAnswersSkipped(values)
-            ? [t('questionSkipped')]
-            : values.map(transformValue);
-          return transformedValues.map((transformedValue) => `${label} ${transformedValue}`);
-        })
-        .flat();
-    } else {
-      words = fieldPhrasalData.values.byColumn
-        .map(({ label, values }) => {
-          const transformedValues = isAnswersSkipped(values)
-            ? [t('questionSkipped')]
-            : values.map(transformValue);
-          return transformedValues.map((transformedValue) => `${label} ${transformedValue}`);
-        })
-        .flat();
-    }
-  } else {
-    // This also shouldn't happen. But including a `else` here allows all
-    // previous branches to have explicitly defined condition, so it's more
-    // clear this way.
-    throw new Error(`Invalid phrasal data type: ${fieldPhrasalDataType}`);
-  }
 
   return (
     <Text component="span" fontWeight="700" fontSize="inherit" lineHeight="inherit">
-      {fieldDisplayMode === 'bullet_list' ||
-      fieldDisplayMode === 'bullet_list_option_row' ||
-      fieldDisplayMode === 'bullet_list_text_row' ? (
+      {itemResponse.itemResponseType === 'list' ? (
         <>
           {isAtStart ? null : (
             <span>
@@ -142,7 +36,7 @@ export const ResponseSegment = ({ phrasalData, field, isAtStart }: ResponseSegme
             marginTop={isAtStart ? `0px` : undefined}
             paddingLeft={`${listPadding}px`}
           >
-            {words.map((item, index) => (
+            {itemResponse.items.map((item, index) => (
               <li key={index}>{item}</li>
             ))}
           </Box>
@@ -150,7 +44,7 @@ export const ResponseSegment = ({ phrasalData, field, isAtStart }: ResponseSegme
       ) : (
         <>
           {isAtStart ? '' : ' '}
-          {joinSentenceWords(words)}
+          {itemResponse.text}
         </>
       )}
     </Text>

--- a/src/entities/activity/ui/items/ActionPlan/TextSegment.tsx
+++ b/src/entities/activity/ui/items/ActionPlan/TextSegment.tsx
@@ -1,6 +1,6 @@
 import Text from '~/shared/ui/Text';
 
-type TextSegmentProps = { text: string; isAtStart?: boolean };
+type TextSegmentProps = { text: string; isAtStart: boolean };
 
 export const TextSegment = ({ text, isAtStart }: TextSegmentProps) => {
   return (

--- a/src/entities/activity/ui/items/ActionPlan/hooks.tsx
+++ b/src/entities/activity/ui/items/ActionPlan/hooks.tsx
@@ -29,11 +29,11 @@ export const usePageMinHeight = () => {
 };
 
 export const usePageMaxHeight = () => {
-  // Use these for local development/testing when a shorter card would be
+  // Use these for local development/testing when shorter cards would be
   // easier to work with:
-  // return 512;
+  return useYScaledDimension(512);
 
-  return 2504;
+  // return useYScaledDimension(2504);
 };
 
 export const useXScaledDimension = (dimension: number) => {

--- a/src/entities/activity/ui/items/ActionPlan/hooks.tsx
+++ b/src/entities/activity/ui/items/ActionPlan/hooks.tsx
@@ -25,15 +25,15 @@ export const usePageWidth = () => {
 };
 
 export const usePageMinHeight = () => {
-  return 275;
+  return useYScaledDimension(275);
 };
 
 export const usePageMaxHeight = () => {
   // Use these for local development/testing when shorter cards would be
   // easier to work with:
-  return useYScaledDimension(512);
+  // return useYScaledDimension(512);
 
-  // return useYScaledDimension(2504);
+  return useYScaledDimension(2504);
 };
 
 export const useXScaledDimension = (dimension: number) => {

--- a/src/entities/activity/ui/items/ActionPlan/hooks.tsx
+++ b/src/entities/activity/ui/items/ActionPlan/hooks.tsx
@@ -28,20 +28,12 @@ export const usePageMinHeight = () => {
   return 275;
 };
 
-export const useCorrelatedPageMaxHeightLineCount = (): { maxHeight: number; lineCount: number } => {
+export const usePageMaxHeight = () => {
   // Use these for local development/testing when a shorter card would be
   // easier to work with:
-  // return { maxHeight: 512, lineCount: 14 };
+  // return 512;
 
-  return {
-    maxHeight: 2504,
-
-    // This number: 97, corresponds to the number of lines of plain text that
-    // can fit into a card of at most 2504px height. If the max height is
-    // adjusted, and/or if the text element's styling is adjusted, then this
-    // number would also need to be adjusted as well.
-    lineCount: 97,
-  };
+  return 2504;
 };
 
 export const useXScaledDimension = (dimension: number) => {

--- a/src/entities/activity/ui/items/ActionPlan/pageComponent.ts
+++ b/src/entities/activity/ui/items/ActionPlan/pageComponent.ts
@@ -8,6 +8,7 @@ import {
   IdentifiablePhrasalTemplatePhrase,
   LineBreakPageComponent,
   ListItemResponsePageComponent,
+  NewlinePageComponent,
   PageComponent,
   SentencePageComponent,
   TextItemResponsePageComponent,
@@ -89,7 +90,7 @@ export const buildPageComponents = (
           }
 
           let valueItems: string[];
-          if (fieldPhrasalData.type === 'array') {
+          if (fieldPhrasalDataType === 'array') {
             valueItems = isAnswersSkipped(fieldPhrasalData.values)
               ? [t('questionSkipped')]
               : fieldPhrasalData.values.map(transformValue);
@@ -158,6 +159,28 @@ export const buildPageComponents = (
               items: valueItems,
             };
             components.push(component);
+          } else if (fieldPhrasalData.context.itemResponseType === 'paragraphText') {
+            valueItems
+              .flatMap((item) => item.split(/\r?\n/))
+              .forEach((text, index) => {
+                if (index > 0) {
+                  const component: NewlinePageComponent = {
+                    phraseIndex,
+                    phraseId: phrase.id,
+                    componentType: 'newline',
+                  };
+                  components.push(component);
+                }
+
+                const component: TextItemResponsePageComponent = {
+                  phraseIndex,
+                  phraseId: phrase.id,
+                  componentType: 'item_response',
+                  itemResponseType: 'text',
+                  text: text || ' ', // Preserve empty lines
+                };
+                components.push(component);
+              });
           } else {
             const component: TextItemResponsePageComponent = {
               phraseIndex,
@@ -317,7 +340,7 @@ export const deepDivideComponents = (
         }
       }
     } else {
-      // Line-break items don't have "content". So just divide at components level.
+      // Line-break and newline items don't have "content". So just divide at components level.
       return divideComponents(components, inclusiveComponentEnd);
     }
   }

--- a/src/entities/activity/ui/items/ActionPlan/pageComponent.ts
+++ b/src/entities/activity/ui/items/ActionPlan/pageComponent.ts
@@ -42,6 +42,16 @@ const sliderValueTransformer =
 const joinWithComma: FieldValueItemsJoiner = (values) => values.join(', ');
 const joinWithDash: FieldValueItemsJoiner = (values) => values.join(' - ');
 
+/**
+ * Transform phrasal data object into more render-friendly data structures. This purpose of this
+ * transformation is to make the render component's code simpler: Instead of having individual
+ * render component dealing with the complexities of phrasal data structure, we just deal with them
+ * once at a centralized place. This way, render components can be code is a much more declarative
+ * manner.
+ * @param t Translation function
+ * @param phrasalData Phrasal data object
+ * @param phrases Phrasal template objects
+ */
 export const buildPageComponents = (
   t: TFunction,
   phrasalData: ActivitiesPhrasalData,
@@ -190,6 +200,15 @@ export const getPagePhraseIds = (components: PageComponent[]) =>
     [] as string[],
   );
 
+/**
+ * Generate a flattened list of component-content indices to be used by the binary search based
+ * truncation algorithm. Instead of having to perform binary search on multiple levels of the data
+ * structure, this flattened list allows binary search to be performed on only a single level. This
+ * greatly simplifies the implementation of the truncation algorithm. And the related function
+ * `deepDivideComponents` is then used to divide the data structure at a
+ * particular component-content index.
+ * @param components The list of page components to generate indices from.
+ */
 export const getFlatComponentIndices = (components: PageComponent[]): FlatComponentIndex[] =>
   components
     .map<FlatComponentIndex[]>((component, componentIndex) => {
@@ -223,6 +242,15 @@ const divideTextItems = (items: string[], inclusiveEnd: number): [string[], stri
   ['…', ...items.slice(inclusiveEnd + 1)],
 ];
 
+/**
+ * Deeply divide a given list of page components at the given component-content index. When a
+ * component is divided at content level, connective `…` are added to both ends of the resulting
+ * splits.
+ * @param components The list of page components to divide.
+ * @param flatIndices The list of component-content indices to choose a division point from.
+ * @param inclusivePivot The index element at which a component-content index will be selected to
+ * perform division at. The chosen component-content index will be used in a inclusive manner.
+ */
 export const deepDivideComponents = (
   components: PageComponent[],
   flatIndices: FlatComponentIndex[],

--- a/src/entities/activity/ui/items/ActionPlan/pageComponent.ts
+++ b/src/entities/activity/ui/items/ActionPlan/pageComponent.ts
@@ -1,0 +1,296 @@
+import { TFunction } from 'i18next';
+
+import {
+  DocumentData,
+  FieldValueItemsJoiner,
+  FieldValueTransformer,
+  FlatComponentIndex,
+  IdentifiablePhrasalTemplatePhrase,
+  LineBreakPageComponent,
+  ListItemResponsePageComponent,
+  PageComponent,
+  SentencePageComponent,
+  TextItemResponsePageComponent,
+} from './Document.type';
+import { ActivitiesPhrasalData, ActivityPhrasalDataSliderRowContext } from './phrasalData';
+
+const isAnswersSkipped = (answers: string[]): boolean => {
+  if (!answers || answers.length <= 0) {
+    return true;
+  }
+
+  let allFalsy = true;
+  for (const answer of answers) {
+    if (answer !== null && answer !== undefined && answer.trim().length > 0) {
+      allFalsy = false;
+    }
+  }
+
+  return allFalsy;
+};
+
+const identity: FieldValueTransformer = (value) => value;
+const sliderValueTransformer =
+  (
+    t: TFunction,
+    ctx: ActivityPhrasalDataSliderRowContext,
+    itemIndex: number,
+  ): FieldValueTransformer =>
+  (value) =>
+    t('sliderValue', { value, total: ctx.maxValues[itemIndex] });
+
+const joinWithComma: FieldValueItemsJoiner = (values) => values.join(', ');
+const joinWithDash: FieldValueItemsJoiner = (values) => values.join(' - ');
+
+export const buildPageComponents = (
+  t: TFunction,
+  phrasalData: ActivitiesPhrasalData,
+  phrases: IdentifiablePhrasalTemplatePhrase[],
+): PageComponent[] => {
+  const components: PageComponent[] = [];
+
+  phrases.forEach((phrase, phraseIndex) => {
+    phrase.fields.forEach((field) => {
+      if (field.type === 'sentence') {
+        const component: SentencePageComponent = {
+          phraseIndex,
+          phraseId: phrase.id,
+          componentType: 'sentence',
+          text: field.text,
+        };
+        components.push(component);
+      } else if (field.type === 'item_response') {
+        const fieldPhrasalData = phrasalData[field.itemName];
+        const fieldPhrasalDataType = fieldPhrasalData.type;
+
+        // Phrasal data for individual fields really should not be missing. But we should
+        // still eliminate the logical path for nil/falsy values anyway.
+        if (fieldPhrasalData) {
+          let transformValue = identity;
+          let joinValueItems = joinWithComma;
+          if (fieldPhrasalData.context.itemResponseType === 'sliderRows') {
+            transformValue = sliderValueTransformer(
+              t,
+              fieldPhrasalData.context as ActivityPhrasalDataSliderRowContext,
+              field.itemIndex,
+            );
+          } else if (fieldPhrasalData.context.itemResponseType === 'timeRange') {
+            joinValueItems = joinWithDash;
+          }
+
+          let valueItems: string[];
+          if (fieldPhrasalData.type === 'array') {
+            valueItems = isAnswersSkipped(fieldPhrasalData.values)
+              ? [t('questionSkipped')]
+              : fieldPhrasalData.values.map(transformValue);
+          } else if (fieldPhrasalDataType === 'indexed-array') {
+            const indexedAnswers = fieldPhrasalData.values[field.itemIndex] || [];
+            valueItems = isAnswersSkipped(indexedAnswers)
+              ? [t('questionSkipped')]
+              : indexedAnswers.map(transformValue);
+          } else if (fieldPhrasalDataType === 'matrix') {
+            // The admin UI actually allows matrix type items to have `sentence` as
+            // their display mode. So in this case, we're just going to assume the
+            // effective render order for the values to be "by row".
+            let renderByRowValues = true;
+            if (
+              field.displayMode === 'sentence_option_row' ||
+              field.displayMode === 'bullet_list_option_row'
+            ) {
+              renderByRowValues = false;
+            } else if (
+              field.displayMode === 'sentence_row_option' ||
+              field.displayMode === 'bullet_list_text_row'
+            ) {
+              renderByRowValues = true;
+            }
+
+            if (renderByRowValues) {
+              valueItems = fieldPhrasalData.values.byRow
+                .map(({ label, values }) => {
+                  const transformedValues = isAnswersSkipped(values)
+                    ? [t('questionSkipped')]
+                    : values.map(transformValue);
+                  return transformedValues.map(
+                    (transformedValue) => `${label} ${transformedValue}`,
+                  );
+                })
+                .flat();
+            } else {
+              valueItems = fieldPhrasalData.values.byColumn
+                .map(({ label, values }) => {
+                  const transformedValues = isAnswersSkipped(values)
+                    ? [t('questionSkipped')]
+                    : values.map(transformValue);
+                  return transformedValues.map(
+                    (transformedValue) => `${label} ${transformedValue}`,
+                  );
+                })
+                .flat();
+            }
+          } else {
+            // This also shouldn't happen. But including a `else` here allows all
+            // previous branches to have explicitly defined condition, so it's more
+            // clear this way.
+            throw new Error(`Invalid phrasal data type: ${fieldPhrasalDataType}`);
+          }
+
+          if (
+            field.displayMode === 'bullet_list' ||
+            field.displayMode === 'bullet_list_option_row' ||
+            field.displayMode === 'bullet_list_text_row'
+          ) {
+            const component: ListItemResponsePageComponent = {
+              phraseIndex,
+              phraseId: phrase.id,
+              componentType: 'item_response',
+              itemResponseType: 'list',
+              items: valueItems,
+            };
+            components.push(component);
+          } else {
+            const component: TextItemResponsePageComponent = {
+              phraseIndex,
+              phraseId: phrase.id,
+              componentType: 'item_response',
+              itemResponseType: 'text',
+              text: joinValueItems(valueItems),
+            };
+            components.push(component);
+          }
+        }
+      } else if (field.type === 'line_break') {
+        const component: LineBreakPageComponent = {
+          phraseIndex,
+          phraseId: phrase.id,
+          componentType: 'line_break',
+        };
+        components.push(component);
+      }
+    });
+  });
+
+  return components;
+};
+
+export const buildDocumentData = (phrases: IdentifiablePhrasalTemplatePhrase[]): DocumentData => {
+  const imageUrlByPhraseId = phrases.reduce(
+    (acc, phrase) => (phrase.image ? { ...acc, [phrase.id]: phrase.image } : acc),
+    {} as Record<string, string>,
+  );
+
+  const hasImage = Object.keys(imageUrlByPhraseId).length > 0;
+
+  return { imageUrlByPhraseId, hasImage };
+};
+
+export const getPagePhraseIds = (components: PageComponent[]) =>
+  components.reduce(
+    (acc, component) => (acc.includes(component.phraseId) ? acc : [...acc, component.phraseId]),
+    [] as string[],
+  );
+
+export const getFlatComponentIndices = (components: PageComponent[]): FlatComponentIndex[] =>
+  components
+    .map<FlatComponentIndex[]>((component, componentIndex) => {
+      if (component.componentType === 'item_response') {
+        if (component.itemResponseType === 'list') {
+          return component.items.map((_, itemIndex) => [componentIndex, itemIndex]);
+        } else {
+          return component.text.split(' ').map((_, wordIndex) => [componentIndex, wordIndex]);
+        }
+      } else if (component.componentType === 'sentence') {
+        return component.text.split(' ').map((_, wordIndex) => [componentIndex, wordIndex]);
+      } else {
+        return [[componentIndex]];
+      }
+    })
+    .flat();
+
+// Set this to `false` to turn off truncation of list items.
+const TRUNCATE_LIST_ITEMS: boolean = true;
+
+const divideComponents = (
+  components: PageComponent[],
+  inclusiveEnd: number,
+): [PageComponent[], PageComponent[]] => [
+  components.slice(0, inclusiveEnd + 1),
+  components.slice(inclusiveEnd + 1),
+];
+
+const divideTextItems = (items: string[], inclusiveEnd: number): [string[], string[]] => [
+  [...items.slice(0, inclusiveEnd + 1), '...'],
+  ['...', ...items.slice(inclusiveEnd + 1)],
+];
+
+export const deepDivideComponents = (
+  components: PageComponent[],
+  flatIndices: FlatComponentIndex[],
+  inclusivePivot: number,
+): [PageComponent[], PageComponent[]] => {
+  const inclusiveEnd = flatIndices[inclusivePivot];
+
+  if (inclusiveEnd.length === 1) {
+    const [inclusiveComponentEnd] = inclusiveEnd;
+    return divideComponents(components, inclusiveComponentEnd);
+  } else {
+    const [inclusiveComponentEnd, inclusiveContentEnd] = inclusiveEnd;
+    const component = components[inclusiveComponentEnd];
+
+    if (component.componentType === 'sentence') {
+      const items = component.text.split(' ');
+      if (inclusiveContentEnd >= items.length - 1) {
+        return divideComponents(components, inclusiveComponentEnd);
+      } else {
+        const itemSplits = divideTextItems(items, inclusiveContentEnd);
+        const split: [SentencePageComponent, SentencePageComponent] = [
+          { ...component, text: itemSplits[0].join(' ') },
+          { ...component, text: itemSplits[1].join(' ') },
+        ];
+        return [
+          [...components.slice(0, inclusiveComponentEnd), split[0]],
+          [split[1], ...components.slice(inclusiveComponentEnd + 1)],
+        ];
+      }
+    } else if (component.componentType === 'item_response') {
+      if (component.itemResponseType === 'list') {
+        if (TRUNCATE_LIST_ITEMS) {
+          const items = component.items;
+          if (inclusiveContentEnd >= items.length - 1) {
+            return divideComponents(components, inclusiveComponentEnd);
+          } else {
+            const itemSplits = divideTextItems(items, inclusiveContentEnd);
+            const split: [ListItemResponsePageComponent, ListItemResponsePageComponent] = [
+              { ...component, items: itemSplits[0] },
+              { ...component, items: itemSplits[1] },
+            ];
+            return [
+              [...components.slice(0, inclusiveComponentEnd), split[0]],
+              [split[1], ...components.slice(inclusiveComponentEnd + 1)],
+            ];
+          }
+        } else {
+          return divideComponents(components, inclusiveComponentEnd);
+        }
+      } else {
+        const items = component.text.split(' ');
+        if (inclusiveContentEnd >= items.length - 1) {
+          return divideComponents(components, inclusiveComponentEnd);
+        } else {
+          const itemSplits = divideTextItems(items, inclusiveContentEnd);
+          const split: [TextItemResponsePageComponent, TextItemResponsePageComponent] = [
+            { ...component, text: itemSplits[0].join(' ') },
+            { ...component, text: itemSplits[1].join(' ') },
+          ];
+          return [
+            [...components.slice(0, inclusiveComponentEnd), split[0]],
+            [split[1], ...components.slice(inclusiveComponentEnd + 1)],
+          ];
+        }
+      }
+    } else {
+      // Line-break items don't have "content". So just divide at components level.
+      return divideComponents(components, inclusiveComponentEnd);
+    }
+  }
+};

--- a/src/entities/activity/ui/items/ActionPlan/pageComponent.ts
+++ b/src/entities/activity/ui/items/ActionPlan/pageComponent.ts
@@ -219,8 +219,8 @@ const divideComponents = (
 ];
 
 const divideTextItems = (items: string[], inclusiveEnd: number): [string[], string[]] => [
-  [...items.slice(0, inclusiveEnd + 1), '...'],
-  ['...', ...items.slice(inclusiveEnd + 1)],
+  [...items.slice(0, inclusiveEnd + 1), '…'],
+  ['…', ...items.slice(inclusiveEnd + 1)],
 ];
 
 export const deepDivideComponents = (

--- a/src/entities/activity/ui/items/ActionPlan/pageRenderer.tsx
+++ b/src/entities/activity/ui/items/ActionPlan/pageRenderer.tsx
@@ -1,0 +1,162 @@
+import React, { ComponentProps } from 'react';
+
+import { PageComponent, PageRenderer } from './Document.type';
+import { Page } from './Page';
+import { deepDivideComponents, getFlatComponentIndices } from './pageComponent';
+
+import measureComponentHeight from '~/shared/utils/measureComponentHeight';
+
+export const pageRenderer =
+  (
+    availableWidth: number,
+    pageProps: Omit<ComponentProps<typeof Page>, 'pageNumber' | 'pageComponents'>,
+  ): PageRenderer =>
+  async (pageNumber, components, flatIndices, inclusivePivot) => {
+    const [renderComponents, restComponents] = deepDivideComponents(
+      components,
+      flatIndices,
+      inclusivePivot,
+    );
+
+    const page = (
+      <Page
+        {...pageProps}
+        key={`page-${pageNumber}`}
+        pageNumber={pageNumber}
+        pageComponents={renderComponents}
+      />
+    );
+
+    const pageHeight = await measureComponentHeight(availableWidth, page);
+
+    return { page, pageHeight, restComponents };
+  };
+
+export const pagesRenderer = (renderPage: PageRenderer, pageMaxHeight: number) => {
+  const renderPages = async (
+    pageNumber: number,
+    components: PageComponent[],
+  ): Promise<React.ReactNode[]> => {
+    // Short-circuit if there is nothing to render.
+    if (components.length <= 0) {
+      return [];
+    }
+
+    // Generate a flattened list of `[component-index, content-index]` tuples from the input
+    // components list. This way, we can perform binary search on the flattened list of tuples,
+    // which is a lot less complicated to do then the alternative, which is to first iterate over
+    // the top level component indices then the nested content indices.
+    const flatIndices = getFlatComponentIndices(components);
+
+    // Binary search has a worst case scenario of `Log2(N)` iterations. So we can use that value
+    // as a loop limiter to prevent infinite loop. This works out to be about 7 per 100 items.
+    // The `x 2` part is just in case I didn't implement the algorithm quite properly, and it
+    // ends up being less efficient.
+    const loopLimit = Math.ceil(Math.log2(flatIndices.length)) * 2;
+
+    let loopCount = 0;
+    /**
+     * Render a page containing a truncated list of components. The truncation point is determine
+     * by the midpoint of the given `range` parameter. This function will recursively use a
+     * binary search algorithm to render a page with the largest possible number of contents.
+     * @param range Use to calculate a midpoint (i.e. the pivot). And the page would render
+     * components and contents up to and including pivot index.
+     * @param prevRange Keep track of the previously used range. This is used during backtracking
+     * to discard a range that caused the page to be too long.
+     * @param isBacktrack Indicates if the function is currently backtracking or not.
+     * Backtracking happens when a page is too short, but the new range caused the page to be
+     * too long. In this case, we'll just have to backtrack and accept the previous range.
+     */
+    const renderTruncatedPage = async (
+      range: [number, number] | null,
+      prevRange: [number, number] | null,
+      isBacktrack: boolean,
+    ): Promise<[React.ReactNode, PageComponent[]]> => {
+      // If the search window is missing (which should only happen during the very first rendering
+      // cycle of a page), then use the entire indices range as the search window.
+      if (range === null) {
+        range = [0, flatIndices.length - 1];
+      }
+
+      // Find the midpoint of the search window, and render a page containing components up to and
+      // including the component at the midpoint index.
+      const pivot = Math.floor(range[0] + (range[1] - range[0]) / 2);
+      const { page, pageHeight, restComponents } = await renderPage(
+        pageNumber,
+        components,
+        flatIndices,
+        pivot,
+      );
+
+      loopCount += 1;
+      if (loopCount > loopLimit) {
+        // *** Loop overflow ***
+        // This condition should in theory never happen, as the loop limiter is greater than the
+        // theoretical upper bound of binary search's worst case scenario iteration count.
+        // But if it does happen for whatever reason, we just have to accept the page as it was
+        // rendered, and move on.
+        return [page, restComponents];
+      }
+
+      if (isBacktrack) {
+        // *** Backtrack Hit ***
+        // This is a special case where regardless of the size of the search window, the page
+        // will be accepted. This can only happen at most once per page. And would happen when
+        // the page was previously rendered as being too small, but was then re-rendered as being
+        // too large.
+        return [page, restComponents];
+      } else {
+        if (range[0] === range[1]) {
+          if (pageHeight <= pageMaxHeight) {
+            // *** Underflow Hit ***
+            // This happens when the page was rendered as smaller than the max size, but the
+            // search window is already too small for further adjustments. In this case, the page
+            // will be accepted as it was rendered.
+            return [page, restComponents];
+          } else {
+            // *** Overflow Hit ***
+            // This happens when the page was rendered as larger than the max size, but the
+            // search window is already too small for further adjustments. In this case, one
+            // additional "backtrack" rendering cycle will happen to re-create and accept the
+            // page with the previously used search window.
+            return await renderTruncatedPage(prevRange, null, true);
+          }
+        } else {
+          if (pageHeight <= pageMaxHeight) {
+            // *** Underflow Retry ***
+            // This happens when the page was rendered as smaller than the max size, and the
+            // search window still has room for adjustment. In this case, a new search widow is
+            // created from the lower half of the current search window to re-render the page to
+            // be larger.
+            let newRange: [number, number] = [pivot, range[1]];
+            if (newRange[1] - newRange[0] <= 1) {
+              // If the current search window is only 1 index apart, then set the new search
+              // window to focus only on the lower bound index.
+              newRange = [newRange[1], newRange[1]];
+            }
+            return await renderTruncatedPage(newRange, range, false);
+          } else {
+            // *** Overflow Retry ***
+            // This happens when the page was rendered as larger than the max size, and this
+            // search window still has room for adjustment. In this case, a new search window is
+            // created from the upper half of the current search window to re-render the page to
+            // be smaller.
+            let newRange: [number, number] = [range[0], pivot];
+            if (newRange[1] - newRange[0] <= 1) {
+              // If the current search window is only 1 index apart, then set the new search
+              // window to focus only on the upper bound index.
+              newRange = [newRange[0], newRange[0]];
+            }
+            return await renderTruncatedPage(newRange, range, false);
+          }
+        }
+      }
+    };
+
+    // Render a page, then recursively render the rest of the pages.
+    const [page, restComponents] = await renderTruncatedPage(null, null, false);
+    const restPages = await renderPages(pageNumber + 1, restComponents);
+    return [page, ...restPages];
+  };
+  return renderPages;
+};

--- a/src/entities/activity/ui/items/ActionPlan/phrasalData.test.ts
+++ b/src/entities/activity/ui/items/ActionPlan/phrasalData.test.ts
@@ -149,6 +149,15 @@ describe('Action Plan', () => {
       expect(data.item).toHaveProperty('context.itemResponseType', 'text');
     });
 
+    it('should extract data from `paragraphText` activity type', () => {
+      const data = extractActivitiesPhrasalData([newTextItem('item', ['oh hai'])]);
+
+      expect(data).toHaveProperty('item');
+      expect(data.item).toHaveProperty('type', 'array');
+      expect(data.item).toHaveProperty('values.0', 'oh hai');
+      expect(data.item).toHaveProperty('context.itemResponseType', 'text');
+    });
+
     it('should extract data from `singleSelect` activity type', () => {
       const data = extractActivitiesPhrasalData([
         newSingleSelectItem('item', ['1'], ['one', 'two', 'three']),

--- a/src/entities/activity/ui/items/ActionPlan/phrasalData.test.ts
+++ b/src/entities/activity/ui/items/ActionPlan/phrasalData.test.ts
@@ -103,7 +103,10 @@ describe('Action Plan', () => {
 
       expect(data).toHaveProperty('item');
       expect(data.item).toHaveProperty('type', 'array');
-      expect(data.item).toHaveProperty('values.0', date.toLocaleTimeString());
+      expect(data.item).toHaveProperty(
+        'values.0',
+        date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+      );
       expect(data.item).toHaveProperty('context.itemResponseType', 'time');
     });
 
@@ -116,8 +119,14 @@ describe('Action Plan', () => {
 
       expect(data).toHaveProperty('item');
       expect(data.item).toHaveProperty('type', 'array');
-      expect(data.item).toHaveProperty('values.0', date1.toLocaleTimeString());
-      expect(data.item).toHaveProperty('values.1', date2.toLocaleTimeString());
+      expect(data.item).toHaveProperty(
+        'values.0',
+        date1.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+      );
+      expect(data.item).toHaveProperty(
+        'values.1',
+        date2.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+      );
       expect(data.item).toHaveProperty('context.itemResponseType', 'timeRange');
     });
 

--- a/src/entities/activity/ui/items/ActionPlan/phrasalData.test.ts
+++ b/src/entities/activity/ui/items/ActionPlan/phrasalData.test.ts
@@ -1,6 +1,7 @@
 import { extractActivitiesPhrasalData } from './phrasalData';
 
 import { ItemRecord } from '~/entities/applet/model';
+import { formatToDtoTime } from '~/shared/utils';
 
 describe('Action Plan', () => {
   describe('extractActivitiesPhrasalData', () => {
@@ -103,10 +104,7 @@ describe('Action Plan', () => {
 
       expect(data).toHaveProperty('item');
       expect(data.item).toHaveProperty('type', 'array');
-      expect(data.item).toHaveProperty(
-        'values.0',
-        date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
-      );
+      expect(data.item).toHaveProperty('values.0', formatToDtoTime(date));
       expect(data.item).toHaveProperty('context.itemResponseType', 'time');
     });
 
@@ -119,14 +117,8 @@ describe('Action Plan', () => {
 
       expect(data).toHaveProperty('item');
       expect(data.item).toHaveProperty('type', 'array');
-      expect(data.item).toHaveProperty(
-        'values.0',
-        date1.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
-      );
-      expect(data.item).toHaveProperty(
-        'values.1',
-        date2.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
-      );
+      expect(data.item).toHaveProperty('values.0', formatToDtoTime(date1));
+      expect(data.item).toHaveProperty('values.1', formatToDtoTime(date2));
       expect(data.item).toHaveProperty('context.itemResponseType', 'timeRange');
     });
 

--- a/src/entities/activity/ui/items/ActionPlan/phrasalData.ts
+++ b/src/entities/activity/ui/items/ActionPlan/phrasalData.ts
@@ -25,8 +25,6 @@ type ActivityPhrasalBaseData<
 
 type ActivityPhrasalArrayFieldData = ActivityPhrasalBaseData<'array', string[]>;
 
-type ActivityPhrasalParagraphFieldData = ActivityPhrasalBaseData<'paragraph', string[]>;
-
 type ActivityPhrasalItemizedArrayValue = Record<number, string[]>;
 
 type ActivityPhrasalIndexedArrayFieldData = ActivityPhrasalBaseData<
@@ -49,8 +47,7 @@ type ActivityPhrasalMatrixFieldData = ActivityPhrasalBaseData<'matrix', Activity
 type ActivityPhrasalData =
   | ActivityPhrasalArrayFieldData
   | ActivityPhrasalIndexedArrayFieldData
-  | ActivityPhrasalMatrixFieldData
-  | ActivityPhrasalParagraphFieldData;
+  | ActivityPhrasalMatrixFieldData;
 
 export type ActivitiesPhrasalData = Record<string, ActivityPhrasalData>;
 
@@ -77,7 +74,7 @@ export const extractActivitiesPhrasalData = (items: ItemRecord[]): ActivitiesPhr
       };
       fieldData = dateFieldData;
     } else if (item.responseType === 'time' || item.responseType === 'timeRange') {
-      const dateFieldData: ActivityPhrasalArrayFieldData = {
+      const timeFieldData: ActivityPhrasalArrayFieldData = {
         type: 'array',
         values: item.answer
           .map((value) => new Date(value))
@@ -85,34 +82,28 @@ export const extractActivitiesPhrasalData = (items: ItemRecord[]): ActivitiesPhr
           .map((value) => formatToDtoTime(value)),
         context: fieldDataContext,
       };
-      fieldData = dateFieldData;
+      fieldData = timeFieldData;
     } else if (
       item.responseType === 'numberSelect' ||
       item.responseType === 'slider' ||
-      item.responseType === 'text'
+      item.responseType === 'text' ||
+      item.responseType === 'paragraphText'
     ) {
-      const dateFieldData: ActivityPhrasalArrayFieldData = {
+      const textFieldData: ActivityPhrasalArrayFieldData = {
         type: 'array',
         values: item.answer.map((value) => `${value || ''}`),
         context: fieldDataContext,
       };
-      fieldData = dateFieldData;
-    } else if (item.responseType === 'paragraphText') {
-      const dateFieldData: ActivityPhrasalParagraphFieldData = {
-        type: 'paragraph',
-        values: item.answer.map((value) => value || ''),
-        context: fieldDataContext,
-      };
-      fieldData = dateFieldData;
+      fieldData = textFieldData;
     } else if (item.responseType === 'singleSelect' || item.responseType === 'multiSelect') {
-      const dateFieldData: ActivityPhrasalArrayFieldData = {
+      const selectFieldData: ActivityPhrasalArrayFieldData = {
         type: 'array',
         values: item.answer
           .map((value) => item.responseValues.options[parseInt(value, 10)]?.text)
           .filter((value) => !!value),
         context: fieldDataContext,
       };
-      fieldData = dateFieldData;
+      fieldData = selectFieldData;
     } else if (item.responseType === 'multiSelectRows') {
       const byRow = item.responseValues.rows.map<ActivityPhrasalIndexedMatrixValue>(
         (row, rowIndex) => {
@@ -143,12 +134,12 @@ export const extractActivitiesPhrasalData = (items: ItemRecord[]): ActivitiesPhr
         },
       );
 
-      const dateFieldData: ActivityPhrasalMatrixFieldData = {
+      const selectFieldData: ActivityPhrasalMatrixFieldData = {
         type: 'matrix',
         values: { byRow, byColumn },
         context: fieldDataContext,
       };
-      fieldData = dateFieldData;
+      fieldData = selectFieldData;
     } else if (item.responseType === 'singleSelectRows') {
       const byRow = item.responseValues.rows.map<ActivityPhrasalIndexedMatrixValue>(
         (row, rowIndex) => {
@@ -171,17 +162,17 @@ export const extractActivitiesPhrasalData = (items: ItemRecord[]): ActivitiesPhr
         },
       );
 
-      const dateFieldData: ActivityPhrasalMatrixFieldData = {
+      const selectFieldData: ActivityPhrasalMatrixFieldData = {
         type: 'matrix',
         values: { byRow, byColumn },
         context: fieldDataContext,
       };
-      fieldData = dateFieldData;
+      fieldData = selectFieldData;
     } else if (item.responseType === 'sliderRows') {
       (fieldDataContext as ActivityPhrasalDataSliderRowContext).maxValues =
         item.responseValues.rows.map(({ maxValue }) => maxValue);
 
-      const dateFieldData: ActivityPhrasalIndexedArrayFieldData = {
+      const sliderRowsFieldData: ActivityPhrasalIndexedArrayFieldData = {
         type: 'indexed-array',
         values: item.answer.reduce((acc, answerValue, answerIndex) => {
           acc[answerIndex] = [`${answerValue || ''}`];
@@ -189,7 +180,7 @@ export const extractActivitiesPhrasalData = (items: ItemRecord[]): ActivitiesPhr
         }, {} as ActivityPhrasalItemizedArrayValue),
         context: fieldDataContext,
       };
-      fieldData = dateFieldData;
+      fieldData = sliderRowsFieldData;
     }
 
     if (fieldData) {

--- a/src/entities/activity/ui/items/ActionPlan/phrasalData.ts
+++ b/src/entities/activity/ui/items/ActionPlan/phrasalData.ts
@@ -2,6 +2,7 @@
 import { phrasalTemplateCompatibleResponseTypes } from '~/abstract/lib/constants';
 import { ActivityItemType } from '~/entities/activity/lib';
 import { ItemRecord } from '~/entities/applet/model';
+import { formatToDtoTime } from '~/shared/utils';
 
 type ActivityPhrasalDataGenericContext = {
   itemResponseType: ActivityItemType;
@@ -81,7 +82,7 @@ export const extractActivitiesPhrasalData = (items: ItemRecord[]): ActivitiesPhr
         values: item.answer
           .map((value) => new Date(value))
           .filter((value) => !!value)
-          .map((value) => value.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })),
+          .map((value) => formatToDtoTime(value)),
         context: fieldDataContext,
       };
       fieldData = dateFieldData;

--- a/src/entities/activity/ui/items/ActionPlan/phrasalData.ts
+++ b/src/entities/activity/ui/items/ActionPlan/phrasalData.ts
@@ -81,7 +81,7 @@ export const extractActivitiesPhrasalData = (items: ItemRecord[]): ActivitiesPhr
         values: item.answer
           .map((value) => new Date(value))
           .filter((value) => !!value)
-          .map((value) => value.toLocaleTimeString()),
+          .map((value) => value.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })),
         context: fieldDataContext,
       };
       fieldData = dateFieldData;

--- a/src/shared/ui/Box/index.tsx
+++ b/src/shared/ui/Box/index.tsx
@@ -12,8 +12,8 @@ import MUIBox, { BoxProps } from '@mui/material/Box';
  * )
  */
 
-const Box = forwardRef<HTMLDivElement, BoxProps>((props: BoxProps) => {
-  return <MUIBox {...props} />;
+const Box = forwardRef<HTMLDivElement, BoxProps>((props, ref) => {
+  return <MUIBox {...props} ref={ref} />;
 });
 
 Box.displayName = 'Box';


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-7861](https://mindlogger.atlassian.net/browse/M2-7861)

This PR updates the Action Plan cards rendering code to implement a binary-searched based truncation algorithm. The algorithm will not only truncate at phrasal field level, but also at phrasal field content level, to ensure each card contains the maximum amount of content. Overflowing contents at the end of a card, and corresponding continuation content at the beginning of the following card, are connected by a set of ellipses.

For a walkthrough of implementation detail, please see this loom recording: https://www.loom.com/share/0f3fd7416f814e769ca1318e2ac13a28

### 📸 Screenshots

**Text Truncation Start**

<img width="664" alt="Screenshot 2024-10-23 at 2 13 01 PM" src="https://github.com/user-attachments/assets/1b6a7e6d-1e6f-41d0-9ddf-de9c90724b9c">

---

**Text Truncation Both Ends**

<img width="647" alt="Screenshot 2024-10-23 at 2 13 04 PM" src="https://github.com/user-attachments/assets/272ad0de-f8e5-4f56-9066-12ca988709ab">

---

**Text Truncation End**

<img width="672" alt="Screenshot 2024-10-23 at 2 15 40 PM" src="https://github.com/user-attachments/assets/1f444505-ca1c-4d05-95a0-9964830a23bd">

---

**List Truncation Start/End **

<img width="640" alt="Screenshot 2024-10-23 at 2 12 34 PM" src="https://github.com/user-attachments/assets/439c5439-7fa0-454b-9e39-9fb8219db3ec">

---

**List Truncation Both Ends**

<img width="643" alt="Screenshot 2024-10-23 at 2 13 15 PM" src="https://github.com/user-attachments/assets/5c85a151-47ee-42b4-be52-1553af7b9639">

---

**List Truncation when Rendered as Sentence**

<img width="657" alt="Screenshot 2024-10-23 at 2 14 34 PM" src="https://github.com/user-attachments/assets/fadc6316-0259-4e5b-bd2c-5e504cbad655">

### 🪤 Peer Testing

> Note: By default, the maximum page height is `2504px`, which is very tall. So for testing, it's easier to run the code locally, then edit the `usePageMaxHeight` function of `src/entities/activity/ui/items/ActionPlan/hooks.tsx`, and make it return a smaller number (i.e. `512`).

1. Create an applet with an activity with a number of items
2. Create a phrasal template item with abundance of content
3. Go through the activity and reach the phrasal template step
4. The Action Plan cards should be truncated

### ✏️ Notes

Although the AC of the ticket only specified truncation of text content, the implementation actually also truncate list items. The reason being: if a list is too long, it should just be truncated anyway. Otherwise, we'll have to deal with all sort of complication around list content overflowing/cut-off, etc. If we REALLY don't want to truncate list items, we can still set a flag in the code to turn that off.