### PR TITLE
feature: paragraph ItemResponseType for phrase builder response options WEB (M2-7762)

### DIFF
--- a/src/abstract/lib/constants.ts
+++ b/src/abstract/lib/constants.ts
@@ -32,4 +32,5 @@ export const phrasalTemplateCompatibleResponseTypes = [
   'multiSelectRows',
   'singleSelectRows',
   'sliderRows',
+  'paragraphText',
 ];

--- a/src/entities/activity/ui/items/ActionPlan/ResponseSegment.tsx
+++ b/src/entities/activity/ui/items/ActionPlan/ResponseSegment.tsx
@@ -72,8 +72,8 @@ export const ResponseSegment = ({ phrasalData, field, isAtStart }: ResponseSegme
     words = isAnswersSkipped(fieldPhrasalData.values)
       ? [t('questionSkipped')]
       : fieldPhrasalData.values
-          .flatMap((value) => value.split(/\r?\n+/))
-          .map((sentence) => sentence.trim());
+          .flatMap((value) => value.split(/\r?\n/)) // Split each paragraph by newlines
+          .map(transformValue);
   } else if (fieldPhrasalDataType === 'indexed-array') {
     const indexedAnswers = fieldPhrasalData.values[field.itemIndex] || [];
     words = isAnswersSkipped(indexedAnswers)

--- a/src/entities/activity/ui/items/ActionPlan/ResponseSegment.tsx
+++ b/src/entities/activity/ui/items/ActionPlan/ResponseSegment.tsx
@@ -65,6 +65,14 @@ export const ResponseSegment = ({ phrasalData, field, isAtStart }: ResponseSegme
     words = isAnswersSkipped(fieldPhrasalData.values)
       ? [t('questionSkipped')]
       : fieldPhrasalData.values.map(transformValue);
+  } else if (fieldPhrasalDataType === 'paragraph') {
+    words = isAnswersSkipped(fieldPhrasalData.values)
+      ? [t('questionSkipped')]
+      : fieldPhrasalData.values
+          .flatMap((value) => value.split(/\r?\n+/)) // Split each paragraph by newlines
+          .map((sentence) => sentence.trim()) // Trim whitespace around each sentence
+          .filter((sentence) => sentence.length > 0) // Filter out any empty strings
+          .map(transformValue); // Transform each sentence individually
   } else if (fieldPhrasalDataType === 'indexed-array') {
     const indexedAnswers = fieldPhrasalData.values[field.itemIndex] || [];
     words = isAnswersSkipped(indexedAnswers)
@@ -118,32 +126,52 @@ export const ResponseSegment = ({ phrasalData, field, isAtStart }: ResponseSegme
 
   return (
     <Text component="span" fontWeight="700" fontSize="inherit" lineHeight="inherit">
-      {fieldDisplayMode === 'bullet_list' ||
-      fieldDisplayMode === 'bullet_list_option_row' ||
-      fieldDisplayMode === 'bullet_list_text_row' ? (
-        <>
-          {isAtStart ? null : (
-            <span>
-              &nbsp;
-              <br />
-            </span>
-          )}
-          <Box
-            component="ul"
-            marginTop={isAtStart ? `0px` : undefined}
-            paddingLeft={`${listPadding}px`}
-          >
-            {words.map((item, index) => (
-              <li key={index}>{item}</li>
-            ))}
-          </Box>
-        </>
-      ) : (
-        <>
-          {isAtStart ? '' : ' '}
-          {joinSentenceWords(words)}
-        </>
-      )}
+      {(() => {
+        if (
+          fieldDisplayMode === 'bullet_list' ||
+          fieldDisplayMode === 'bullet_list_option_row' ||
+          fieldDisplayMode === 'bullet_list_text_row'
+        ) {
+          return (
+            <>
+              {isAtStart ? null : (
+                <span>
+                  &nbsp;
+                  <br />
+                </span>
+              )}
+              <Box
+                component="ul"
+                marginTop={isAtStart ? `0px` : undefined}
+                paddingLeft={`${listPadding}px`}
+              >
+                {words.map((item, index) => (
+                  <li key={index}>{item}</li>
+                ))}
+              </Box>
+            </>
+          );
+        } else if (fieldPhrasalDataType === 'paragraph') {
+          return (
+            <>
+              {isAtStart ? '' : ' '}
+              {words.map((item, index) => (
+                <span key={index}>
+                  {item}
+                  {index < words.length - 1 && <br />}{' '}
+                </span>
+              ))}
+            </>
+          );
+        } else {
+          return (
+            <>
+              {isAtStart ? '' : ' '}
+              {joinSentenceWords(words)}
+            </>
+          );
+        }
+      })()}
     </Text>
   );
 };

--- a/src/entities/activity/ui/items/ActionPlan/phrasalData.ts
+++ b/src/entities/activity/ui/items/ActionPlan/phrasalData.ts
@@ -84,7 +84,8 @@ export const extractActivitiesPhrasalData = (items: ItemRecord[]): ActivitiesPhr
     } else if (
       item.responseType === 'numberSelect' ||
       item.responseType === 'slider' ||
-      item.responseType === 'text'
+      item.responseType === 'text' ||
+      item.responseType === 'paragraphText'
     ) {
       const dateFieldData: ActivityPhrasalArrayFieldData = {
         type: 'array',

--- a/src/entities/activity/ui/items/ActionPlan/phrasalData.ts
+++ b/src/entities/activity/ui/items/ActionPlan/phrasalData.ts
@@ -1,3 +1,4 @@
+/* eslint-disable prettier/prettier */
 import { phrasalTemplateCompatibleResponseTypes } from '~/abstract/lib/constants';
 import { ActivityItemType } from '~/entities/activity/lib';
 import { ItemRecord } from '~/entities/applet/model';
@@ -23,6 +24,8 @@ type ActivityPhrasalBaseData<
 
 type ActivityPhrasalArrayFieldData = ActivityPhrasalBaseData<'array', string[]>;
 
+type ActivityPhrasalParagraphFieldData = ActivityPhrasalBaseData<'paragraph', string[]>;
+
 type ActivityPhrasalItemizedArrayValue = Record<number, string[]>;
 
 type ActivityPhrasalIndexedArrayFieldData = ActivityPhrasalBaseData<
@@ -45,7 +48,8 @@ type ActivityPhrasalMatrixFieldData = ActivityPhrasalBaseData<'matrix', Activity
 type ActivityPhrasalData =
   | ActivityPhrasalArrayFieldData
   | ActivityPhrasalIndexedArrayFieldData
-  | ActivityPhrasalMatrixFieldData;
+  | ActivityPhrasalMatrixFieldData
+  | ActivityPhrasalParagraphFieldData;
 
 export type ActivitiesPhrasalData = Record<string, ActivityPhrasalData>;
 
@@ -84,12 +88,18 @@ export const extractActivitiesPhrasalData = (items: ItemRecord[]): ActivitiesPhr
     } else if (
       item.responseType === 'numberSelect' ||
       item.responseType === 'slider' ||
-      item.responseType === 'text' ||
-      item.responseType === 'paragraphText'
+      item.responseType === 'text'
     ) {
       const dateFieldData: ActivityPhrasalArrayFieldData = {
         type: 'array',
         values: item.answer.map((value) => `${value || ''}`),
+        context: fieldDataContext,
+      };
+      fieldData = dateFieldData;
+    } else if (item.responseType === 'paragraphText') {
+      const dateFieldData: ActivityPhrasalParagraphFieldData = {
+        type: 'paragraph',
+        values: item.answer.map((value) => value || ''),
         context: fieldDataContext,
       };
       fieldData = dateFieldData;


### PR DESCRIPTION
- [ ] Added paragraphText phrasalTemplateCompatibleResponseTypes
- [ ] Assign item.reponseType with value paragraphText to the text-type rendering formatting on the ActionPlan. The entire paragraph should apper between fields of the ActionPlan. 

### 📝 Description
As an Admin, I want to choose the paragraph item type as a response phrase field so that I can include its contents in my Action Plan. By adding paragraph option to the allowed types on validate_phrasal_templates, the backend can store Activities with PhrasalBuilder Items that contain Parragraph items as elements of the PhraseBuilder item. 
 
🔗 [Jira Ticket M2-7762](https://mindlogger.atlassian.net/browse/M2-7762)

Changes include:
- [ ] The entire paragraph should apper between fields of the ActionPlan. 

### 📸 Screenshots

<img width="996" alt="image" src="https://github.com/user-attachments/assets/2cefac3c-5835-4ba5-8c1e-0f2f8fcd36cc">

### 🪤 Peer Testing
* Create an activity
* Create and item  of type parragraph inside your activity
* In the same activity create a new item of type phrase builder
* Phrase builder should allow you to choose the newly created paragraph item inside the “Select Item (Response)” dropdown menu.
* Complete an activity from the web application and validate that the parragraph can be selected on the Phrase Builder section. 
* Invite a user to the new applet/activity
* Logged as a user complete the new applet/activity 
* On the last section of the Activity you will be able to see the new Action Plan with the paragraph inserted between the fields of the PhraseBuilder-ActionPlan-PhrasalTemplate 

