### PR TITLE
feat: Submit `eventHistoryId` in answer data (M2-8480)

### DIFF
--- a/src/abstract/lib/GroupBuilder/ActivityGroupsBuilder.test.ts
+++ b/src/abstract/lib/GroupBuilder/ActivityGroupsBuilder.test.ts
@@ -20,6 +20,7 @@ import { ActivityPipelineType, FlowProgress, GroupProgressState } from '~/abstra
 import { AvailabilityLabelType, EventAvailability } from '~/entities/event';
 import { PeriodicityType } from '~/entities/event';
 import { MIDNIGHT_DATE } from '~/shared/constants';
+import { mockEvent } from '~/test/utils/mock';
 
 const getProgress = (startAt: Date, endAt: Date | null) => {
   const result: GroupProgressState = {
@@ -30,6 +31,7 @@ const getProgress = (startAt: Date, endAt: Date | null) => {
       context: {
         summaryData: {},
       },
+      event: mockEvent,
     },
   };
   return result;
@@ -1580,6 +1582,7 @@ describe('ActivityGroupsBuilder', () => {
           context: {
             summaryData: {},
           },
+          event: mockEvent,
         },
       };
 

--- a/src/abstract/lib/GroupBuilder/AvailableGroupBuilder.test.ts
+++ b/src/abstract/lib/GroupBuilder/AvailableGroupBuilder.test.ts
@@ -9,6 +9,7 @@ import { ActivityType } from './types';
 import { ActivityPipelineType, GroupProgressState } from '~/abstract/lib';
 import { AvailabilityLabelType, EventAvailability, PeriodicityType } from '~/entities/event';
 import { HourMinute } from '~/shared/utils';
+import { mockEvent } from '~/test/utils/mock';
 
 jest.mock('@app/shared/lib/constants', () => ({
   ...jest.requireActual('@app/shared/lib/constants'),
@@ -24,6 +25,7 @@ const getProgress = (startAt: Date, endAt: Date | null) => {
       context: {
         summaryData: {},
       },
+      event: mockEvent,
     },
   };
   return result;

--- a/src/abstract/lib/GroupBuilder/ScheduledGroupEvaluator.test.ts
+++ b/src/abstract/lib/GroupBuilder/ScheduledGroupEvaluator.test.ts
@@ -8,6 +8,7 @@ import { ActivityType } from './types';
 import { ActivityPipelineType, GroupProgressState } from '~/abstract/lib';
 import { AvailabilityLabelType, EventAvailability, PeriodicityType } from '~/entities/event';
 import { HourMinute } from '~/shared/utils';
+import { mockEvent } from '~/test/utils/mock';
 
 jest.mock('@app/shared/lib/constants', () => ({
   ...jest.requireActual('@app/shared/lib/constants'),
@@ -23,6 +24,7 @@ const getProgress = (startAt: Date, endAt: Date | null) => {
       context: {
         summaryData: {},
       },
+      event: mockEvent,
     },
   };
   return result;

--- a/src/abstract/lib/types/entityProgress.ts
+++ b/src/abstract/lib/types/entityProgress.ts
@@ -50,7 +50,7 @@ export type ActivityOrFlowProgress = {
   event: ScheduleEventDto | null;
 } & (FlowProgress | ActivityProgress);
 
-type EventProgressTimestampState = {
+export type EventProgressTimestampState = {
   startAt: number | null;
   endAt: number | null;
 };

--- a/src/abstract/lib/types/entityProgress.ts
+++ b/src/abstract/lib/types/entityProgress.ts
@@ -1,4 +1,5 @@
 import { AnswerAlert, ScoreRecord } from '~/features/PassSurvey/lib';
+import { ScheduleEventDto } from '~/shared/api';
 
 export type Consents = {
   shareToPublic: boolean;
@@ -34,19 +35,20 @@ export type FlowProgress = {
   pipelineActivityOrder: number;
   currentActivityStartAt: number | null;
   executionGroupKey: string;
-  context: ProgressContext;
 };
 
 export type ActivityProgress = {
   type: ActivityPipelineType.Regular;
-  context: ProgressContext;
 };
 
 export type ProgressContext = {
   summaryData: Record<ActivityId, FlowSummaryData>;
 };
 
-export type ActivityOrFlowProgress = FlowProgress | ActivityProgress;
+export type ActivityOrFlowProgress = {
+  context: ProgressContext;
+  event: ScheduleEventDto | null;
+} & (FlowProgress | ActivityProgress);
 
 type EventProgressTimestampState = {
   startAt: number | null;

--- a/src/entities/applet/model/hooks/useGroupProgressStateManager.ts
+++ b/src/entities/applet/model/hooks/useGroupProgressStateManager.ts
@@ -3,6 +3,8 @@ import { useCallback } from 'react';
 import { groupProgressSelector } from '../selectors';
 import { actions } from '../slice';
 import {
+  FlowRestartedPayload,
+  InProgressActivity,
   InProgressEntity,
   InProgressFlow,
   RemoveGroupProgressPayload,
@@ -21,6 +23,9 @@ type Return = {
 
   entityCompleted: (props: InProgressEntity) => void;
   flowUpdated: (props: InProgressFlow) => void;
+
+  flowRestarted: (props: FlowRestartedPayload) => void;
+  activityRestarted: (props: InProgressActivity) => void;
 };
 
 export const useGroupProgressStateManager = (): Return => {
@@ -39,6 +44,20 @@ export const useGroupProgressStateManager = (): Return => {
       );
     },
     [groupProgresses],
+  );
+
+  const activityRestarted = useCallback(
+    (props: InProgressActivity) => {
+      dispatch(actions.activityRestarted(props));
+    },
+    [dispatch],
+  );
+
+  const flowRestarted = useCallback(
+    (props: FlowRestartedPayload) => {
+      dispatch(actions.flowRestarted(props));
+    },
+    [dispatch],
   );
 
   const flowUpdated = useCallback(
@@ -85,5 +104,8 @@ export const useGroupProgressStateManager = (): Return => {
 
     entityCompleted,
     flowUpdated,
+
+    activityRestarted,
+    flowRestarted,
   };
 };

--- a/src/entities/applet/model/slice.ts
+++ b/src/entities/applet/model/slice.ts
@@ -6,7 +6,6 @@ import {
   CompletedEntitiesState,
   CompletedEventEntities,
   ItemTimerTickPayload,
-  InProgressActivity,
   InProgressEntity,
   InProgressFlow,
   MultiInformantPayload,
@@ -23,6 +22,8 @@ import {
   RemoveGroupProgressPayload,
   SaveSummaryDataInContext,
   ProlificUrlParamsPayload,
+  ActivityStartedPayload,
+  FlowStartedPayload,
 } from './types';
 
 import {
@@ -240,8 +241,8 @@ const appletsSlice = createSlice({
       activityProgress.step -= 1;
     },
 
-    activityStarted: (state, { payload }: PayloadAction<InProgressActivity>) => {
-      const id = getProgressId(payload.activityId, payload.eventId, payload.targetSubjectId);
+    activityStarted: (state, { payload }: PayloadAction<ActivityStartedPayload>) => {
+      const id = getProgressId(payload.activityId, payload.event.id, payload.targetSubjectId);
 
       const activityEvent: GroupProgress = {
         type: ActivityPipelineType.Regular,
@@ -250,13 +251,14 @@ const appletsSlice = createSlice({
         context: {
           summaryData: {},
         },
+        event: payload.event,
       };
 
       state.groupProgress[id] = activityEvent;
     },
 
-    flowStarted: (state, { payload }: PayloadAction<InProgressFlow>) => {
-      const id = getProgressId(payload.flowId, payload.eventId, payload.targetSubjectId);
+    flowStarted: (state, { payload }: PayloadAction<FlowStartedPayload>) => {
+      const id = getProgressId(payload.flowId, payload.event.id, payload.targetSubjectId);
 
       const flowEvent: GroupProgress = {
         type: ActivityPipelineType.Flow,
@@ -269,6 +271,7 @@ const appletsSlice = createSlice({
         context: {
           summaryData: {},
         },
+        event: payload.event,
       };
 
       state.groupProgress[id] = flowEvent;

--- a/src/entities/applet/model/types.ts
+++ b/src/entities/applet/model/types.ts
@@ -22,7 +22,7 @@ import {
   TimeRangeItem,
   PhrasalTemplateItem,
 } from '~/entities/activity/lib';
-import { ScoreAndReports } from '~/shared/api';
+import { ScheduleEventDto, ScoreAndReports } from '~/shared/api';
 import { DayMonthYearDTO, HourMinuteDTO } from '~/shared/utils';
 
 export type UserEventTypes = 'SET_ANSWER' | 'PREV' | 'NEXT' | 'SKIP' | 'DONE';
@@ -245,5 +245,13 @@ export type InProgressFlow = {
   targetSubjectId: string | null;
   pipelineActivityOrder: number;
 };
+
+export type ActivityStartedPayload = {
+  event: ScheduleEventDto;
+} & Omit<InProgressActivity, 'eventId'>;
+
+export type FlowStartedPayload = {
+  event: ScheduleEventDto;
+} & Omit<InProgressFlow, 'eventId'>;
 
 export type MultiInformantPayload = Required<MultiInformantState>;

--- a/src/entities/applet/model/types.ts
+++ b/src/entities/applet/model/types.ts
@@ -159,7 +159,7 @@ export type RemoveGroupProgressPayload = {
 };
 
 export type SaveGroupProgressPayload = {
-  activityId: string;
+  entityId: string;
   eventId: string;
   targetSubjectId: string | null;
   progressPayload: GroupProgress;
@@ -253,5 +253,12 @@ export type ActivityStartedPayload = {
 export type FlowStartedPayload = {
   event: ScheduleEventDto;
 } & Omit<InProgressFlow, 'eventId'>;
+
+export type FlowRestartedPayload = {
+  flowId: string;
+  eventId: string;
+  targetSubjectId: string | null;
+  activityId: string;
+};
 
 export type MultiInformantPayload = Required<MultiInformantState>;

--- a/src/entities/event/lib/types/event.ts
+++ b/src/entities/event/lib/types/event.ts
@@ -57,4 +57,5 @@ export type ScheduleEvent = {
   notificationSettings: NotificationSettings;
   selectedDate: Date | null;
   scheduledAt: Date | null;
+  version?: string | null;
 };

--- a/src/entities/event/model/mappers.ts
+++ b/src/entities/event/model/mappers.ts
@@ -30,6 +30,7 @@ export function mapEventFromDto(dto: ScheduleEventDto): ScheduleEvent {
       notifications: [],
       reminder: null,
     },
+    version: dto.version,
   };
 }
 

--- a/src/features/PassSurvey/hooks/useAnswers.ts
+++ b/src/features/PassSurvey/hooks/useAnswers.ts
@@ -56,7 +56,7 @@ export const useAnswerBuilder = (): AnswerBuilder => {
         groupProgress,
         userEvents: params.userEvents,
         items: params.items,
-        event: params.event ?? context.event,
+        event: params.event ?? groupProgress.event ?? context.event,
         activityId: params.activityId,
         appletId: params.appletId ?? context.appletId,
         appletVersion: params.appletVersion ?? context.appletVersion,

--- a/src/features/PassSurvey/hooks/useStartSurvey.ts
+++ b/src/features/PassSurvey/hooks/useStartSurvey.ts
@@ -42,7 +42,7 @@ export const useStartSurvey = ({ applet, isPublic, publicAppletKey }: Props) => 
   const appletId = applet?.id;
   const flows = applet?.activityFlows;
 
-  const { removeGroupProgress } = appletModel.hooks.useGroupProgressStateManager();
+  const { flowRestarted, activityRestarted } = appletModel.hooks.useGroupProgressStateManager();
 
   const { removeActivityProgress } = appletModel.hooks.useActivityProgress();
 
@@ -118,7 +118,10 @@ export const useStartSurvey = ({ applet, isPublic, publicAppletKey }: Props) => 
 
       if (shouldRestart) {
         removeActivityProgress({ activityId, eventId, targetSubjectId });
-        removeGroupProgress({ entityId: flowId, eventId, targetSubjectId });
+
+        // Update group progress rather than remove to preserve version of event that the flow was
+        // started with
+        flowRestarted({ flowId, eventId, targetSubjectId, activityId: firstActivityId });
       }
 
       const activityIdToNavigate = shouldRestart ? firstActivityId : activityId;
@@ -134,7 +137,10 @@ export const useStartSurvey = ({ applet, isPublic, publicAppletKey }: Props) => 
 
     if (shouldRestart) {
       removeActivityProgress({ activityId, eventId, targetSubjectId });
-      removeGroupProgress({ entityId: activityId, eventId, targetSubjectId });
+
+      // Update group progress rather than remove to preserve version of event that the activity was
+      // started with
+      activityRestarted({ activityId, eventId, targetSubjectId });
     }
 
     return navigateToEntity({

--- a/src/features/PassSurvey/model/AnswersConstructService.ts
+++ b/src/features/PassSurvey/model/AnswersConstructService.ts
@@ -142,6 +142,7 @@ export default class AnswersConstructService implements ICompletionConstructServ
         width: window.innerWidth,
         height: window.innerHeight,
       },
+      eventHistoryId: `${this.event.id}_${this.event.version}`,
     };
   }
 

--- a/src/features/PassSurvey/model/AnswersConstructService.ts
+++ b/src/features/PassSurvey/model/AnswersConstructService.ts
@@ -142,7 +142,7 @@ export default class AnswersConstructService implements ICompletionConstructServ
         width: window.innerWidth,
         height: window.innerHeight,
       },
-      eventHistoryId: `${this.event.id}_${this.event.version}`,
+      ...(this.event.version && { eventHistoryId: `${this.event.id}_${this.event.version}` }),
     };
   }
 

--- a/src/shared/api/types/activity.ts
+++ b/src/shared/api/types/activity.ts
@@ -136,6 +136,7 @@ export type AnswerPayload = {
   sourceSubjectId?: ID | null;
   targetSubjectId?: ID | null;
   prolificParams?: ProlificUrlParamsPayload;
+  eventHistoryId?: string | null;
 };
 
 export type AlertDTO = {

--- a/src/shared/api/types/applet.ts
+++ b/src/shared/api/types/applet.ts
@@ -134,6 +134,7 @@ export type ScheduleEventDto = {
     timer: HourMinute | null;
     idleTimer: HourMinute | null;
   };
+  version?: string | null;
 };
 
 export type AppletEventsResponse = {

--- a/src/shared/api/types/events.ts
+++ b/src/shared/api/types/events.ts
@@ -1,6 +1,5 @@
 import { AllUserEventsDTO, AppletEventsResponse } from './applet';
 import { BaseSuccessResponse } from './base';
-import { HourMinute } from '../../utils';
 
 export type TimerTypeDTO = 'NOT_SET';
 export type PeriodicityTypeDTO = 'ONCE' | 'DAILY' | 'WEEKLY' | 'WEEKDAYS' | 'MONTHLY' | 'ALWAYS';
@@ -15,28 +14,3 @@ export type GetEventsByPublicAppletKey = {
 
 export type SuccessEventsByAppletIdResponse = BaseSuccessResponse<AppletEventsResponse>;
 export type SuccessAllUserEventsResponse = BaseSuccessResponse<AllUserEventsDTO[]>;
-
-export type EventsByAppletIdResponseDTO = {
-  appletId: string;
-  events: EventDTO[];
-};
-
-export type EventDTO = {
-  id: string;
-  entityId: string;
-  availability: {
-    oneTimeCompletion: boolean;
-    periodicityType: 'ONCE' | 'DAILY' | 'WEEKLY' | 'WEEKDAYS' | 'MONTHLY' | 'ALWAYS';
-    timeFrom: HourMinute;
-    timeTo: HourMinute;
-    allowAccessBeforeFromTime: boolean;
-    startDate: string;
-    endDate: string;
-  };
-  selectedDate: string | null;
-  timers: {
-    timer: HourMinute;
-    idleTimer: HourMinute;
-  };
-  availabilityType: 'AlwaysAvailable' | 'ScheduledAccess';
-};

--- a/src/test/utils/mock.ts
+++ b/src/test/utils/mock.ts
@@ -5,6 +5,7 @@ import {
   ActivityFlowDTO,
   AppletEventsResponse,
   HydratedAssignmentDTO,
+  ScheduleEventDto,
 } from '~/shared/api';
 import { SubjectDTO } from '~/shared/api/types/subject';
 
@@ -173,6 +174,24 @@ const mockEventId4 = 'event-4';
 const mockEventId5 = 'event-5';
 const mockEventId6 = 'event-6';
 
+export const mockEvent: ScheduleEventDto = {
+  id: mockEventId6,
+  entityId: mockFlowId3,
+  availabilityType: AvailabilityLabelType.AlwaysAvailable,
+  availability: {
+    oneTimeCompletion: false,
+    periodicityType: 'ALWAYS',
+    timeFrom: { hours: 0, minutes: 0 },
+    timeTo: { hours: 0, minutes: 0 },
+    allowAccessBeforeFromTime: false,
+  },
+  selectedDate: null,
+  timers: {
+    timer: null,
+    idleTimer: null,
+  },
+};
+
 export const mockEventsResponse: AppletEventsResponse = {
   events: [
     {
@@ -260,23 +279,7 @@ export const mockEventsResponse: AppletEventsResponse = {
         idleTimer: null,
       },
     },
-    {
-      id: mockEventId6,
-      entityId: mockFlowId3,
-      availabilityType: AvailabilityLabelType.AlwaysAvailable,
-      availability: {
-        oneTimeCompletion: false,
-        periodicityType: 'ALWAYS',
-        timeFrom: { hours: 0, minutes: 0 },
-        timeTo: { hours: 0, minutes: 0 },
-        allowAccessBeforeFromTime: false,
-      },
-      selectedDate: null,
-      timers: {
-        timer: null,
-        idleTimer: null,
-      },
-    },
+    mockEvent,
   ],
 };
 
@@ -292,5 +295,6 @@ export const mockEntityProgress: GroupProgressState = {
     context: { summaryData: {} },
     startAt: 1,
     endAt: null,
+    event: mockEvent,
   },
 };

--- a/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.ts
+++ b/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.ts
@@ -11,7 +11,7 @@ type FilterCompletedEntitiesProps = {
 };
 
 export const useEntitiesSync = ({ completedEntities }: FilterCompletedEntitiesProps) => {
-  const { applet } = useContext(AppletDetailsContext);
+  const { applet, events } = useContext(AppletDetailsContext);
   const { saveGroupProgress, getGroupProgress } = appletModel.hooks.useGroupProgressStateManager();
 
   const syncEntity = useCallback(
@@ -32,6 +32,8 @@ export const useEntitiesSync = ({ completedEntities }: FilterCompletedEntitiesPr
       });
 
       if (!groupProgress) {
+        const event = events.events.find(({ id }) => id === eventId) ?? null;
+
         return saveGroupProgress({
           activityId: entityId,
           eventId,
@@ -43,11 +45,10 @@ export const useEntitiesSync = ({ completedEntities }: FilterCompletedEntitiesPr
             context: {
               summaryData: {},
             },
+            event,
           },
         });
-      }
-
-      if (groupProgress.endAt) {
+      } else if (groupProgress.endAt) {
         const isServerEndAtBigger = endAtTimestamp > new Date(groupProgress.endAt).getTime();
 
         if (!isServerEndAtBigger) {
@@ -65,7 +66,7 @@ export const useEntitiesSync = ({ completedEntities }: FilterCompletedEntitiesPr
         });
       }
     },
-    [applet.respondentMeta?.subjectId, getGroupProgress, saveGroupProgress],
+    [applet.respondentMeta?.subjectId, events.events, getGroupProgress, saveGroupProgress],
   );
 
   useEffect(() => {

--- a/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.ts
+++ b/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.ts
@@ -35,7 +35,7 @@ export const useEntitiesSync = ({ completedEntities }: FilterCompletedEntitiesPr
         const event = events.events.find(({ id }) => id === eventId) ?? null;
 
         return saveGroupProgress({
-          activityId: entityId,
+          entityId,
           eventId,
           targetSubjectId,
           progressPayload: {
@@ -56,7 +56,7 @@ export const useEntitiesSync = ({ completedEntities }: FilterCompletedEntitiesPr
         }
 
         return saveGroupProgress({
-          activityId: entityId,
+          entityId,
           eventId,
           targetSubjectId,
           progressPayload: {

--- a/src/widgets/Survey/model/hooks/useEntityTimer.ts
+++ b/src/widgets/Survey/model/hooks/useEntityTimer.ts
@@ -34,7 +34,7 @@ export const useEntityTimer = ({ onFinish }: Props) => {
   useEffect(() => {
     const isSummaryScreenOpen = activityProgress?.isSummaryScreenOpen ?? false;
 
-    const timerSettings = context.event.timers.timer;
+    const timerSettings = groupProgress?.event?.timers.timer;
 
     if (!groupProgress || !timerSettings || isSummaryScreenOpen) {
       return;
@@ -85,7 +85,6 @@ export const useEntityTimer = ({ onFinish }: Props) => {
   }, [
     activityProgress?.isSummaryScreenOpen,
     context.entityId,
-    context.event.timers.timer,
     context.eventId,
     groupProgress,
     onFinish,

--- a/src/widgets/Survey/ui/PassingScreen.tsx
+++ b/src/widgets/Survey/ui/PassingScreen.tsx
@@ -341,7 +341,7 @@ const PassingScreen = (props: Props) => {
 
   // This effect is responsible for starting the timer when the user is inactive
   useEffect(() => {
-    const idleTimer = context?.event?.timers?.idleTimer;
+    const idleTimer = groupProgress?.event?.timers?.idleTimer;
 
     if (!idleTimer) {
       return;
@@ -359,14 +359,19 @@ const PassingScreen = (props: Props) => {
     return () => {
       IdleTimer.stop(listener);
     };
-  }, [IdleTimer, autoCompletionState, context.event?.timers?.idleTimer, props.onTimerFinish]);
+  }, [
+    IdleTimer,
+    autoCompletionState,
+    groupProgress?.event?.timers?.idleTimer,
+    props.onTimerFinish,
+  ]);
 
   return (
     <>
       <SurveyLayout
         progress={progress}
         isSaveAndExitButtonShown={true}
-        entityTimer={context.event?.timers?.timer ?? undefined}
+        entityTimer={groupProgress?.event?.timers?.timer ?? undefined}
         footerActions={
           <SurveyManageButtons
             timerSettings={!isSubmitModalOpen ? timerSettings : undefined}

--- a/src/widgets/Survey/ui/WelcomeScreen.tsx
+++ b/src/widgets/Survey/ui/WelcomeScreen.tsx
@@ -29,7 +29,6 @@ const WelcomeScreen = () => {
   const { setInitialProgress } = appletModel.hooks.useActivityProgress();
 
   const isFlow = !!context.flow;
-  const isTimedActivity = !!context.event?.timers?.timer;
   const targetSubjectId = context.targetSubject?.id ?? null;
 
   const groupProgress = appletModel.hooks.useGroupProgressRecord({
@@ -38,28 +37,30 @@ const WelcomeScreen = () => {
     targetSubjectId,
   });
 
+  const isTimedActivity = !!groupProgress?.event?.timers?.timer;
+
   const startAssessment = useCallback(() => {
     const isGroupDefined = !!groupProgress;
 
     const isGroupStarted = isGroupDefined && groupProgress.startAt && !groupProgress.endAt;
 
     if (context.flow && !isGroupStarted) {
-      startFlow(context.eventId, context.flow, targetSubjectId);
+      startFlow(context.event, context.flow, targetSubjectId);
     }
 
     if (!context.flow) {
-      startActivity(context.activityId, context.eventId, targetSubjectId);
+      startActivity(context.activityId, context.event, targetSubjectId);
     }
 
     return setInitialProgress({
       activity: context.activity,
-      eventId: context.eventId,
+      eventId: context.event.id,
       targetSubjectId,
     });
   }, [
     context.activity,
     context.activityId,
-    context.eventId,
+    context.event,
     context.flow,
     targetSubjectId,
     groupProgress,
@@ -104,7 +105,7 @@ const WelcomeScreen = () => {
     <SurveyLayout
       progress={0}
       isSaveAndExitButtonShown={true}
-      entityTimer={context.event?.timers?.timer ?? undefined}
+      entityTimer={groupProgress?.event?.timers.timer ?? undefined}
       footerActions={
         <StartSurveyButton
           width={greaterThanSM ? '375px' : '335px'}
@@ -179,8 +180,8 @@ const WelcomeScreen = () => {
           <Box textAlign="center" marginTop="16px">
             <Text variant="body1" fontSize="18px">
               {t('youWillHaveToCompleteIt', {
-                hours: context.event.timers.timer?.hours,
-                minutes: context.event.timers.timer?.minutes,
+                hours: groupProgress.event?.timers.timer?.hours,
+                minutes: groupProgress.event?.timers.timer?.minutes,
               })}
             </Text>
             <Text variant="body1" fontSize="18px">

--- a/src/widgets/Survey/ui/WelcomeScreen.tsx
+++ b/src/widgets/Survey/ui/WelcomeScreen.tsx
@@ -44,12 +44,14 @@ const WelcomeScreen = () => {
 
     const isGroupStarted = isGroupDefined && groupProgress.startAt && !groupProgress.endAt;
 
+    const event = groupProgress?.event ?? context.event;
+
     if (context.flow && !isGroupStarted) {
-      startFlow(context.event, context.flow, targetSubjectId);
+      startFlow(event, context.flow, targetSubjectId);
     }
 
     if (!context.flow) {
-      startActivity(context.activityId, context.event, targetSubjectId);
+      startActivity(context.activityId, event, targetSubjectId);
     }
 
     return setInitialProgress({


### PR DESCRIPTION
### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

> [!IMPORTANT]
> For the answer submission to be accepted by the BE, it requires running it with this branch checked out: https://github.com/ChildMindInstitute/mindlogger-backend-refactor/pull/1754

🔗 [Jira Ticket M2-8480](https://mindlogger.atlassian.net/browse/M2-8480)

This change adds the `eventHistoryId` property to answer submissions.

### 🪤 Peer Testing

<!-- If peer testing is not needed, then delete this section -->
<!-- Uncomment out any of the following as needed:           -->
<!-- **Requires `yarn install`**     -->

1. Create an applet with an activity and an activity flow.
2. Log into the Web App.
3. Open DevTools Network tab.
4. Submit an assessment and observe the payload of the `POST /answers` request:
    **Expected outcome:** The JSON object should contain the property `eventHistoryId` with a value in this format: `[event ID]_[version]`.
5. While in DevTools, inspect the most recent result of the `GET /users/me/events/{applet_id}` endpoint and take note of the `version` associated with each event.
6. **Restart the activity**, proceed past the welcome screen, then click **Save & Exit**.
7. **Restart the flow**, proceed past the welcome screen, then click **Save & Exit**.
8. From the Admin App's **Applet > Schedule** tab, edit the event associated with each activity & flow and enable **Scheduled access** for each of them.
9. Reload the Web App, and again inspect the most recent result of the `GET /users/me/events/{applet_id}` endpoint, taking note of the `version` associated with each event.
    **Expected outcome:** They should be **incremented** from what you observed in step 5.
11. **Resume the activity**, submit the assessment, and observe the payload of the `POST /answers` request:
    **Expected outcome:** The JSON object should contain the property `eventHistoryId` with a value in this format: `[event ID]_[version]`, where `[version]` corresponds to the activity's event version found in **step 5**.
12. **Resume the flow**, submit each activity, and observe the payload of each `POST /answers` request associated with its activities:
    **Expected outcome:** The JSON object for each submission should contain the property `eventHistoryId` with a value in this format: `[event ID]_[version]`, where `[version]` corresponds to the flow's event version found in **step 5**.
13. Repeat steps 6-11, but click **Restart** instead of resuming.
    **Expected outcome:** The version found in the `eventHistoryId` property for each submission should correspond to the respective version observed in **step 5**.