### PR TITLE
fix: The "Return to Admin App" button is not working when starting the activity/flow using "Take Now" (M2-8219)

### DIFF
--- a/src/features/TakeNow/ui/TakeNowSuccessModal.tsx
+++ b/src/features/TakeNow/ui/TakeNowSuccessModal.tsx
@@ -2,7 +2,6 @@ import { useContext } from 'react';
 
 import { TakeNowSuccessModalProps } from '../lib/types';
 
-import { SurveyContext } from '~/features/PassSurvey';
 import { MuiModal } from '~/shared/ui';
 import {
   addFeatureToEvent,
@@ -13,6 +12,7 @@ import {
   ReturnToAdminAppEvent,
   useCustomTranslation,
 } from '~/shared/utils';
+import { AppletDetailsContext } from '~/widgets/ActivityGroups/lib';
 
 export const TakeNowSuccessModal = ({
   isOpen,
@@ -23,7 +23,7 @@ export const TakeNowSuccessModal = ({
   submitId,
 }: TakeNowSuccessModalProps) => {
   const { t } = useCustomTranslation();
-  const { applet } = useContext(SurveyContext);
+  const { applet } = useContext(AppletDetailsContext);
 
   const handleReturnToAdminAppClick = () => {
     const event: ReturnToAdminAppEvent = {


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-8219](https://mindlogger.atlassian.net/browse/M2-8219)

This ticket fixes an incorrect context access that resulted in an undefined dereference (`applet.id`)

### 📸 Screenshots

#### Before

https://github.com/user-attachments/assets/c9c6c1cd-496f-401b-943b-f210d6a63a8d

#### After

https://github.com/user-attachments/assets/6659d01c-5475-448d-8e4e-5ece94abb4a7

### 🪤 Peer Testing

1. Perform a take now assessment and click the return to admin app button
2. Confirm that the tab is closed

### ✏️ Notes

N/A
