### PR TITLE
fix: Hide one-time completion self-report assessments after complete (M2-8164, M2-8026)

### DIFF
--- a/src/entities/activity/lib/hooks/useTextVariablesReplacer.ts
+++ b/src/entities/activity/lib/hooks/useTextVariablesReplacer.ts
@@ -19,7 +19,7 @@ export const useTextVariablesReplacer = ({
 }: Props) => {
   const replaceTextVariables = (text: string) => {
     if (items && answers) {
-      const nickname = respondentMeta?.nickname;
+      const nickname = respondentMeta?.nickname ?? '';
 
       const replacer = new MarkdownVariableReplacer(items, answers, completedEntityTime, nickname);
       return replacer.process(text);

--- a/src/shared/api/types/applet.ts
+++ b/src/shared/api/types/applet.ts
@@ -17,7 +17,11 @@ export type GetPublicAppletActivityByIdPayload = {
   activityId: string;
 };
 
-export type RespondentMetaDTO = { nickname: string };
+export type RespondentMetaDTO = {
+  subjectId: string | null;
+  nickname: string | null;
+  tag: string | null;
+};
 
 // API Responses - Success
 export type AppletListSuccessResponse = BaseSuccessListResponse<AppletListDTO>;
@@ -66,6 +70,7 @@ export type AppletBaseDTO = {
   activityFlows: Array<ActivityFlowDTO>;
   encryption: EncryptionDTO | null;
   integrations?: Integration[];
+  respondentMeta?: RespondentMetaDTO;
 };
 
 export type ActivityBaseDTO = {

--- a/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.ts
+++ b/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.ts
@@ -16,11 +16,8 @@ export const useEntitiesSync = ({ completedEntities }: FilterCompletedEntitiesPr
 
   const syncEntity = useCallback(
     (entity: CompletedEntityDTO) => {
-      const hoursMinutes = entity.localEndTime.split(':');
-      const endAtDate = new Date(entity.localEndDate).setHours(
-        Number(hoursMinutes[0]),
-        Number(hoursMinutes[1]),
-      );
+      const endAtDate = new Date(`${entity.localEndDate}T${entity.localEndTime}`);
+      const endAtTimestamp = endAtDate.getTime();
 
       const entityId = entity.id;
       const eventId = entity.scheduledEventId;
@@ -42,7 +39,7 @@ export const useEntitiesSync = ({ completedEntities }: FilterCompletedEntitiesPr
           progressPayload: {
             type: ActivityPipelineType.Regular,
             startAt: null,
-            endAt: new Date(endAtDate).getTime(),
+            endAt: endAtTimestamp,
             context: {
               summaryData: {},
             },
@@ -51,7 +48,7 @@ export const useEntitiesSync = ({ completedEntities }: FilterCompletedEntitiesPr
       }
 
       if (groupProgress.endAt) {
-        const isServerEndAtBigger = endAtDate > new Date(groupProgress.endAt).getTime();
+        const isServerEndAtBigger = endAtTimestamp > new Date(groupProgress.endAt).getTime();
 
         if (!isServerEndAtBigger) {
           return;
@@ -63,7 +60,7 @@ export const useEntitiesSync = ({ completedEntities }: FilterCompletedEntitiesPr
           targetSubjectId,
           progressPayload: {
             ...groupProgress,
-            endAt: new Date(endAtDate).getTime(),
+            endAt: endAtTimestamp,
           },
         });
       }


### PR DESCRIPTION
### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-8164](https://mindlogger.atlassian.net/browse/M2-8164)
🔗 [Jira Ticket M2-8026](https://mindlogger.atlassian.net/browse/M2-8026)

In the web app, self-report assessments are identified and tracked using `targetSubjectId === null`. However, for past submissions, the BE returns the raw value of `targetSubjectId`, which is the subject ID of the respondent. These submissions needed to be normalized to have their `targetSubjectId` set to `null`. But for the web app to know which submissions are self-reports, we needed to find out what the subject ID of the respondent (currently logged in user) is for the current applet.

This entailed adding a new `respondentMeta` property to the applet `base_info` endpoint on the BE (https://github.com/ChildMindInstitute/mindlogger-backend-refactor/pull/1646), which is the endpoint the web app is already using to fetch the basic info for the applet to render the main activities/flows list. Now this value is available to the Web App to perform the needed equality comparison against `targetSubjectId`, and normalize it to `null` accordingly.

> [!NOTE]
> ~~To test this, you need to use the Web App connected to [this PR](https://github.com/ChildMindInstitute/mindlogger-backend-refactor/pull/1646)'s branch of the BE repo.~~ This is now been merged, so no special steps are needed here.

### 🪤 Peer Testing

#### Preconditions:

1. Set up an applet with an activity that is either auto-assigned, or has a manual self-report assignment.
2. Set up the schedule for that activity to be one-time completion, or on a daily schedule.

#### Steps (M2-8164):
1. Log into the Web App as a participant that is eligible to perform a self-report on that activity.
2. Complete the self-report assessment for that activity and observe the list of activities upon completion.
    **Expected outcome:** The self-report assignment should no longer be present in the list.

#### Steps (M2-8026):
1. Log into the Mobile App as a participant that is eligible to perform a self-report on that activity.
2. Complete the self-report assessment for that activity.
3. Log into the Web App as that participant.
4. Navigate to the applet and observe the list of activities upon completion.
    **Expected outcome:** The self-report assignment should not be present in the list.