### PR TITLE
fix: Response Identifier fix – look up option by `value` not index (M2-8780)

### DIFF
--- a/src/features/PassSurvey/model/AnswersConstructService.ts
+++ b/src/features/PassSurvey/model/AnswersConstructService.ts
@@ -226,8 +226,10 @@ export default class AnswersConstructService implements ICompletionConstructServ
     if (item.responseType === 'text') {
       identifier = item.answer[0];
     } else if (item.responseType === 'singleSelect') {
-      const optionIndex = Number(item.answer[0]);
-      identifier = item.responseValues.options[optionIndex].text;
+      const option = item.responseValues.options.find(
+        ({ value }) => value === Number(item.answer[0]),
+      );
+      identifier = option?.text ?? null;
     }
 
     return identifier;


### PR DESCRIPTION
### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-8780](https://mindlogger.atlassian.net/browse/M2-8780)

When submitting an assessment that includes a **Single Selection** item with **Response Identifier** setting enabled, and an option was chosen after previous options were deleted by the admin, the Response Identifier can be miscalculated, and in fact even result in the Web App causing an error that prevents submission due to out-of-bounds array lookup.

The matching option should have been looked up by `value`, not by array index; this PR fixes that.

The mobile app does option lookup differently since its design is quite different from the web app, and as a result does not have this bug.

### 🪤 Peer Testing

#### Preconditions:

1.  Have an applet with an activity and an Single Selection item with the "Response Identifier" setting **checked**.
2.  On that item, allow the respondent to choose from 3 options.
3.  Don't submit any responses to this activity yet (it'll make things unclear later).

**Steps to Reproduce the Issue**

1.  In the Admin App, edit the aforementioned activity, and **delete** the 1st option from the Single Selection item, then re-save the Applet.
2.  Perform Take Now on the activity, select the 1st option, and submit the assessment. (Note that with the bug present, the submission may fail here if choosing an option that causes an out of bounds array error.)
3.  Navigate to Dataviz, expand the **More Filters** section, and observe the options listed there.
    **Expected outcome:** The option in the dropdown should match what was picked during the assessment. (Before the bug was fixed, a different option will be listed there than the one selected during the assessment.)