### PR TITLE
fix: Action Plan not showing correct answer of Single/Multi selection question

### DIFF
--- a/src/entities/activity/ui/items/ActionPlan/phrasalData.test.ts
+++ b/src/entities/activity/ui/items/ActionPlan/phrasalData.test.ts
@@ -34,7 +34,7 @@ describe('Action Plan', () => {
         name,
         responseType: type,
         responseValues: {
-          options: options.map((option) => ({ text: option })),
+          options: options.map((option, value) => ({ text: option, value })),
         },
         answer,
       }) as never as ItemRecord;

--- a/src/entities/activity/ui/items/ActionPlan/phrasalData.ts
+++ b/src/entities/activity/ui/items/ActionPlan/phrasalData.ts
@@ -100,8 +100,12 @@ export const extractActivitiesPhrasalData = (items: ItemRecord[]): ActivitiesPhr
       const selectFieldData: ActivityPhrasalArrayFieldData = {
         type: 'array',
         values: item.answer
-          .map((value) => item.responseValues.options[parseInt(value, 10)]?.text)
-          .filter((value) => !!value),
+          .map(
+            (value) =>
+              item.responseValues.options.find((option) => option.value === parseInt(value, 10))
+                ?.text,
+          )
+          .filter((value): value is string => !!value),
         context: fieldDataContext,
       };
       fieldData = selectFieldData;


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [x] Tests for the changes have been added / updated


### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-8471](https://mindlogger.atlassian.net/browse/M2-8471)

The Action Plan assumes the Single and Multi selection item type's options have matching index and `value` values. Eg.
```
{
  "type": "singleSelect",
  "options": [
    {
      "id": "aad6025b-82f6-4dd1-8409-65ab6f29742f",
      "text": "Option A",
      "value": 0, // the Admin Panel automatically gives this a value of 0 and places it in the index 0 position of the options array
    },
    {
      "id": "05a34bac-848c-469a-ab7f-60a790520d64",
      "text": "Option B",
      "value": 1, // the Admin Panel automatically gives this a value of 1 and places it in the index 1 position of the options array
    },
    {
      "id": "307a3dc4-82e8-4894-8aa9-9c68e49ae151",
      "text": "Option C",
      "value": 2,
    }
  ],
} 
```

However this isn't always the case. If in the Admin Panel the first option is deleted and another one is added, the existing items shift forward and the new one is added in the end, resulting in options that no longer have matching index and `value` values. 
```
{
  "type": "singleSelect",
  "options": [
    {
      "id": "05a34bac-848c-469a-ab7f-60a790520d64",
      "text": "Option B",
      "value": 1, // this option is no longer in the index 1 position of the options array
    },
    {
      "id": "307a3dc4-82e8-4894-8aa9-9c68e49ae151",
      "text": "Option C",
      "value": 2,
    }
    {
      "id": "946a3dc4-64f48-5465-6af6-6d45e54sd545",
      "text": "Option D",
      "value": 3,
    }
  ],
} 
```

Because of this incorrect assumption, the Action Plan would attempt to match the user's answer (which is based on the `value`) with the index position in the options array which won't work in all cases (such as the second version above) resulting in an incorrect answer being displayed in the Action Plan. 

Changes include:

- Updates how the Action Plan matches the user's answer with the option, using the `value` instead of the index position of the option



### 🪤 Peer Testing

<!-- If peer testing is not needed, then delete this section -->
<!-- Uncomment out any of the following as needed:           -->
<!-- **Requires `yarn install`**     -->
Peer testing can follow the Steps to Reproduce in the ticket, [M2-8471](https://mindlogger.atlassian.net/browse/M2-8471)



[M2-8471]: https://mindlogger.atlassian.net/browse/M2-8471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ