### PR TITLE
feat: Submit response data identifier from Single Selection items (M2-8688)

### DIFF
--- a/src/entities/activity/lib/helpers.test.ts
+++ b/src/entities/activity/lib/helpers.test.ts
@@ -141,6 +141,7 @@ describe('Activity helpers', () => {
             addTooltip: false,
             setPalette: false,
             autoAdvance: false,
+            responseDataIdentifier: false,
             additionalResponseOption: {
               textInputOption: false,
               textInputRequired: false,
@@ -164,6 +165,7 @@ describe('Activity helpers', () => {
             addTooltip: false,
             setPalette: false,
             autoAdvance: false,
+            responseDataIdentifier: false,
             additionalResponseOption: {
               textInputOption: true,
               textInputRequired: false,
@@ -207,6 +209,7 @@ describe('Activity helpers', () => {
             addTooltip: false,
             setPalette: false,
             autoAdvance: false,
+            responseDataIdentifier: false,
             additionalResponseOption: {
               textInputOption: true,
               textInputRequired: false,
@@ -230,6 +233,7 @@ describe('Activity helpers', () => {
             addTooltip: false,
             setPalette: false,
             autoAdvance: false,
+            responseDataIdentifier: false,
             additionalResponseOption: {
               textInputOption: true,
               textInputRequired: true,

--- a/src/entities/activity/lib/types/item.ts
+++ b/src/entities/activity/lib/types/item.ts
@@ -231,6 +231,7 @@ export type RadioItemConfig = ButtonsConfig &
     setPalette: boolean;
     autoAdvance: boolean;
     portraitLayout: boolean | null;
+    responseDataIdentifier: boolean;
   };
 
 export type RadioValues = {

--- a/src/features/PassSurvey/model/AnswersConstructService.ts
+++ b/src/features/PassSurvey/model/AnswersConstructService.ts
@@ -4,7 +4,6 @@ import { v4 as uuid } from 'uuid';
 import { ItemAnswer, mapAlerts, mapToAnswers } from '../helpers';
 
 import { ActivityPipelineType, GroupProgress } from '~/abstract/lib';
-import { DefaultAnswer } from '~/entities/activity';
 import { appletModel } from '~/entities/applet';
 import { userModel } from '~/entities/user';
 import {
@@ -201,18 +200,30 @@ export default class AnswersConstructService implements ICompletionConstructServ
   }
 
   private getDataIdentifier(items: ItemRecord[]): string | null {
-    const firstResponseDataIdentifier = items.find((item) => {
-      if (item.responseType === 'text') {
-        return item.config.responseDataIdentifier;
+    const item = items.find((item) => {
+      if (
+        (item.responseType === 'text' || item.responseType === 'singleSelect') &&
+        item.config.responseDataIdentifier
+      ) {
+        return item;
       }
-      return false;
+      return undefined;
     });
 
-    if (!firstResponseDataIdentifier) {
+    if (!item) {
       return null;
     }
 
-    return (firstResponseDataIdentifier.answer as DefaultAnswer)[0];
+    let identifier: string | null = null;
+
+    if (item.responseType === 'text') {
+      identifier = item.answer[0];
+    } else if (item.responseType === 'singleSelect') {
+      const optionIndex = Number(item.answer[0]);
+      identifier = item.responseValues.options[optionIndex].text;
+    }
+
+    return identifier;
   }
 
   private isSurveyCompleted(): boolean {

--- a/src/shared/api/types/item.ts
+++ b/src/shared/api/types/item.ts
@@ -170,6 +170,7 @@ export type RadioItemConfigDTO = AdditionalResponseOptionConfigDTO & {
   setPalette: boolean;
   autoAdvance: boolean;
   portraitLayout: boolean | null;
+  responseDataIdentifier: boolean;
 };
 
 export type RadioItemResponseValuesDTO = {


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [x] Tests for the changes have been added

### 📝 Description

🔗 [Jira Ticket M2-8688](https://mindlogger.atlassian.net/browse/M2-8688)

This change updates function that evaluates what to send to the BE for the response data identifier (`identifier` string), supporting both **Short Text** and, now, **Single Selection** item types. It uses the value from the first item in the activity containing a response identifier, per existing behaviour.

### 🪤 Peer Testing

<!-- If peer testing is not needed, then delete this section -->
<!-- Uncomment out any of the following as needed:           -->
<!-- **Requires `yarn install`**     -->

1. Create an activity containing a Single Selection item with **Response Data Identifier** checked. Assign it two options with labels `Option 1` and `Option 2`.
2. Perform an assessment of that activity in the Web App, selecting `Option 1`, and submit your answers.
    **Expected outcome:** Answers should be submitted successfully.
3. Perform a second assessment, selecting `Option 2`, and submit your answers.
    **Expected outcome:** Answers should be submitted successfully.
4. In the Admin App, navigate to Dataviz for the respondent participant to view their submissions.
5. Adjust the filter date range to be only today's date.
6. Expand the **More Filters** section, then enable the **Filter by identifier** toggle:
    <img src="https://github.com/user-attachments/assets/d7948dae-0d9d-4296-8168-1cf2523caa71" width="600">
7. Open the **Response Identifier** dropdown.
    **Expected outcome:** It should contain `Option 1` and `Option 2` as possible response identifiers.
8. Select the `Option 1` response identifier from the dropdown.
    **Expected outcome:** Only your first submission should be shown.
8. Deselect the `Option 1` response identifier and select the `Option 2` response identifier.
    **Expected outcome:** Only your second submission should be shown.
