### PR TITLE
chore: Include extra data in call to JIRA webhook

### DIFF
--- a/.github/workflows/update-jira-tickets.yaml
+++ b/.github/workflows/update-jira-tickets.yaml
@@ -103,6 +103,8 @@ jobs:
           echo "tickets=${jiraTickets}" >> $GITHUB_OUTPUT
 
       - name: Periodically ping Jenkins for current tag build status
+        env:
+          REPO_URL: "${{ github.server_url }}/${{ github.repository }}"
         run: |
           repoName=${GITHUB_REPOSITORY##*/}
           currentTag="${{ steps.get-tag.outputs.tag }}"
@@ -124,7 +126,7 @@ jobs:
             if [[ "$result" == "SUCCESS" ]]; then
               echo "Build successful! Submitting ticket numbers to Jira"
               tickets="${{ steps.jira-tickets.outputs.tickets }}"
-              json="{ \"issues\": $(echo "${tickets}" | jq -R -s -c 'split(" ")[:-1]') }"
+              json="{ \"issues\": $(echo "${tickets}" | jq -R -s -c 'split(" ")[:-1]'), \"data\": { \"tag\": \"${currentTag}\", \"repository\": \"${REPO_URL}\" } }"
               curl -X POST -H 'Content-Type: application/json' --url "${JIRA_WEBHOOK_URL}" --data "$json"
               break
             elif [[ "$result" != "null" ]]; then


### PR DESCRIPTION
### 📝 Description

Whenever a release candidate deployment happens from this repository, a GitHub Actions workflow attempts to process the tickets it contains, and consumes a Jira webhook that triggers an automation to move those tickets into the "To Be Tested" column. I recently updated that automation to also leave a comment on the ticket when the deployment happens

<img width="307" alt="image" src="https://github.com/user-attachments/assets/911bf35f-a438-486e-82d0-d192ed8525e7">

This PR adds more details to the webhook call so that the comment may include more details about the deployment. These details are:
- The release candidate tag
- The repository URL

Once merged here and in the other repositories, I'll update the automation to include these details.

### 📸 Screenshots

N/A

### 🪤 Peer Testing

Due to the external dependency on Jenkins, we won't be able to properlu test this before merging. Please review the code change carefully

### ✏️ Notes

N/A