### PR TITLE
chore: Mixpanel Refactor

### DIFF
--- a/src/entities/applet/ui/AppletCard.tsx
+++ b/src/entities/applet/ui/AppletCard.tsx
@@ -3,7 +3,7 @@ import { AppletListItem } from '../lib';
 import ROUTES from '~/shared/constants/routes';
 import { Box } from '~/shared/ui';
 import { CustomCard } from '~/shared/ui';
-import { MixpanelEvents, MixpanelProps, Mixpanel, useCustomNavigation } from '~/shared/utils';
+import { MixpanelEventType, MixpanelProps, Mixpanel, useCustomNavigation } from '~/shared/utils';
 
 type Props = {
   applet: AppletListItem;
@@ -13,7 +13,7 @@ export const AppletCard = ({ applet }: Props) => {
   const navigator = useCustomNavigation();
 
   const onAppletCardClick = () => {
-    Mixpanel.track(MixpanelEvents.AppletClick, { [MixpanelProps.AppletId]: applet.id });
+    Mixpanel.track({ action: MixpanelEventType.AppletClick, [MixpanelProps.AppletId]: applet.id });
     return navigator.navigate(ROUTES.appletDetails.navigateTo(applet.id));
   };
 

--- a/src/entities/user/model/hooks/useOnLogin.ts
+++ b/src/entities/user/model/hooks/useOnLogin.ts
@@ -2,7 +2,13 @@ import { useUserState } from './useUserState';
 import { secureUserPrivateKeyStorage } from '../secureUserPrivateKeyStorage';
 
 import ROUTES from '~/shared/constants/routes';
-import { Mixpanel, secureTokensStorage, useCustomNavigation, useEncryption } from '~/shared/utils';
+import {
+  Mixpanel,
+  MixpanelEventType,
+  secureTokensStorage,
+  useCustomNavigation,
+  useEncryption,
+} from '~/shared/utils';
 import { FeatureFlags } from '~/shared/utils/featureFlags';
 
 type Params = {
@@ -43,7 +49,7 @@ export const useOnLogin = (params: Params) => {
     if (params.backRedirectPath !== undefined) {
       navigate(params.backRedirectPath);
     } else {
-      Mixpanel.track('Login Successful');
+      Mixpanel.track({ action: MixpanelEventType.LoginSuccessful });
       Mixpanel.login(user.id);
 
       navigate(ROUTES.appletList.path);

--- a/src/features/InvitationAccept/ui/InvitationAcceptButton.tsx
+++ b/src/features/InvitationAccept/ui/InvitationAcceptButton.tsx
@@ -3,7 +3,7 @@ import { useAcceptInviteMutation, useInvitationTranslation } from '~/entities/in
 import ROUTES from '~/shared/constants/routes';
 import { Box } from '~/shared/ui';
 import { BaseButton } from '~/shared/ui';
-import { Mixpanel, useCustomNavigation } from '~/shared/utils';
+import { Mixpanel, MixpanelEventType, useCustomNavigation } from '~/shared/utils';
 
 interface InvitationAcceptButtonProps {
   invitationKey: string;
@@ -18,7 +18,7 @@ export const InvitationAcceptButton = ({ invitationKey }: InvitationAcceptButton
   const { mutate: acceptInvite, isLoading: isAcceptLoading } = useAcceptInviteMutation({
     onSuccess() {
       addSuccessBanner(t('invitationAccepted'));
-      Mixpanel.track('Invitation Accepted');
+      Mixpanel.track({ action: MixpanelEventType.InvitationAccepted });
       return navigate(ROUTES.appletList.path);
     },
   });

--- a/src/features/Login/ui/LoginForm.tsx
+++ b/src/features/Login/ui/LoginForm.tsx
@@ -6,9 +6,8 @@ import { LoginSchema, TLoginForm } from '../model/login.schema';
 import { useBanners } from '~/entities/banner/model';
 import { ILoginPayload, useLoginMutation, userModel } from '~/entities/user';
 import { ROUTES, Theme } from '~/shared/constants';
-import { Box, Text } from '~/shared/ui';
-import { BaseButton, BasicFormProvider, Input, PasswordIcon } from '~/shared/ui';
-import { Mixpanel, useCustomForm, usePasswordType } from '~/shared/utils';
+import { BaseButton, BasicFormProvider, Box, Input, PasswordIcon, Text } from '~/shared/ui';
+import { Mixpanel, MixpanelEventType, useCustomForm, usePasswordType } from '~/shared/utils';
 
 interface LoginFormProps {
   locationState?: Record<string, unknown>;
@@ -54,7 +53,7 @@ export const LoginForm = ({ locationState }: LoginFormProps) => {
   };
 
   const onLoginButtonClick = () => {
-    Mixpanel.track('Login Button click');
+    Mixpanel.track({ action: MixpanelEventType.LoginBtnClick });
   };
 
   return (

--- a/src/features/Logout/lib/useLogout.ts
+++ b/src/features/Logout/lib/useLogout.ts
@@ -4,7 +4,12 @@ import { appletModel } from '~/entities/applet';
 import { useLogoutMutation, userModel } from '~/entities/user';
 import { AutoCompletionModel } from '~/features/AutoCompletion';
 import ROUTES from '~/shared/constants/routes';
-import { Mixpanel, secureTokensStorage, useCustomNavigation } from '~/shared/utils';
+import {
+  Mixpanel,
+  MixpanelEventType,
+  secureTokensStorage,
+  useCustomNavigation,
+} from '~/shared/utils';
 import { FeatureFlags } from '~/shared/utils/featureFlags';
 
 type UseLogoutReturn = {
@@ -34,7 +39,7 @@ export const useLogout = (): UseLogoutReturn => {
     secureTokensStorage.clearTokens();
     userModel.secureUserPrivateKeyStorage.clearUserPrivateKey();
 
-    Mixpanel.track('logout');
+    Mixpanel.track({ action: MixpanelEventType.Logout });
     Mixpanel.logout();
     FeatureFlags.logout();
     return navigator.navigate(ROUTES.login.path);

--- a/src/features/PassSurvey/hooks/useStartSurvey.ts
+++ b/src/features/PassSurvey/hooks/useStartSurvey.ts
@@ -3,11 +3,11 @@ import { appletModel } from '~/entities/applet';
 import { AppletBaseDTO } from '~/shared/api';
 import ROUTES from '~/shared/constants/routes';
 import {
-  MixpanelEvents,
-  MixpanelPayload,
+  MixpanelEventType,
   MixpanelProps,
   Mixpanel,
   useCustomNavigation,
+  AssessmentStartedEvent,
 } from '~/shared/utils';
 
 type NavigateToEntityProps = {
@@ -83,25 +83,26 @@ export const useStartSurvey = (props: Props) => {
     targetSubjectId,
     shouldRestart,
   }: OnActivityCardClickProps) {
-    const analyticsPayload: MixpanelPayload = {
+    const event: AssessmentStartedEvent = {
+      action: MixpanelEventType.AssessmentStarted,
       [MixpanelProps.AppletId]: appletId,
       [MixpanelProps.ActivityId]: activityId,
     };
 
     if (flowId) {
-      analyticsPayload[MixpanelProps.ActivityFlowId] = flowId;
+      event[MixpanelProps.ActivityFlowId] = flowId;
     }
 
     if (isInMultiInformantFlow()) {
-      analyticsPayload[MixpanelProps.Feature] = 'Multi-informant';
+      event[MixpanelProps.Feature] = 'Multi-informant';
 
       const { multiInformantAssessmentId } = getMultiInformantState();
       if (multiInformantAssessmentId) {
-        analyticsPayload[MixpanelProps.MultiInformantAssessmentId] = multiInformantAssessmentId;
+        event[MixpanelProps.MultiInformantAssessmentId] = multiInformantAssessmentId;
       }
     }
 
-    Mixpanel.track(MixpanelEvents.AssessmentStarted, analyticsPayload);
+    Mixpanel.track(event);
 
     if (flowId) {
       const flow = flows?.find((x) => x.id === flowId);

--- a/src/features/PrivateJoinAccept/ui/PrivateJoinAcceptButton.tsx
+++ b/src/features/PrivateJoinAccept/ui/PrivateJoinAcceptButton.tsx
@@ -5,7 +5,7 @@ import { useAcceptPrivateInviteMutation, useInvitationTranslation } from '~/enti
 import ROUTES from '~/shared/constants/routes';
 import { Box } from '~/shared/ui';
 import { BaseButton } from '~/shared/ui';
-import { MixpanelEvents, MixpanelProps, Mixpanel } from '~/shared/utils';
+import { MixpanelEventType, MixpanelProps, Mixpanel } from '~/shared/utils';
 
 interface PrivateJoinAcceptButtonProps {
   invitationKey: string;
@@ -23,7 +23,8 @@ export const PrivateJoinAcceptButton = ({
   const { mutate: acceptPrivateInvite, isLoading } = useAcceptPrivateInviteMutation({
     onSuccess() {
       addSuccessBanner(t('invitationAccepted'));
-      Mixpanel.track(MixpanelEvents.InvitationAccepted, {
+      Mixpanel.track({
+        action: MixpanelEventType.InvitationAccepted,
         [MixpanelProps.AppletId]: appletId,
       });
       return navigate(ROUTES.appletList.path);

--- a/src/features/Signup/ui/SignupForm.tsx
+++ b/src/features/Signup/ui/SignupForm.tsx
@@ -15,7 +15,7 @@ import {
   BaseButton,
   Text,
 } from '~/shared/ui';
-import { Mixpanel, useCustomForm, usePasswordType } from '~/shared/utils';
+import { Mixpanel, MixpanelEventType, useCustomForm, usePasswordType } from '~/shared/utils';
 
 interface SignupFormProps {
   locationState?: Record<string, unknown>;
@@ -60,7 +60,7 @@ export const SignupForm = ({ locationState }: SignupFormProps) => {
     onSuccess() {
       removeErrorBanner();
       addSuccessBanner(t('success'));
-      Mixpanel.track('Signup Successful');
+      Mixpanel.track({ action: MixpanelEventType.SignupSuccessful });
       const { email, password } = form.getValues();
 
       return login({ email, password });

--- a/src/features/TakeNow/ui/TakeNowSuccessModal.tsx
+++ b/src/features/TakeNow/ui/TakeNowSuccessModal.tsx
@@ -3,9 +3,9 @@ import { TakeNowSuccessModalProps } from '../lib/types';
 import { MuiModal } from '~/shared/ui';
 import {
   Mixpanel,
-  MixpanelEvents,
-  MixpanelPayload,
+  MixpanelEventType,
   MixpanelProps,
+  ReturnToAdminAppEvent,
   useCustomTranslation,
 } from '~/shared/utils';
 
@@ -21,37 +21,33 @@ export const TakeNowSuccessModal = ({
   const { t } = useCustomTranslation();
 
   const handleReturnToAdminAppClick = () => {
-    const analyticsPayload: MixpanelPayload = {
+    const event: ReturnToAdminAppEvent = {
+      action: MixpanelEventType.ReturnToAdminApp,
       [MixpanelProps.AppletId]: appletId,
       [MixpanelProps.SubmitId]: submitId,
     };
 
     if (activityId) {
-      analyticsPayload[MixpanelProps.ActivityId] = activityId;
+      event[MixpanelProps.ActivityId] = activityId;
     } else if (activityFlowId) {
-      analyticsPayload[MixpanelProps.ActivityFlowId] = activityFlowId;
+      event[MixpanelProps.ActivityFlowId] = activityFlowId;
     }
 
-    analyticsPayload[MixpanelProps.Feature] = 'Multi-informant';
+    event[MixpanelProps.Feature] = 'Multi-informant';
 
     if (multiInformantAssessmentId) {
-      analyticsPayload[MixpanelProps.MultiInformantAssessmentId] = multiInformantAssessmentId;
+      event[MixpanelProps.MultiInformantAssessmentId] = multiInformantAssessmentId;
     }
 
-    Mixpanel.track(
-      MixpanelEvents.ReturnToAdminApp,
-      analyticsPayload,
-      { send_immediately: true },
-      () => {
-        onClose?.();
-        const targetWindow = window.opener as Window;
+    Mixpanel.track(event, { send_immediately: true }, () => {
+      onClose?.();
+      const targetWindow = window.opener as Window;
 
-        if (targetWindow) {
-          // Send message to the opening tab in the Admin App to close this tab (see its TakeNowModal component).
-          targetWindow.postMessage('close-me', import.meta.env.VITE_ADMIN_PANEL_HOST);
-        }
-      },
-    );
+      if (targetWindow) {
+        // Send message to the opening tab in the Admin App to close this tab (see its TakeNowModal component).
+        targetWindow.postMessage('close-me', import.meta.env.VITE_ADMIN_PANEL_HOST);
+      }
+    });
   };
 
   return (

--- a/src/features/TransferOwnershipAccept/ui/TransferOwnershipAccept.tsx
+++ b/src/features/TransferOwnershipAccept/ui/TransferOwnershipAccept.tsx
@@ -4,7 +4,7 @@ import { PageMessage } from '~/shared/ui';
 import Box from '~/shared/ui/Box';
 import Loader from '~/shared/ui/Loader';
 import Text from '~/shared/ui/Text';
-import { MixpanelEvents, MixpanelProps, Mixpanel, useCustomTranslation } from '~/shared/utils';
+import { MixpanelEventType, MixpanelProps, Mixpanel, useCustomTranslation } from '~/shared/utils';
 
 type TransferOwnershipProps = {
   appletId: string;
@@ -20,7 +20,8 @@ export const TransferOwnershipAccept = ({ appletId, keyParam }: TransferOwnershi
     { appletId, key: keyParam },
     {
       onSuccess() {
-        Mixpanel.track(MixpanelEvents.TransferOwnershipAccepted, {
+        Mixpanel.track({
+          action: MixpanelEventType.TransferOwnershipAccepted,
           [MixpanelProps.AppletId]: appletId,
         });
       },

--- a/src/features/TransferOwnershipDecline/ui/TransfetOwnershipDecline.tsx
+++ b/src/features/TransferOwnershipDecline/ui/TransfetOwnershipDecline.tsx
@@ -4,7 +4,7 @@ import { PageMessage } from '~/shared/ui';
 import Box from '~/shared/ui/Box';
 import Loader from '~/shared/ui/Loader';
 import Text from '~/shared/ui/Text';
-import { Mixpanel, useCustomTranslation } from '~/shared/utils';
+import { Mixpanel, MixpanelEventType, useCustomTranslation } from '~/shared/utils';
 
 type TransferOwnershipProps = {
   appletId: string;
@@ -18,7 +18,7 @@ export const TransferOwnershipDecline = ({ appletId, keyParam }: TransferOwnersh
     { appletId, key: keyParam },
     {
       onSuccess() {
-        Mixpanel.track('Transfer Ownership Declined');
+        Mixpanel.track({ action: MixpanelEventType.TransferOwnershipDeclined });
       },
     },
   );

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -7,7 +7,7 @@ import { LoginForm, useLoginTranslation } from '~/features/Login';
 import { ROUTES, Theme } from '~/shared/constants';
 import Box from '~/shared/ui/Box';
 import Text from '~/shared/ui/Text';
-import { Mixpanel, useOnceEffect } from '~/shared/utils';
+import { Mixpanel, MixpanelEventType, useOnceEffect } from '~/shared/utils';
 
 const DownloadMobileLinks = lazy(() => import('~/widgets/DownloadMobileLinks'));
 
@@ -18,7 +18,7 @@ function LoginPage() {
   const { addSuccessBanner } = useBanners();
 
   const onCreateAccountClick = () => {
-    Mixpanel.track('Create account button on login screen click');
+    Mixpanel.track({ action: MixpanelEventType.LoginScreenCreateAccountBtnClick });
   };
 
   useOnceEffect(() => {

--- a/src/shared/utils/analytics/mixpanel.ts
+++ b/src/shared/utils/analytics/mixpanel.ts
@@ -1,6 +1,6 @@
 import mixpanel, { Callback, RequestOptions } from 'mixpanel-browser';
 
-import { MixpanelPayload } from './mixpanel.types';
+import { MixpanelEvent } from './mixpanel.types';
 
 const PROJECT_TOKEN = import.meta.env.VITE_MIXPANEL_TOKEN;
 
@@ -22,14 +22,10 @@ export const Mixpanel = {
   trackPageView(pageName: string) {
     if (shouldEnableMixpanel) mixpanel.track_pageview({ page: `[Web] ${pageName}` });
   },
-  track(
-    action: string,
-    payload?: MixpanelPayload,
-    optionsOrCallback?: RequestOptions | Callback,
-    callback?: Callback,
-  ) {
+  track(event: MixpanelEvent, optionsOrCallback?: RequestOptions | Callback, callback?: Callback) {
     if (shouldEnableMixpanel) {
-      mixpanel.track(`[Web] ${action}`, payload, optionsOrCallback, callback);
+      const { action, ...properties } = event;
+      mixpanel.track(`[Web] ${action}`, properties, optionsOrCallback, callback);
     } else {
       if (typeof optionsOrCallback === 'function') optionsOrCallback(0);
       callback?.(0);

--- a/src/shared/utils/analytics/mixpanel.types.ts
+++ b/src/shared/utils/analytics/mixpanel.types.ts
@@ -7,15 +7,111 @@ export enum MixpanelProps {
   MultiInformantAssessmentId = 'Multi-informant Assessment ID',
 }
 
-export type MixpanelPayload = Partial<Record<MixpanelProps, unknown>>;
+export enum MixpanelEventType {
+  AppletClick = 'Applet click',
+  TransferOwnershipAccepted = 'Transfer Ownership Accepted',
+  AssessmentCompleted = 'Assessment completed',
+  AssessmentStarted = 'Assessment Started',
+  InvitationAccepted = 'Invitation Accepted',
+  ActivityRestarted = 'Activity Restart Button Pressed',
+  ActivityResumed = 'Activity Resume Button Pressed',
+  ReturnToAdminApp = 'Return to Admin App button clicked',
+  LoginSuccessful = 'Login Successful',
+  LoginBtnClick = 'Login Button click',
+  Logout = 'logout',
+  SignupSuccessful = 'Signup Successful',
+  TransferOwnershipDeclined = 'Transfer Ownership Declined',
+  LoginScreenCreateAccountBtnClick = 'Create account button on login screen click',
+}
 
-export const MixpanelEvents = {
-  AppletClick: 'Applet click',
-  TransferOwnershipAccepted: 'Transfer Ownership Accepted',
-  AssessmentCompleted: 'Assessment completed',
-  AssessmentStarted: 'Assessment Started',
-  InvitationAccepted: 'Invitation Accepted',
-  ActivityRestarted: 'Activity Restart Button Pressed',
-  ActivityResumed: 'Activity Resume Button Pressed',
-  ReturnToAdminApp: 'Return to Admin App button clicked',
+type WithAppletId<T> = T & { [MixpanelProps.AppletId]?: string | null };
+
+export type AppletClickEvent = WithAppletId<{
+  action: MixpanelEventType.AppletClick;
+}>;
+
+export type TransferOwnershipAcceptedEvent = WithAppletId<{
+  action: MixpanelEventType.TransferOwnershipAccepted;
+}>;
+
+export type AssessmentCompletedEvent = WithAppletId<{
+  action: MixpanelEventType.AssessmentCompleted;
+  [MixpanelProps.SubmitId]: string;
+  [MixpanelProps.ActivityId]?: string;
+  [MixpanelProps.ActivityFlowId]?: string;
+  [MixpanelProps.Feature]?: 'Multi-informant';
+  [MixpanelProps.MultiInformantAssessmentId]?: string;
+}>;
+
+export type AssessmentStartedEvent = WithAppletId<{
+  action: MixpanelEventType.AssessmentStarted;
+  [MixpanelProps.ActivityId]?: string;
+  [MixpanelProps.ActivityFlowId]?: string;
+  [MixpanelProps.Feature]?: 'Multi-informant';
+  [MixpanelProps.MultiInformantAssessmentId]?: string;
+}>;
+
+export type InvitationAcceptedEvent = WithAppletId<{
+  action: MixpanelEventType.InvitationAccepted;
+}>;
+
+export type ActivityRestartedEvent = WithAppletId<{
+  action: MixpanelEventType.ActivityRestarted;
+  [MixpanelProps.ActivityId]?: string;
+  [MixpanelProps.ActivityFlowId]?: string | null;
+}>;
+
+export type ActivityResumedEvent = WithAppletId<{
+  action: MixpanelEventType.ActivityResumed;
+  [MixpanelProps.ActivityId]?: string;
+  [MixpanelProps.ActivityFlowId]?: string | null;
+}>;
+
+export type ReturnToAdminAppEvent = WithAppletId<{
+  action: MixpanelEventType.ReturnToAdminApp;
+  [MixpanelProps.SubmitId]?: string | null;
+  [MixpanelProps.ActivityId]?: string;
+  [MixpanelProps.ActivityFlowId]?: string;
+  [MixpanelProps.Feature]?: 'Multi-informant';
+  [MixpanelProps.MultiInformantAssessmentId]?: string;
+}>;
+
+export type LoginSuccessfulEvent = {
+  action: MixpanelEventType.LoginSuccessful;
 };
+
+export type LoginBtnClickEvent = {
+  action: MixpanelEventType.LoginBtnClick;
+};
+
+export type LogoutEvent = {
+  action: MixpanelEventType.Logout;
+};
+
+export type SignupSuccessfulEvent = {
+  action: MixpanelEventType.SignupSuccessful;
+};
+
+export type TransferOwnershipDeclinedEvent = {
+  action: MixpanelEventType.TransferOwnershipDeclined;
+};
+
+export type LoginScreenCreateAccountBtnClickEvent = {
+  action: MixpanelEventType.LoginScreenCreateAccountBtnClick;
+};
+
+export type MixpanelEvent =
+  | AppletClickEvent
+  | TransferOwnershipAcceptedEvent
+  | AssessmentCompletedEvent
+  | AssessmentStartedEvent
+  | InvitationAcceptedEvent
+  | ActivityRestartedEvent
+  | ActivityResumedEvent
+  | ReturnToAdminAppEvent
+  | LoginSuccessfulEvent
+  | LoginBtnClickEvent
+  | LogoutEvent
+  | SignupSuccessfulEvent
+  | TransferOwnershipDeclinedEvent
+  | LoginScreenCreateAccountBtnClickEvent;

--- a/src/widgets/ActivityGroups/ui/ActivityCard/index.tsx
+++ b/src/widgets/ActivityGroups/ui/ActivityCard/index.tsx
@@ -18,12 +18,13 @@ import { useAutoCompletionRecord } from '~/features/AutoCompletion/model';
 import { useStartSurvey } from '~/features/PassSurvey';
 import Box from '~/shared/ui/Box';
 import {
-  MixpanelEvents,
+  MixpanelEventType,
   Mixpanel,
   MixpanelProps,
   useAppSelector,
   useCustomMediaQuery,
-  MixpanelPayload,
+  ActivityRestartedEvent,
+  ActivityResumedEvent,
 } from '~/shared/utils';
 import { TargetSubjectLabel } from '~/widgets/TargetSubjectLabel';
 
@@ -114,31 +115,33 @@ export const ActivityCard = ({ activityListItem }: Props) => {
   const restartActivity = () => {
     onStartActivity(true);
 
-    const analyticsPayload: MixpanelPayload = {
+    const event: ActivityRestartedEvent = {
+      action: MixpanelEventType.ActivityRestarted,
       [MixpanelProps.AppletId]: context.applet.id,
       [MixpanelProps.ActivityId]: activityListItem.activityId,
     };
 
     if (isFlow) {
-      analyticsPayload[MixpanelProps.ActivityFlowId] = activityListItem.flowId;
+      event[MixpanelProps.ActivityFlowId] = activityListItem.flowId;
     }
 
-    Mixpanel.track(MixpanelEvents.ActivityRestarted, analyticsPayload);
+    Mixpanel.track(event);
   };
 
   const resumeActivity = () => {
     onStartActivity(false);
 
-    const analyticsPayload: MixpanelPayload = {
+    const event: ActivityResumedEvent = {
+      action: MixpanelEventType.ActivityResumed,
       [MixpanelProps.AppletId]: context.applet.id,
       [MixpanelProps.ActivityId]: activityListItem.activityId,
     };
 
     if (isFlow) {
-      analyticsPayload[MixpanelProps.ActivityFlowId] = activityListItem.flowId;
+      event[MixpanelProps.ActivityFlowId] = activityListItem.flowId;
     }
 
-    Mixpanel.track(MixpanelEvents.ActivityResumed, analyticsPayload);
+    Mixpanel.track(event);
   };
 
   return (


### PR DESCRIPTION
### 📝 Description

This PR modifies the way events are tracked with Mixpanel to match a [similar change](https://github.com/ChildMindInstitute/mindlogger-admin/pull/1959) in the admin repo. There is now a central place to define events and their properties so that we can conveniently see which properties are included in each event, and where they are used.

Now in order to track a new event, you first define it in the event type in the `MixpanelEventType` enum

```typescript
export enum MixpanelEventType {
  UpgradeToFullAccountClicked = 'Upgrade to Full Account clicked',
}
```

Then define any extra properties it will need in the `MixpanelProps` enum

```typescript
export enum MixpanelProps {
  Via = 'Via',
}
```

Then finally define the event type and add it to the `MixpanelEvent` type union

```typescript
export type UpgradeToFullAccountClickedEvent = WithAppletId<{
  action: MixpanelEventType.UpgradeToFullAccountClicked;
  [MixpanelProps.Via]: 'Applet - Participants';
}>;

export type MixpanelEvent =
  | MixpanelInvitationSentEvent
  | LoginSuccessfulEvent
  | LoginBtnClickEvent
  // ...
  UpgradeToFullAccountClickedEvent;
```

> [!TIP]
> Wrapping the type in `WithAppletId` adds an optional `Applet ID` property to the event

### 📸 Screenshots

N/A

### 🪤 Peer Testing

Read the code I guess 🤷

### ✏️ Notes

N/A