### PR TITLE
test: Update tests script to run with UTC timezone

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
 		"prettier:check": "prettier src --check",
 		"prettier:fix": "prettier src --write",
 		"prepare": "husky install",
-		"test:watch": "vitest",
-		"test": "vitest run",
-		"test:ui": "vitest --ui",
-		"coverage": "vitest run --coverage"
+		"test:watch": "TZ=UTC vitest",
+		"test": "TZ=UTC vitest run",
+		"test:ui": "TZ=UTC vitest --ui",
+		"coverage": "TZ=UTC vitest run --coverage"
 	},
 	"dependencies": {
 		"@emotion/react": "^11.13.3",


### PR DESCRIPTION
### 📝 Description

Tests related to dates for IFCL were failing due to timezone misalignment. This PR updates the yarn scripts to run in UTC timezone.

🔗 [Jira Ticket M2-8680](https://mindlogger.atlassian.net/browse/M2-8680)
