### PR TITLE
fix: Update Time/TimeRange/Date validations (M2-8302)

### DIFF
--- a/src/features/PassSurvey/model/ConditionalLogicValidator.test.ts
+++ b/src/features/PassSurvey/model/ConditionalLogicValidator.test.ts
@@ -1227,10 +1227,7 @@ describe('ConditionalLogicValidator', () => {
   });
 
   it('should validate EQUAL_TO_TIME correctly -> the times match', () => {
-    const time = {
-      hours: 10,
-      minutes: 30,
-    };
+    const time = '10:30';
 
     const condition: EqualToTimeCondition = {
       itemName: 'random-item-name',
@@ -1248,10 +1245,7 @@ describe('ConditionalLogicValidator', () => {
   });
 
   it('should validate EQUAL_TO_TIME correctly -> the times don`t match', () => {
-    const time = {
-      hours: 10,
-      minutes: 30,
-    };
+    const time = '10:30';
 
     const condition: EqualToTimeCondition = {
       itemName: 'random-item-name',
@@ -1269,10 +1263,7 @@ describe('ConditionalLogicValidator', () => {
   });
 
   it('should validate NOT_EQUAL_TO_TIME correctly -> the times don`t match', () => {
-    const time = {
-      hours: 10,
-      minutes: 30,
-    };
+    const time = '10:30';
 
     const condition: NotEqualToTimeCondition = {
       itemName: 'random-item-name',
@@ -1290,10 +1281,7 @@ describe('ConditionalLogicValidator', () => {
   });
 
   it('should validate NOT_EQUAL_TO_TIME correctly -> the times match', () => {
-    const time = {
-      hours: 10,
-      minutes: 30,
-    };
+    const time = '10:30';
 
     const condition: NotEqualToTimeCondition = {
       itemName: 'random-item-name',
@@ -1311,10 +1299,7 @@ describe('ConditionalLogicValidator', () => {
   });
 
   it('should validate GREATER_THAN_TIME correctly -> the time is greater', () => {
-    const time = {
-      hours: 10,
-      minutes: 30,
-    };
+    const time = '10:30';
 
     const condition: GreaterThanTimeCondition = {
       itemName: 'random-item-name',
@@ -1332,10 +1317,7 @@ describe('ConditionalLogicValidator', () => {
   });
 
   it('should validate GREATER_THAN_TIME correctly -> the time is equal', () => {
-    const time = {
-      hours: 10,
-      minutes: 30,
-    };
+    const time = '10:30';
 
     const condition: GreaterThanTimeCondition = {
       itemName: 'random-item-name',
@@ -1353,10 +1335,7 @@ describe('ConditionalLogicValidator', () => {
   });
 
   it('should validate GREATER_THAN_TIME correctly -> the time is less', () => {
-    const time = {
-      hours: 10,
-      minutes: 30,
-    };
+    const time = '10:30';
 
     const condition: GreaterThanTimeCondition = {
       itemName: 'random-item-name',
@@ -1374,10 +1353,7 @@ describe('ConditionalLogicValidator', () => {
   });
 
   it('should validate LESS_THAN_TIME correctly -> the time is less', () => {
-    const time = {
-      hours: 10,
-      minutes: 30,
-    };
+    const time = '10:30';
 
     const condition: LessThanTimeCondition = {
       itemName: 'random-item-name',
@@ -1395,10 +1371,7 @@ describe('ConditionalLogicValidator', () => {
   });
 
   it('should validate LESS_THAN_TIME correctly -> the time is equal', () => {
-    const time = {
-      hours: 10,
-      minutes: 30,
-    };
+    const time = '10:30';
 
     const condition: LessThanTimeCondition = {
       itemName: 'random-item-name',
@@ -1416,10 +1389,7 @@ describe('ConditionalLogicValidator', () => {
   });
 
   it('should validate LESS_THAN_TIME correctly -> the time is greater', () => {
-    const time = {
-      hours: 10,
-      minutes: 30,
-    };
+    const time = '10:30';
 
     const condition: LessThanTimeCondition = {
       itemName: 'random-item-name',
@@ -1570,7 +1540,7 @@ describe('ConditionalLogicValidator', () => {
       type: 'EQUAL_TO_TIME_RANGE',
       payload: {
         fieldName: 'from',
-        time: { hours: 10, minutes: 0 },
+        time: '10:00',
       },
     };
 
@@ -1592,7 +1562,7 @@ describe('ConditionalLogicValidator', () => {
       type: 'EQUAL_TO_TIME_RANGE',
       payload: {
         fieldName: 'from',
-        time: { hours: 10, minutes: 0 },
+        time: '10:00',
       },
     };
 
@@ -1614,7 +1584,7 @@ describe('ConditionalLogicValidator', () => {
       type: 'EQUAL_TO_TIME_RANGE',
       payload: {
         fieldName: 'to',
-        time: { hours: 11, minutes: 0 },
+        time: '11:00',
       },
     };
 
@@ -1636,7 +1606,7 @@ describe('ConditionalLogicValidator', () => {
       type: 'EQUAL_TO_TIME_RANGE',
       payload: {
         fieldName: 'to',
-        time: { hours: 11, minutes: 0 },
+        time: '11:00',
       },
     };
 
@@ -1658,7 +1628,7 @@ describe('ConditionalLogicValidator', () => {
       type: 'NOT_EQUAL_TO_TIME_RANGE',
       payload: {
         fieldName: 'from',
-        time: { hours: 10, minutes: 0 },
+        time: '10:00',
       },
     };
 
@@ -1680,7 +1650,7 @@ describe('ConditionalLogicValidator', () => {
       type: 'NOT_EQUAL_TO_TIME_RANGE',
       payload: {
         fieldName: 'from',
-        time: { hours: 10, minutes: 0 },
+        time: '10:00',
       },
     };
 
@@ -1702,7 +1672,7 @@ describe('ConditionalLogicValidator', () => {
       type: 'NOT_EQUAL_TO_TIME_RANGE',
       payload: {
         fieldName: 'to',
-        time: { hours: 11, minutes: 0 },
+        time: '11:00',
       },
     };
 
@@ -1724,7 +1694,7 @@ describe('ConditionalLogicValidator', () => {
       type: 'NOT_EQUAL_TO_TIME_RANGE',
       payload: {
         fieldName: 'to',
-        time: { hours: 11, minutes: 0 },
+        time: '11:00',
       },
     };
 
@@ -1746,7 +1716,7 @@ describe('ConditionalLogicValidator', () => {
       type: 'GREATER_THAN_TIME_RANGE',
       payload: {
         fieldName: 'from',
-        time: { hours: 10, minutes: 0 },
+        time: '10:00',
       },
     };
 
@@ -1768,7 +1738,7 @@ describe('ConditionalLogicValidator', () => {
       type: 'GREATER_THAN_TIME_RANGE',
       payload: {
         fieldName: 'from',
-        time: { hours: 10, minutes: 0 },
+        time: '10:00',
       },
     };
 
@@ -1790,7 +1760,7 @@ describe('ConditionalLogicValidator', () => {
       type: 'GREATER_THAN_TIME_RANGE',
       payload: {
         fieldName: 'from',
-        time: { hours: 10, minutes: 0 },
+        time: '10:00',
       },
     };
 
@@ -1812,7 +1782,7 @@ describe('ConditionalLogicValidator', () => {
       type: 'LESS_THAN_TIME_RANGE',
       payload: {
         fieldName: 'to',
-        time: { hours: 11, minutes: 0 },
+        time: '11:00',
       },
     };
 
@@ -1834,7 +1804,7 @@ describe('ConditionalLogicValidator', () => {
       type: 'LESS_THAN_TIME_RANGE',
       payload: {
         fieldName: 'to',
-        time: { hours: 11, minutes: 0 },
+        time: '11:00',
       },
     };
 
@@ -1856,7 +1826,7 @@ describe('ConditionalLogicValidator', () => {
       type: 'LESS_THAN_TIME_RANGE',
       payload: {
         fieldName: 'to',
-        time: { hours: 11, minutes: 0 },
+        time: '11:00',
       },
     };
 
@@ -1872,10 +1842,10 @@ describe('ConditionalLogicValidator', () => {
     expect(validator.validate()).toBe(false);
   });
 
-  it('should validate BETWEEN_TIME_RANGES correctly -> the time range is between', () => {
+  it('should validate BETWEEN_TIMES_RANGES correctly -> the time range is between', () => {
     const condition: BetweenTimeRangeCondition = {
       itemName: 'random-item-name',
-      type: 'BETWEEN_TIME_RANGE',
+      type: 'BETWEEN_TIMES_RANGE',
       payload: {
         fieldName: 'from',
         minTime: { hours: 10, minutes: 0 },
@@ -1895,10 +1865,10 @@ describe('ConditionalLogicValidator', () => {
     expect(validator.validate()).toBe(true);
   });
 
-  it('should validate BETWEEN_TIME_RANGES correctly -> the time range is not between', () => {
+  it('should validate BETWEEN_TIMES_RANGES correctly -> the time range is not between', () => {
     const condition: BetweenTimeRangeCondition = {
       itemName: 'random-item-name',
-      type: 'BETWEEN_TIME_RANGE',
+      type: 'BETWEEN_TIMES_RANGE',
       payload: {
         fieldName: 'from',
         minTime: { hours: 10, minutes: 0 },
@@ -1918,10 +1888,10 @@ describe('ConditionalLogicValidator', () => {
     expect(validator.validate()).toBe(false);
   });
 
-  it('should validate BETWEEN_TIME_RANGES correctly -> the time range is equal to minTime', () => {
+  it('should validate BETWEEN_TIMES_RANGES correctly -> the time range is equal to minTime', () => {
     const condition: BetweenTimeRangeCondition = {
       itemName: 'random-item-name',
-      type: 'BETWEEN_TIME_RANGE',
+      type: 'BETWEEN_TIMES_RANGE',
       payload: {
         fieldName: 'from',
         minTime: { hours: 10, minutes: 0 },
@@ -1941,10 +1911,10 @@ describe('ConditionalLogicValidator', () => {
     expect(validator.validate()).toBe(false);
   });
 
-  it('should validate BETWEEN_TIME_RANGES correctly -> the time range is equal to maxTime', () => {
+  it('should validate BETWEEN_TIMES_RANGES correctly -> the time range is equal to maxTime', () => {
     const condition: BetweenTimeRangeCondition = {
       itemName: 'random-item-name',
-      type: 'BETWEEN_TIME_RANGE',
+      type: 'BETWEEN_TIMES_RANGE',
       payload: {
         fieldName: 'from',
         minTime: { hours: 10, minutes: 0 },
@@ -1964,10 +1934,10 @@ describe('ConditionalLogicValidator', () => {
     expect(validator.validate()).toBe(false);
   });
 
-  it('should validate BETWEEN_TIME_RANGES correctly -> the to time range is between', () => {
+  it('should validate BETWEEN_TIMES_RANGES correctly -> the to time range is between', () => {
     const condition: BetweenTimeRangeCondition = {
       itemName: 'random-item-name',
-      type: 'BETWEEN_TIME_RANGE',
+      type: 'BETWEEN_TIMES_RANGE',
       payload: {
         fieldName: 'to',
         minTime: { hours: 10, minutes: 0 },
@@ -1987,10 +1957,10 @@ describe('ConditionalLogicValidator', () => {
     expect(validator.validate()).toBe(true);
   });
 
-  it('should validate BETWEEN_TIME_RANGES correctly -> the to time range is not between', () => {
+  it('should validate BETWEEN_TIMES_RANGES correctly -> the to time range is not between', () => {
     const condition: BetweenTimeRangeCondition = {
       itemName: 'random-item-name',
-      type: 'BETWEEN_TIME_RANGE',
+      type: 'BETWEEN_TIMES_RANGE',
       payload: {
         fieldName: 'to',
         minTime: { hours: 10, minutes: 0 },
@@ -2010,10 +1980,10 @@ describe('ConditionalLogicValidator', () => {
     expect(validator.validate()).toBe(false);
   });
 
-  it('should validate BETWEEN_TIME_RANGES correctly -> the to time range is equal to minTime', () => {
+  it('should validate BETWEEN_TIMES_RANGES correctly -> the to time range is equal to minTime', () => {
     const condition: BetweenTimeRangeCondition = {
       itemName: 'random-item-name',
-      type: 'BETWEEN_TIME_RANGE',
+      type: 'BETWEEN_TIMES_RANGE',
       payload: {
         fieldName: 'to',
         minTime: { hours: 10, minutes: 30 },
@@ -2033,10 +2003,10 @@ describe('ConditionalLogicValidator', () => {
     expect(validator.validate()).toBe(false);
   });
 
-  it('should validate BETWEEN_TIME_RANGES correctly -> the to time range is equal to maxTime', () => {
+  it('should validate BETWEEN_TIMES_RANGES correctly -> the to time range is equal to maxTime', () => {
     const condition: BetweenTimeRangeCondition = {
       itemName: 'random-item-name',
-      type: 'BETWEEN_TIME_RANGE',
+      type: 'BETWEEN_TIMES_RANGE',
       payload: {
         fieldName: 'to',
         minTime: { hours: 10, minutes: 30 },
@@ -2056,10 +2026,10 @@ describe('ConditionalLogicValidator', () => {
     expect(validator.validate()).toBe(false);
   });
 
-  it('should validate OUTSIDE_OF_TIME_RANGES correctly -> the from time range is outside', () => {
+  it('should validate OUTSIDE_OF_TIMES_RANGES correctly -> the from time range is outside', () => {
     const condition: OutsideOfTimeRangeCondition = {
       itemName: 'random-item-name',
-      type: 'OUTSIDE_OF_TIME_RANGE',
+      type: 'OUTSIDE_OF_TIMES_RANGE',
       payload: {
         fieldName: 'from',
         minTime: { hours: 10, minutes: 0 },
@@ -2079,10 +2049,10 @@ describe('ConditionalLogicValidator', () => {
     expect(validator.validate()).toBe(true);
   });
 
-  it('should validate OUTSIDE_OF_TIME_RANGES correctly -> the from time range is not outside', () => {
+  it('should validate OUTSIDE_OF_TIMES_RANGES correctly -> the from time range is not outside', () => {
     const condition: OutsideOfTimeRangeCondition = {
       itemName: 'random-item-name',
-      type: 'OUTSIDE_OF_TIME_RANGE',
+      type: 'OUTSIDE_OF_TIMES_RANGE',
       payload: {
         fieldName: 'from',
         minTime: { hours: 10, minutes: 0 },
@@ -2102,10 +2072,10 @@ describe('ConditionalLogicValidator', () => {
     expect(validator.validate()).toBe(false);
   });
 
-  it('should validate OUTSIDE_OF_TIME_RANGES correctly -> the from time range is equal to minTime', () => {
+  it('should validate OUTSIDE_OF_TIMES_RANGES correctly -> the from time range is equal to minTime', () => {
     const condition: OutsideOfTimeRangeCondition = {
       itemName: 'random-item-name',
-      type: 'OUTSIDE_OF_TIME_RANGE',
+      type: 'OUTSIDE_OF_TIMES_RANGE',
       payload: {
         fieldName: 'from',
         minTime: { hours: 10, minutes: 0 },
@@ -2125,10 +2095,10 @@ describe('ConditionalLogicValidator', () => {
     expect(validator.validate()).toBe(false);
   });
 
-  it('should validate OUTSIDE_OF_TIME_RANGES correctly -> the from time range is equal to maxTime', () => {
+  it('should validate OUTSIDE_OF_TIMES_RANGES correctly -> the from time range is equal to maxTime', () => {
     const condition: OutsideOfTimeRangeCondition = {
       itemName: 'random-item-name',
-      type: 'OUTSIDE_OF_TIME_RANGE',
+      type: 'OUTSIDE_OF_TIMES_RANGE',
       payload: {
         fieldName: 'from',
         minTime: { hours: 10, minutes: 0 },
@@ -2148,10 +2118,10 @@ describe('ConditionalLogicValidator', () => {
     expect(validator.validate()).toBe(false);
   });
 
-  it('should validate OUTSIDE_OF_TIME_RANGES correctly -> the to time range is outside', () => {
+  it('should validate OUTSIDE_OF_TIMES_RANGES correctly -> the to time range is outside', () => {
     const condition: OutsideOfTimeRangeCondition = {
       itemName: 'random-item-name',
-      type: 'OUTSIDE_OF_TIME_RANGE',
+      type: 'OUTSIDE_OF_TIMES_RANGE',
       payload: {
         fieldName: 'to',
         minTime: { hours: 10, minutes: 0 },
@@ -2171,10 +2141,10 @@ describe('ConditionalLogicValidator', () => {
     expect(validator.validate()).toBe(true);
   });
 
-  it('should validate OUTSIDE_OF_TIME_RANGES correctly -> the to time range is not outside', () => {
+  it('should validate OUTSIDE_OF_TIMES_RANGES correctly -> the to time range is not outside', () => {
     const condition: OutsideOfTimeRangeCondition = {
       itemName: 'random-item-name',
-      type: 'OUTSIDE_OF_TIME_RANGE',
+      type: 'OUTSIDE_OF_TIMES_RANGE',
       payload: {
         fieldName: 'to',
         minTime: { hours: 10, minutes: 0 },
@@ -2194,10 +2164,10 @@ describe('ConditionalLogicValidator', () => {
     expect(validator.validate()).toBe(false);
   });
 
-  it('should validate OUTSIDE_OF_TIME_RANGES correctly -> the to time range is equal to minTime', () => {
+  it('should validate OUTSIDE_OF_TIMES_RANGES correctly -> the to time range is equal to minTime', () => {
     const condition: OutsideOfTimeRangeCondition = {
       itemName: 'random-item-name',
-      type: 'OUTSIDE_OF_TIME_RANGE',
+      type: 'OUTSIDE_OF_TIMES_RANGE',
       payload: {
         fieldName: 'to',
         minTime: { hours: 10, minutes: 0 },
@@ -2217,10 +2187,10 @@ describe('ConditionalLogicValidator', () => {
     expect(validator.validate()).toBe(false);
   });
 
-  it('should validate OUTSIDE_OF_TIME_RANGES correctly -> the to time range is equal to maxTime', () => {
+  it('should validate OUTSIDE_OF_TIMES_RANGES correctly -> the to time range is equal to maxTime', () => {
     const condition: OutsideOfTimeRangeCondition = {
       itemName: 'random-item-name',
-      type: 'OUTSIDE_OF_TIME_RANGE',
+      type: 'OUTSIDE_OF_TIMES_RANGE',
       payload: {
         fieldName: 'to',
         minTime: { hours: 10, minutes: 0 },

--- a/src/features/PassSurvey/model/ConditionalLogicValidator.ts
+++ b/src/features/PassSurvey/model/ConditionalLogicValidator.ts
@@ -50,6 +50,7 @@ import {
   isFirstTimeLater,
   isTimesEqual,
   timeToHourMinute,
+  parseDateToMidnightUTC,
 } from '~/shared/utils';
 
 interface IConditionalLogicValidator {
@@ -271,7 +272,10 @@ export class ConditionalLogicValidator implements IConditionalLogicValidator {
 
   private validateGreaterThanDate(rule: GreaterThanDateCondition, item: ItemRecord): boolean {
     if (item.responseType === 'date') {
-      return isFirstDateEarlier(new Date(rule.payload.date), new Date(item.answer[0]));
+      return isFirstDateEarlier(
+        parseDateToMidnightUTC(rule.payload.date),
+        new Date(item.answer[0]),
+      );
     }
 
     return true;
@@ -279,7 +283,7 @@ export class ConditionalLogicValidator implements IConditionalLogicValidator {
 
   private validateLessThanDate(rule: LessThanDateCondition, item: ItemRecord): boolean {
     if (item.responseType === 'date') {
-      return isFirstDateLater(new Date(rule.payload.date), new Date(item.answer[0]));
+      return isFirstDateLater(parseDateToMidnightUTC(rule.payload.date), new Date(item.answer[0]));
     }
 
     return true;
@@ -287,7 +291,7 @@ export class ConditionalLogicValidator implements IConditionalLogicValidator {
 
   private validateEqualToDate(rule: EqualToDateCondition, item: ItemRecord): boolean {
     if (item.responseType === 'date') {
-      return isSameDay(new Date(rule.payload.date), new Date(item.answer[0]));
+      return isSameDay(parseDateToMidnightUTC(rule.payload.date), new Date(item.answer[0]));
     }
 
     return true;
@@ -295,7 +299,7 @@ export class ConditionalLogicValidator implements IConditionalLogicValidator {
 
   private validateNotEqualToDate(rule: NotEqualToDateCondition, item: ItemRecord): boolean {
     if (item.responseType === 'date') {
-      return !isSameDay(new Date(rule.payload.date), new Date(item.answer[0]));
+      return !isSameDay(parseDateToMidnightUTC(rule.payload.date), new Date(item.answer[0]));
     }
 
     return true;
@@ -304,8 +308,11 @@ export class ConditionalLogicValidator implements IConditionalLogicValidator {
   private validateBetweenDates(rule: BetweenDatesCondition, item: ItemRecord): boolean {
     if (item.responseType === 'date') {
       return (
-        isFirstDateEarlier(new Date(rule.payload.minDate), new Date(item.answer[0])) &&
-        isFirstDateLater(new Date(rule.payload.maxDate), new Date(item.answer[0]))
+        isFirstDateEarlier(
+          parseDateToMidnightUTC(rule.payload.minDate),
+          new Date(item.answer[0]),
+        ) &&
+        isFirstDateLater(parseDateToMidnightUTC(rule.payload.maxDate), new Date(item.answer[0]))
       );
     }
 
@@ -315,8 +322,8 @@ export class ConditionalLogicValidator implements IConditionalLogicValidator {
   private validateOutsideOfDates(rule: OutsideOfDatesCondition, item: ItemRecord): boolean {
     if (item.responseType === 'date') {
       return (
-        isFirstDateLater(new Date(rule.payload.minDate), new Date(item.answer[0])) ||
-        isFirstDateEarlier(new Date(rule.payload.maxDate), new Date(item.answer[0]))
+        isFirstDateLater(parseDateToMidnightUTC(rule.payload.minDate), new Date(item.answer[0])) ||
+        isFirstDateEarlier(parseDateToMidnightUTC(rule.payload.maxDate), new Date(item.answer[0]))
       );
     }
 

--- a/src/features/PassSurvey/model/ConditionalLogicValidator.ts
+++ b/src/features/PassSurvey/model/ConditionalLogicValidator.ts
@@ -141,10 +141,10 @@ export class ConditionalLogicValidator implements IConditionalLogicValidator {
       case 'NOT_EQUAL_TO_TIME_RANGE':
         return this.validateNotEqualToTimeRange(this.rule, this.item);
 
-      case 'BETWEEN_TIME_RANGE':
+      case 'BETWEEN_TIMES_RANGE':
         return this.validateBetweenTimeRange(this.rule, this.item);
 
-      case 'OUTSIDE_OF_TIME_RANGE':
+      case 'OUTSIDE_OF_TIMES_RANGE':
         return this.validateOutsideOfTimeRange(this.rule, this.item);
 
       case 'GREATER_THAN_SLIDER_ROWS':

--- a/src/features/PassSurvey/model/ConditionalLogicValidator.ts
+++ b/src/features/PassSurvey/model/ConditionalLogicValidator.ts
@@ -49,6 +49,7 @@ import {
   isFirstTimeEarlier,
   isFirstTimeLater,
   isTimesEqual,
+  timeToHourMinute,
 } from '~/shared/utils';
 
 interface IConditionalLogicValidator {
@@ -325,8 +326,9 @@ export class ConditionalLogicValidator implements IConditionalLogicValidator {
   private validateGreaterThanTime(rule: GreaterThanTimeCondition, item: ItemRecord): boolean {
     if (item.responseType === 'time') {
       const time = dateStringToHourMinuteRaw(item.answer[0]);
+      const ruleTime = timeToHourMinute(rule.payload.time);
 
-      return isFirstTimeLater(time, rule.payload.time);
+      return isFirstTimeLater(time, ruleTime);
     }
 
     return true;
@@ -335,8 +337,9 @@ export class ConditionalLogicValidator implements IConditionalLogicValidator {
   private validateLessThanTime(rule: LessThanTimeCondition, item: ItemRecord): boolean {
     if (item.responseType === 'time') {
       const time = dateStringToHourMinuteRaw(item.answer[0]);
+      const ruleTime = timeToHourMinute(rule.payload.time);
 
-      return isFirstTimeEarlier(time, rule.payload.time);
+      return isFirstTimeEarlier(time, ruleTime);
     }
 
     return true;
@@ -345,8 +348,9 @@ export class ConditionalLogicValidator implements IConditionalLogicValidator {
   private validateEqualToTime(rule: EqualToTimeCondition, item: ItemRecord): boolean {
     if (item.responseType === 'time') {
       const time = dateStringToHourMinuteRaw(item.answer[0]);
+      const ruleTime = timeToHourMinute(rule.payload.time);
 
-      return isTimesEqual(rule.payload.time, time);
+      return isTimesEqual(ruleTime, time);
     }
 
     return true;
@@ -355,8 +359,9 @@ export class ConditionalLogicValidator implements IConditionalLogicValidator {
   private validateNotEqualToTime(rule: NotEqualToTimeCondition, item: ItemRecord): boolean {
     if (item.responseType === 'time') {
       const time = dateStringToHourMinuteRaw(item.answer[0]);
+      const ruleTime = timeToHourMinute(rule.payload.time);
 
-      return !isTimesEqual(rule.payload.time, time);
+      return !isTimesEqual(ruleTime, time);
     }
 
     return true;
@@ -400,8 +405,9 @@ export class ConditionalLogicValidator implements IConditionalLogicValidator {
       }
 
       const time = dateStringToHourMinuteRaw(timeToValidate);
+      const ruleTime = timeToHourMinute(rule.payload.time);
 
-      return isFirstTimeLater(time, rule.payload.time);
+      return isFirstTimeLater(time, ruleTime);
     }
 
     return true;
@@ -415,8 +421,9 @@ export class ConditionalLogicValidator implements IConditionalLogicValidator {
       }
 
       const time = dateStringToHourMinuteRaw(timeToValidate);
+      const ruleTime = timeToHourMinute(rule.payload.time);
 
-      return isFirstTimeEarlier(time, rule.payload.time);
+      return isFirstTimeEarlier(time, ruleTime);
     }
 
     return true;
@@ -430,8 +437,9 @@ export class ConditionalLogicValidator implements IConditionalLogicValidator {
       }
 
       const time = dateStringToHourMinuteRaw(timeToValidate);
+      const ruleTime = timeToHourMinute(rule.payload.time);
 
-      return isTimesEqual(rule.payload.time, time);
+      return isTimesEqual(ruleTime, time);
     }
 
     return true;
@@ -448,8 +456,9 @@ export class ConditionalLogicValidator implements IConditionalLogicValidator {
       }
 
       const time = dateStringToHourMinuteRaw(timeToValidate);
+      const ruleTime = timeToHourMinute(rule.payload.time);
 
-      return !isTimesEqual(rule.payload.time, time);
+      return !isTimesEqual(ruleTime, time);
     }
 
     return true;

--- a/src/features/PassSurvey/model/ConditionalLogicValidator.ts
+++ b/src/features/PassSurvey/model/ConditionalLogicValidator.ts
@@ -394,6 +394,10 @@ export class ConditionalLogicValidator implements IConditionalLogicValidator {
   ): boolean {
     if (item.responseType === 'timeRange') {
       const timeToValidate = rule.payload.fieldName === 'from' ? item.answer[0] : item.answer[1];
+      if (!timeToValidate) {
+        // There is no selection yet
+        return false;
+      }
 
       const time = dateStringToHourMinuteRaw(timeToValidate);
 
@@ -406,6 +410,9 @@ export class ConditionalLogicValidator implements IConditionalLogicValidator {
   private validateLessThanTimeRange(rule: LessThanTimeRangeCondition, item: ItemRecord): boolean {
     if (item.responseType === 'timeRange') {
       const timeToValidate = rule.payload.fieldName === 'from' ? item.answer[0] : item.answer[1];
+      if (!timeToValidate) {
+        return false;
+      }
 
       const time = dateStringToHourMinuteRaw(timeToValidate);
 
@@ -418,6 +425,9 @@ export class ConditionalLogicValidator implements IConditionalLogicValidator {
   private validateEqualToTimeRange(rule: EqualToTimeRangeCondition, item: ItemRecord): boolean {
     if (item.responseType === 'timeRange') {
       const timeToValidate = rule.payload.fieldName === 'from' ? item.answer[0] : item.answer[1];
+      if (!timeToValidate) {
+        return false;
+      }
 
       const time = dateStringToHourMinuteRaw(timeToValidate);
 
@@ -433,6 +443,9 @@ export class ConditionalLogicValidator implements IConditionalLogicValidator {
   ): boolean {
     if (item.responseType === 'timeRange') {
       const timeToValidate = rule.payload.fieldName === 'from' ? item.answer[0] : item.answer[1];
+      if (!timeToValidate) {
+        return false;
+      }
 
       const time = dateStringToHourMinuteRaw(timeToValidate);
 
@@ -445,6 +458,9 @@ export class ConditionalLogicValidator implements IConditionalLogicValidator {
   private validateBetweenTimeRange(rule: BetweenTimeRangeCondition, item: ItemRecord): boolean {
     if (item.responseType === 'timeRange') {
       const timeToValidate = rule.payload.fieldName === 'from' ? item.answer[0] : item.answer[1];
+      if (!timeToValidate) {
+        return false;
+      }
 
       const time = dateStringToHourMinuteRaw(timeToValidate);
 
@@ -460,6 +476,9 @@ export class ConditionalLogicValidator implements IConditionalLogicValidator {
   private validateOutsideOfTimeRange(rule: OutsideOfTimeRangeCondition, item: ItemRecord): boolean {
     if (item.responseType === 'timeRange') {
       const timeToValidate = rule.payload.fieldName === 'from' ? item.answer[0] : item.answer[1];
+      if (!timeToValidate) {
+        return false;
+      }
 
       const time = dateStringToHourMinuteRaw(timeToValidate);
 

--- a/src/shared/api/types/conditionalLogic.ts
+++ b/src/shared/api/types/conditionalLogic.ts
@@ -260,10 +260,7 @@ export type GreaterThanTimeRangeCondition = {
   type: 'GREATER_THAN_TIME_RANGE';
   payload: {
     fieldName: 'from' | 'to';
-    time: {
-      hours: number; // 0 - 23
-      minutes: number; // 0 - 59
-    };
+    time: string;
   };
 };
 
@@ -272,10 +269,7 @@ export type LessThanTimeRangeCondition = {
   type: 'LESS_THAN_TIME_RANGE';
   payload: {
     fieldName: 'from' | 'to';
-    time: {
-      hours: number; // 0 - 23
-      minutes: number; // 0 - 59
-    };
+    time: string;
   };
 };
 
@@ -284,10 +278,7 @@ export type EqualToTimeRangeCondition = {
   type: 'EQUAL_TO_TIME_RANGE';
   payload: {
     fieldName: 'from' | 'to';
-    time: {
-      hours: number; // 0 - 23
-      minutes: number; // 0 - 59
-    };
+    time: string;
   };
 };
 
@@ -296,10 +287,7 @@ export type NotEqualToTimeRangeCondition = {
   type: 'NOT_EQUAL_TO_TIME_RANGE';
   payload: {
     fieldName: 'from' | 'to';
-    time: {
-      hours: number; // 0 - 23
-      minutes: number; // 0 - 59
-    };
+    time: string;
   };
 };
 

--- a/src/shared/api/types/conditionalLogic.ts
+++ b/src/shared/api/types/conditionalLogic.ts
@@ -317,7 +317,7 @@ export type NotEqualToTimeRangeCondition = {
 
 export type BetweenTimeRangeCondition = {
   itemName: string;
-  type: 'BETWEEN_TIME_RANGE';
+  type: 'BETWEEN_TIMES_RANGE';
   payload: {
     fieldName: 'from' | 'to';
     minTime: {
@@ -333,7 +333,7 @@ export type BetweenTimeRangeCondition = {
 
 export type OutsideOfTimeRangeCondition = {
   itemName: string;
-  type: 'OUTSIDE_OF_TIME_RANGE';
+  type: 'OUTSIDE_OF_TIMES_RANGE';
   payload: {
     fieldName: 'from' | 'to';
     minTime: {

--- a/src/shared/api/types/conditionalLogic.ts
+++ b/src/shared/api/types/conditionalLogic.ts
@@ -197,10 +197,7 @@ export type GreaterThanTimeCondition = {
   itemName: string;
   type: 'GREATER_THAN_TIME';
   payload: {
-    time: {
-      hours: number; // 0 - 23
-      minutes: number; // 0 - 59
-    };
+    time: string;
   };
 };
 
@@ -208,10 +205,7 @@ export type LessThanTimeCondition = {
   itemName: string;
   type: 'LESS_THAN_TIME';
   payload: {
-    time: {
-      hours: number; // 0 - 23
-      minutes: number; // 0 - 59
-    };
+    time: string;
   };
 };
 
@@ -219,10 +213,7 @@ export type EqualToTimeCondition = {
   itemName: string;
   type: 'EQUAL_TO_TIME';
   payload: {
-    time: {
-      hours: number; // 0 - 23
-      minutes: number; // 0 - 59
-    };
+    time: string;
   };
 };
 
@@ -230,10 +221,7 @@ export type NotEqualToTimeCondition = {
   itemName: string;
   type: 'NOT_EQUAL_TO_TIME';
   payload: {
-    time: {
-      hours: number; // 0 - 23
-      minutes: number; // 0 - 59
-    };
+    time: string;
   };
 };
 

--- a/src/shared/utils/convert/date/index.ts
+++ b/src/shared/utils/convert/date/index.ts
@@ -1,3 +1,4 @@
 export * from './toDayMonthYear';
 export * from './toHourMinute';
 export * from './msToMinSec';
+export * from './parseDateToMidnightUTC';

--- a/src/shared/utils/convert/date/parseDateToMidnightUTC.test.ts
+++ b/src/shared/utils/convert/date/parseDateToMidnightUTC.test.ts
@@ -1,0 +1,33 @@
+import { parseDateToMidnightUTC } from './parseDateToMidnightUTC';
+
+describe('parseDateToMidnightUTC', () => {
+  it('should return a Date object for a valid date string', () => {
+    const dateStr = '2025-01-01';
+    const result = parseDateToMidnightUTC(dateStr);
+    expect(result).toBeInstanceOf(Date);
+    expect(result.toISOString()).toBe('2025-01-01T00:00:00.000Z');
+  });
+
+  test('should throw error for invalid formats', () => {
+    expect(() => parseDateToMidnightUTC('2025/01/01')).toThrow(
+      '[parseDateToMidnightUTC] Invalid date string format',
+    );
+    expect(() => parseDateToMidnightUTC('2025-01')).toThrow(
+      '[parseDateToMidnightUTC] Invalid date string format',
+    );
+    expect(() => parseDateToMidnightUTC('invalid-date')).toThrow(
+      '[parseDateToMidnightUTC] Invalid date string format',
+    );
+    expect(() => parseDateToMidnightUTC('')).toThrow(
+      '[parseDateToMidnightUTC] Invalid date string format',
+    );
+  });
+
+  it('should handle timezone inconsistencies correctly', () => {
+    const dateStr = '2024-06-15';
+    const result = parseDateToMidnightUTC(dateStr);
+    expect(result.getUTCDate()).toBe(15);
+    expect(result.getUTCMonth()).toBe(5);
+    expect(result.getUTCFullYear()).toBe(2024);
+  });
+});

--- a/src/shared/utils/convert/date/parseDateToMidnightUTC.ts
+++ b/src/shared/utils/convert/date/parseDateToMidnightUTC.ts
@@ -1,0 +1,12 @@
+/**
+ * Parses a date string to a Date object, appending 'T00:00:00' to remove timezone offset
+ */
+export const parseDateToMidnightUTC = (dateStr: string) => {
+  const dateMatch = dateStr.match(/(\d{4})-(\d{2})-(\d{2})/);
+
+  if (!dateMatch) {
+    throw new Error('[parseDateToMidnightUTC] Invalid date string format');
+  }
+
+  return new Date(`${dateStr}T00:00:00`);
+};

--- a/src/shared/utils/convert/date/parseDateToMidnightUTC.ts
+++ b/src/shared/utils/convert/date/parseDateToMidnightUTC.ts
@@ -1,5 +1,14 @@
 /**
- * Parses a date string to a Date object, appending 'T00:00:00' to remove timezone offset
+ * Parses a date string to a Date object, appending 'T00:00:00Z' to remove timezone offset
+ *
+ * @param {String} dateStr - The date string from which to extract the raw hours and minutes.
+ * @returns {Date} An object containing the extracted raw hours and minutes.
+ * @throws {Error} Throws an error if the date string format is invalid.
+ *
+ * @example
+ * const dateStr = '2025-01-01';
+ * const date = parseDateToMidnightUTC(dateStr);
+ * // date: 2025-01-01T00:00:00.000Z
  */
 export const parseDateToMidnightUTC = (dateStr: string) => {
   const dateMatch = dateStr.match(/(\d{4})-(\d{2})-(\d{2})/);
@@ -8,5 +17,5 @@ export const parseDateToMidnightUTC = (dateStr: string) => {
     throw new Error('[parseDateToMidnightUTC] Invalid date string format');
   }
 
-  return new Date(`${dateStr}T00:00:00`);
+  return new Date(`${dateStr}T00:00:00Z`);
 };

--- a/src/shared/utils/convert/index.ts
+++ b/src/shared/utils/convert/index.ts
@@ -1,3 +1,4 @@
 export * from './string';
 export * from './date';
 export * from './enum';
+export * from './time';

--- a/src/shared/utils/convert/time/index.ts
+++ b/src/shared/utils/convert/time/index.ts
@@ -1,0 +1,1 @@
+export * from './toHourMinute';

--- a/src/shared/utils/convert/time/toHourMinute.test.ts
+++ b/src/shared/utils/convert/time/toHourMinute.test.ts
@@ -1,0 +1,16 @@
+import { timeToHourMinute } from './toHourMinute';
+
+describe('timeToHourMinute', () => {
+  test('should correctly parse valid time string', () => {
+    expect(timeToHourMinute('12:34')).toEqual({ hours: 12, minutes: 34 });
+    expect(timeToHourMinute('00:00')).toEqual({ hours: 0, minutes: 0 });
+  });
+
+  test('should throw error for invalid formats', () => {
+    expect(() => timeToHourMinute('1234')).toThrow('[timeToHourMinute] Invalid time string format');
+    expect(() => timeToHourMinute('12:345')).toThrow(
+      '[timeToHourMinute] Invalid time string format',
+    );
+    expect(() => timeToHourMinute('')).toThrow('[timeToHourMinute] Invalid time string format');
+  });
+});

--- a/src/shared/utils/convert/time/toHourMinute.ts
+++ b/src/shared/utils/convert/time/toHourMinute.ts
@@ -1,0 +1,24 @@
+import { HourMinute } from '../../types';
+
+/**
+ * Converts a time string to an object containing hours and minutes.
+ *
+ * @param {string} timeStr - The time string from which to extract the local hours and minutes.
+ * @returns {HourMinute} An object containing the extracted local hours and minutes.
+ *
+ * @example
+ * const timeStr = '10:30';
+ * const time = timeToHourMinute(timeStr);
+ * // time: { hours: 10, minutes: 30 }
+ */
+export const timeToHourMinute = (timeStr: string): HourMinute => {
+  const timeMatch = timeStr.match(/^(\d{2}):(\d{2})$/);
+  if (!timeMatch) {
+    throw new Error('[timeToHourMinute] Invalid time string format');
+  }
+
+  return {
+    hours: parseInt(timeMatch[1]),
+    minutes: parseInt(timeMatch[2]),
+  };
+};


### PR DESCRIPTION
- [x] Tests for the changes have been added

### 📝 Description

Updates Time/TimeRange/Date item conditional logic validations

🔗 [Jira Ticket M2-8302](https://mindlogger.atlassian.net/browse/M2-8302)
🔗 [Jira Ticket M2-8619](https://mindlogger.atlassian.net/browse/M2-8619)

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

Changes include:

- Update mismatched TimeRange types
- Update time parse on Greater Than/Less Than/Equal To/Not Equal conditions
- Update date parse on Greater Than/Less Than/Equal To/Not Equal conditions
- Fixes crash when entering TimeRange values

### 🪤 Peer Testing

#### Applet on Amplify
Use the provided applet in the linked amplify environment:
```
Credentials:
user: pr573@example.com
pass: pr573!
```
![CleanShot 2025-01-30 at 15 13 41](https://github.com/user-attachments/assets/d075575e-8f2e-4a04-814d-e28c68cd6adc)


- Complete the provided Activities for testing Time, Time Range and Date item type conditional logic
- Each activity includes a summary of test cases and expected validations
- Testing the same Applet on the `dev` environment will fail validations or crash

> [!NOTE]
> On "Between of" and "Outside of" conditions, boundaries are treated as failures.
> For example, for the rule "Time is **Between** **09:00** and **10:00**" a response of 09:00 will not pass validation.

#### Local Testing

- Create an applet containing Time, TimeRange and Date item types
- Add at least 1 other items
- Create conditional logic using: GREATER_THAN, LESS_THAN, EQUAL, NOT_EQUAL, BETWEEN, OUTSIDE conditional rules for each item


> [!NOTE]
> Use https://github.com/ChildMindInstitute/mindlogger-admin/pull/2023 to avoid issues while saving conditional logic Dates/Time item types
