### PR TITLE
fix: Action Plan matrix item type render bugs (M2-8348)

### DIFF
--- a/src/entities/activity/ui/items/ActionPlan/pageComponent.ts
+++ b/src/entities/activity/ui/items/ActionPlan/pageComponent.ts
@@ -100,44 +100,21 @@ export const buildPageComponents = (
               ? [t('questionSkipped')]
               : indexedAnswers.map(transformValue);
           } else if (fieldPhrasalDataType === 'matrix') {
-            // The admin UI actually allows matrix type items to have `sentence` as
-            // their display mode. So in this case, we're just going to assume the
-            // effective render order for the values to be "by row".
-            let renderByRowValues = true;
-            if (
-              field.displayMode === 'sentence_option_row' ||
-              field.displayMode === 'bullet_list_option_row'
-            ) {
-              renderByRowValues = false;
-            } else if (
+            const rowFirst =
               field.displayMode === 'sentence_row_option' ||
-              field.displayMode === 'bullet_list_text_row'
-            ) {
-              renderByRowValues = true;
+              field.displayMode === 'bullet_list_text_row';
+
+            valueItems = [];
+            for (const { rowLabel, columnLabels } of fieldPhrasalData.values) {
+              for (const columnLabel of columnLabels) {
+                valueItems.push(
+                  rowFirst ? `${rowLabel} ${columnLabel}` : `${columnLabel} ${rowLabel}`,
+                );
+              }
             }
 
-            if (renderByRowValues) {
-              valueItems = fieldPhrasalData.values.byRow
-                .map(({ label, values }) => {
-                  const transformedValues = isAnswersSkipped(values)
-                    ? [t('questionSkipped')]
-                    : values.map(transformValue);
-                  return transformedValues.map(
-                    (transformedValue) => `${label} ${transformedValue}`,
-                  );
-                })
-                .flat();
-            } else {
-              valueItems = fieldPhrasalData.values.byColumn
-                .map(({ label, values }) => {
-                  const transformedValues = isAnswersSkipped(values)
-                    ? [t('questionSkipped')]
-                    : values.map(transformValue);
-                  return transformedValues.map(
-                    (transformedValue) => `${label} ${transformedValue}`,
-                  );
-                })
-                .flat();
+            if (isAnswersSkipped(valueItems)) {
+              valueItems = [t('questionSkipped')];
             }
           } else {
             // This also shouldn't happen. But including a `else` here allows all

--- a/src/entities/activity/ui/items/ActionPlan/pageComponent.ts
+++ b/src/entities/activity/ui/items/ActionPlan/pageComponent.ts
@@ -13,7 +13,11 @@ import {
   SentencePageComponent,
   TextItemResponsePageComponent,
 } from './Document.type';
-import { ActivitiesPhrasalData, ActivityPhrasalDataSliderRowContext } from './phrasalData';
+import {
+  ActivitiesPhrasalData,
+  ActivityPhrasalDataSliderContext,
+  ActivityPhrasalDataSliderRowContext,
+} from './phrasalData';
 
 const isAnswersSkipped = (answers: string[]): boolean => {
   if (!answers || answers.length <= 0) {
@@ -32,13 +36,12 @@ const isAnswersSkipped = (answers: string[]): boolean => {
 
 const identity: FieldValueTransformer = (value) => value;
 const sliderValueTransformer =
-  (
-    t: TFunction,
-    ctx: ActivityPhrasalDataSliderRowContext,
-    itemIndex: number,
-  ): FieldValueTransformer =>
+  (t: TFunction, maxValue: number): FieldValueTransformer =>
   (value) =>
-    t('sliderValue', { value, total: ctx.maxValues[itemIndex] });
+    t('sliderValue', {
+      value,
+      total: maxValue,
+    });
 
 const joinWithComma: FieldValueItemsJoiner = (values) => values.join(', ');
 const joinWithDash: FieldValueItemsJoiner = (values) => values.join(' - ');
@@ -79,11 +82,17 @@ export const buildPageComponents = (
         if (fieldPhrasalData) {
           let transformValue = identity;
           let joinValueItems = joinWithComma;
-          if (fieldPhrasalData.context.itemResponseType === 'sliderRows') {
+          if (fieldPhrasalData.context.itemResponseType === 'slider') {
             transformValue = sliderValueTransformer(
               t,
-              fieldPhrasalData.context as ActivityPhrasalDataSliderRowContext,
-              field.itemIndex,
+              (fieldPhrasalData.context as ActivityPhrasalDataSliderContext).maxValue,
+            );
+          } else if (fieldPhrasalData.context.itemResponseType === 'sliderRows') {
+            transformValue = sliderValueTransformer(
+              t,
+              (fieldPhrasalData.context as ActivityPhrasalDataSliderRowContext).maxValues[
+                field.itemIndex
+              ],
             );
           } else if (fieldPhrasalData.context.itemResponseType === 'timeRange') {
             joinValueItems = joinWithDash;

--- a/src/entities/activity/ui/items/ActionPlan/phrasalData.test.ts
+++ b/src/entities/activity/ui/items/ActionPlan/phrasalData.test.ts
@@ -27,7 +27,6 @@ describe('Action Plan', () => {
     const newTimeItem = newSimpleItem('time');
     const newTimeRangeItem = newSimpleItem('timeRange');
     const newNumberSelectItem = newSimpleItem<number>('numberSelect');
-    const newSliderItem = newSimpleItem('slider');
     const newTextItem = newSimpleItem('text');
 
     const newSelectItem = (type: string) => (name: string, answer: string[], options: string[]) =>
@@ -70,6 +69,14 @@ describe('Action Plan', () => {
           rows: options[0].map((option) => ({ rowName: option })),
           options: options[1].map((option, index) => ({ id: `col:${index}`, text: option })),
         },
+        answer,
+      }) as never as ItemRecord;
+
+    const newSliderItem = (name: string, answer: string[], maxValue: number) =>
+      ({
+        name,
+        responseType: 'slider',
+        responseValues: { maxValue },
         answer,
       }) as never as ItemRecord;
 
@@ -132,12 +139,13 @@ describe('Action Plan', () => {
     });
 
     it('should extract data from `slider` activity type', () => {
-      const data = extractActivitiesPhrasalData([newSliderItem('item', ['6'])]);
+      const data = extractActivitiesPhrasalData([newSliderItem('item', ['6'], 10)]);
 
       expect(data).toHaveProperty('item');
       expect(data.item).toHaveProperty('type', 'array');
       expect(data.item).toHaveProperty('values.0', '6');
       expect(data.item).toHaveProperty('context.itemResponseType', 'slider');
+      expect(data.item).toHaveProperty('context.maxValue', 10);
     });
 
     it('should extract data from `text` activity type', () => {

--- a/src/entities/activity/ui/items/ActionPlan/phrasalData.test.ts
+++ b/src/entities/activity/ui/items/ActionPlan/phrasalData.test.ts
@@ -53,14 +53,14 @@ describe('Action Plan', () => {
         responseType: 'multiSelectRows',
         responseValues: {
           rows: options[0].map((option) => ({ rowName: option })),
-          options: options[1].map((option) => ({ text: option })),
+          options: options[1].map((option, index) => ({ id: `col:${index}`, text: option })),
         },
         answer,
       }) as never as ItemRecord;
 
     const newSingleSelectRowsItem = (
       name: string,
-      answer: string[],
+      answer: (string | null)[],
       options: [string[], string[]],
     ) =>
       ({
@@ -199,22 +199,12 @@ describe('Action Plan', () => {
 
       expect(data).toHaveProperty('item');
       expect(data.item).toHaveProperty('type', 'matrix');
-      expect(data.item).toHaveProperty('values.byRow.0.label', 'R1');
-      expect(data.item).toHaveProperty('values.byRow.0.values.0', 'C1');
-      expect(data.item).toHaveProperty('values.byRow.0.values.1', 'C2');
-      expect(data.item).toHaveProperty('values.byRow.1.label', 'R2');
-      expect(data.item).toHaveProperty('values.byRow.1.values.0', 'C2');
-      expect(data.item).toHaveProperty('values.byRow.2.label', 'R3');
-      expect(data.item).toHaveProperty('values.byRow.2.values.0', 'C2');
-      expect(data.item).toHaveProperty('values.byRow.2.values.1', 'C3');
-      expect(data.item).toHaveProperty('values.byColumn.0.label', 'C1');
-      expect(data.item).toHaveProperty('values.byColumn.0.values.0', 'R1');
-      expect(data.item).toHaveProperty('values.byColumn.1.label', 'C2');
-      expect(data.item).toHaveProperty('values.byColumn.1.values.0', 'R1');
-      expect(data.item).toHaveProperty('values.byColumn.1.values.1', 'R2');
-      expect(data.item).toHaveProperty('values.byColumn.1.values.2', 'R3');
-      expect(data.item).toHaveProperty('values.byColumn.2.label', 'C3');
-      expect(data.item).toHaveProperty('values.byColumn.2.values.0', 'R3');
+      expect(data.item).toHaveProperty('values.0.rowLabel', 'R1');
+      expect(data.item).toHaveProperty('values.0.columnLabels', ['C1', 'C2']);
+      expect(data.item).toHaveProperty('values.1.rowLabel', 'R2');
+      expect(data.item).toHaveProperty('values.1.columnLabels', ['C2']);
+      expect(data.item).toHaveProperty('values.2.rowLabel', 'R3');
+      expect(data.item).toHaveProperty('values.2.columnLabels', ['C2', 'C3']);
       expect(data.item).toHaveProperty('context.itemResponseType', 'multiSelectRows');
     });
 
@@ -232,18 +222,12 @@ describe('Action Plan', () => {
 
       expect(data).toHaveProperty('item');
       expect(data.item).toHaveProperty('type', 'matrix');
-      expect(data.item).toHaveProperty('values.byRow.0.label', 'R1');
-      expect(data.item).toHaveProperty('values.byRow.0.values.0', 'C3');
-      expect(data.item).toHaveProperty('values.byRow.1.label', 'R2');
-      expect(data.item).toHaveProperty('values.byRow.1.values.0', 'C1');
-      expect(data.item).toHaveProperty('values.byRow.2.label', 'R3');
-      expect(data.item).toHaveProperty('values.byRow.2.values.0', 'C2');
-      expect(data.item).toHaveProperty('values.byColumn.0.label', 'C1');
-      expect(data.item).toHaveProperty('values.byColumn.0.values.0', 'R2');
-      expect(data.item).toHaveProperty('values.byColumn.1.label', 'C2');
-      expect(data.item).toHaveProperty('values.byColumn.1.values.0', 'R3');
-      expect(data.item).toHaveProperty('values.byColumn.2.label', 'C3');
-      expect(data.item).toHaveProperty('values.byColumn.2.values.0', 'R1');
+      expect(data.item).toHaveProperty('values.0.rowLabel', 'R1');
+      expect(data.item).toHaveProperty('values.0.columnLabels', ['C3']);
+      expect(data.item).toHaveProperty('values.1.rowLabel', 'R2');
+      expect(data.item).toHaveProperty('values.1.columnLabels', ['C1']);
+      expect(data.item).toHaveProperty('values.2.rowLabel', 'R3');
+      expect(data.item).toHaveProperty('values.2.columnLabels', ['C2']);
       expect(data.item).toHaveProperty('context.itemResponseType', 'singleSelectRows');
     });
 

--- a/src/entities/activity/ui/items/ActionPlan/phrasalData.ts
+++ b/src/entities/activity/ui/items/ActionPlan/phrasalData.ts
@@ -8,6 +8,11 @@ type ActivityPhrasalDataGenericContext = {
   itemResponseType: ActivityItemType;
 };
 
+export type ActivityPhrasalDataSliderContext = ActivityPhrasalDataGenericContext & {
+  itemResponseType: 'slider';
+  maxValue: number;
+};
+
 export type ActivityPhrasalDataSliderRowContext = ActivityPhrasalDataGenericContext & {
   itemResponseType: 'sliderRows';
   maxValues: number[];
@@ -82,13 +87,12 @@ export const extractActivitiesPhrasalData = (items: ItemRecord[]): ActivitiesPhr
       fieldData = timeFieldData;
     } else if (
       item.responseType === 'numberSelect' ||
-      item.responseType === 'slider' ||
       item.responseType === 'text' ||
       item.responseType === 'paragraphText'
     ) {
       const textFieldData: ActivityPhrasalArrayFieldData = {
         type: 'array',
-        values: item.answer.map((value) => `${value || ''}`),
+        values: item.answer.map((value) => `${value ?? ''}`),
         context: fieldDataContext,
       };
       fieldData = textFieldData;
@@ -139,6 +143,16 @@ export const extractActivitiesPhrasalData = (items: ItemRecord[]): ActivitiesPhr
         context: fieldDataContext,
       };
       fieldData = matrixFieldData;
+    } else if (item.responseType === 'slider') {
+      (fieldDataContext as ActivityPhrasalDataSliderContext).maxValue =
+        item.responseValues.maxValue;
+
+      const sliderFieldData: ActivityPhrasalArrayFieldData = {
+        type: 'array',
+        values: item.answer.map((value) => `${value ?? ''}`),
+        context: fieldDataContext,
+      };
+      fieldData = sliderFieldData;
     } else if (item.responseType === 'sliderRows') {
       (fieldDataContext as ActivityPhrasalDataSliderRowContext).maxValues =
         item.responseValues.rows.map(({ maxValue }) => maxValue);
@@ -146,7 +160,7 @@ export const extractActivitiesPhrasalData = (items: ItemRecord[]): ActivitiesPhr
       const sliderRowsFieldData: ActivityPhrasalIndexedArrayFieldData = {
         type: 'indexed-array',
         values: item.answer.reduce((acc, answerValue, answerIndex) => {
-          acc[answerIndex] = [`${answerValue || ''}`];
+          acc[answerIndex] = [`${answerValue ?? ''}`];
           return acc;
         }, {} as ActivityPhrasalItemizedArrayValue),
         context: fieldDataContext,


### PR DESCRIPTION
- [x] Tests for the changes have been added

### 📝 Description

🔗 [Jira Ticket M2-8348](https://mindlogger.atlassian.net/browse/M2-8348)

Simplified and fixed logic for generating response text for matrix item types (Single Selection per Row, Multiple Selection per Row). Aligned behaviour with Figma (see 4 examples shown in [this row](https://www.figma.com/design/3wcZ6bxK2QVo733ADxVjBw/SSI-2024?node-id=731-105259&t=M6XInWl55yDqUTtT-4)). Specifically:

- Simply omit data from rows/columns where no selection was made, rather than display "skipped" text
- The order of responses shouldn't change based on the format picked from the dropdown – responses should always be output by column left to right, then by row top to bottom. The only thing that changes based on the format selection is whether to output each response as `columnLabel rowLabel` vs. `rowLabel columnLabel` (and whether to display as bullets or sentences – although that aspect wasn't touched in this PR).

### 📸 Screenshots

https://github.com/user-attachments/assets/c0f96b6d-e0f6-4c8e-9bb7-5b369c6b9eb8

### 🪤 Peer Testing

**Setup:**
- Applet with an activity containing a Single Selection per Row item, a Multiple Selection per Row Item, and a Phrase Builder referencing those items
- Ensure each matrix item contain multiple rows and columns, and that they are skippable

**Steps:**
1. Open the web app and start the activity.
2. For each matrix item type, answer at least one row but leave some rows unanswered.
3. Proceed to the Action Plan.
    **Expected outcome:** Rows for which there are no answers do not display "(Question skipped)"
4. Go back and adjust your responses so that multiple items are selected in a row (for the Multiple Selection per Row item) and multiple rows have the same column selected (for the Single Selection per Row item).
5. Proceed to the Action Plan.
    **Expected outcome:** Responses are rendered in the order of walking through the grid from left to right and top to bottom, as if reading a paragraph of text (per Figma spec).
6. Go back and clear all your responses for both matrix items.
7. Proceed to the Action Plan.
    **Expected outcome:** Each response is rendered as "(Question skipped)" in the Action Plan.
8. In the Admin App, edit the Phrase Builder item and change the formats for the matrix items to render each response in a different format than before.
9. Log out of the Web App and log back in, and perform the activity again.
10. Choose a variety of answers for each matrix item.
11. Proceed to the Action Plan.
    **Expected outcome:** Responses are still rendered in the order of walking through the grid from left to right and top to bottom, as if reading a paragraph of text (per Figma spec), with the only change being whether the answers are rendered as a sentence vs. a bullet list, or the order in which each response has its row/column label displayed.
