### PR TITLE
feat: add events tracking for Prolific

### DIFF
--- a/src/features/PassSurvey/hooks/useStartSurvey.ts
+++ b/src/features/PassSurvey/hooks/useStartSurvey.ts
@@ -1,5 +1,6 @@
 import { EntityType } from '~/abstract/lib/GroupBuilder';
 import { appletModel } from '~/entities/applet';
+import { prolificParamsSelector } from '~/entities/applet/model/selectors';
 import { AppletBaseDTO } from '~/shared/api';
 import ROUTES from '~/shared/constants/routes';
 import {
@@ -8,11 +9,13 @@ import {
   Mixpanel,
   useCustomNavigation,
   AssessmentStartedEvent,
+  useAppSelector,
 } from '~/shared/utils';
 import {
   addFeatureToEvent,
   addSurveyPropsToEvent,
   MixpanelFeature,
+  WithProlific,
 } from '~/shared/utils/analytics';
 
 type NavigateToEntityProps = {
@@ -45,6 +48,8 @@ export const useStartSurvey = ({ applet, isPublic, publicAppletKey }: Props) => 
   const { removeGroupProgress } = appletModel.hooks.useGroupProgressStateManager();
 
   const { removeActivityProgress } = appletModel.hooks.useActivityProgress();
+
+  const prolificParams = useAppSelector(prolificParamsSelector);
 
   const { isInMultiInformantFlow, getMultiInformantState } =
     appletModel.hooks.useMultiInformantState();
@@ -90,10 +95,19 @@ export const useStartSurvey = ({ applet, isPublic, publicAppletKey }: Props) => 
   }: OnActivityCardClickProps) {
     if (!applet) return;
 
-    const event: AssessmentStartedEvent = addSurveyPropsToEvent(
+    const event: WithProlific<AssessmentStartedEvent> = addSurveyPropsToEvent(
       { action: MixpanelEventType.AssessmentStarted },
-      { applet, activityId, flowId },
+      {
+        applet,
+        activityId,
+        flowId,
+      },
     );
+
+    if (prolificParams) {
+      event[MixpanelProps.ProlificPid] = prolificParams.prolificPid;
+      event[MixpanelProps.ProlificStudyId] = prolificParams.studyId;
+    }
 
     if (isInMultiInformantFlow()) {
       addFeatureToEvent(event, MixpanelFeature.MultiInformant);

--- a/src/features/PassSurvey/hooks/useStartSurvey.ts
+++ b/src/features/PassSurvey/hooks/useStartSurvey.ts
@@ -105,8 +105,10 @@ export const useStartSurvey = ({ applet, isPublic, publicAppletKey }: Props) => 
     );
 
     if (prolificParams) {
-      event[MixpanelProps.ProlificPid] = prolificParams.prolificPid;
-      event[MixpanelProps.ProlificStudyId] = prolificParams.studyId;
+      addFeatureToEvent(event, MixpanelFeature.Prolific);
+
+      event[MixpanelProps.StudyUserId] = prolificParams.prolificPid;
+      event[MixpanelProps.StudyReference] = prolificParams.studyId;
     }
 
     if (isInMultiInformantFlow()) {

--- a/src/features/PassSurvey/hooks/useSubmitAnswersMutation.ts
+++ b/src/features/PassSurvey/hooks/useSubmitAnswersMutation.ts
@@ -70,14 +70,14 @@ export const useSubmitAnswersMutations = ({ isPublic, onSubmitSuccess, onSubmitE
     Mixpanel.track(assessmentCompletedEvent);
 
     if (prolificParams) {
-      addFeatureToEvent(assessmentCompletedEvent, MixpanelFeature.Prolific);
-
       const signupEvent: WithProlific<SignupSuccessfulEvent> = {
         action: MixpanelEventType.SignupSuccessful,
       };
 
       signupEvent[MixpanelProps.StudyUserId] = prolificParams.prolificPid;
       signupEvent[MixpanelProps.StudyReference] = prolificParams.studyId;
+
+      addFeatureToEvent(signupEvent, MixpanelFeature.Prolific);
 
       Mixpanel.track(signupEvent);
     }

--- a/src/features/PassSurvey/hooks/useSubmitAnswersMutation.ts
+++ b/src/features/PassSurvey/hooks/useSubmitAnswersMutation.ts
@@ -45,8 +45,10 @@ export const useSubmitAnswersMutations = ({ isPublic, onSubmitSuccess, onSubmitE
     );
 
     if (prolificParams) {
-      assessmentCompletedEvent[MixpanelProps.ProlificPid] = prolificParams.prolificPid;
-      assessmentCompletedEvent[MixpanelProps.ProlificStudyId] = prolificParams.studyId;
+      addFeatureToEvent(assessmentCompletedEvent, MixpanelFeature.Prolific);
+
+      assessmentCompletedEvent[MixpanelProps.StudyUserId] = prolificParams.prolificPid;
+      assessmentCompletedEvent[MixpanelProps.StudyReference] = prolificParams.studyId;
     }
 
     if (isInMultiInformantFlow()) {
@@ -68,12 +70,14 @@ export const useSubmitAnswersMutations = ({ isPublic, onSubmitSuccess, onSubmitE
     Mixpanel.track(assessmentCompletedEvent);
 
     if (prolificParams) {
+      addFeatureToEvent(assessmentCompletedEvent, MixpanelFeature.Prolific);
+
       const signupEvent: WithProlific<SignupSuccessfulEvent> = {
         action: MixpanelEventType.SignupSuccessful,
       };
 
-      signupEvent[MixpanelProps.ProlificPid] = prolificParams.prolificPid;
-      signupEvent[MixpanelProps.ProlificStudyId] = prolificParams.studyId;
+      signupEvent[MixpanelProps.StudyUserId] = prolificParams.prolificPid;
+      signupEvent[MixpanelProps.StudyReference] = prolificParams.studyId;
 
       Mixpanel.track(signupEvent);
     }

--- a/src/shared/utils/analytics/mixpanel.types.ts
+++ b/src/shared/utils/analytics/mixpanel.types.ts
@@ -10,6 +10,8 @@ export enum MixpanelProps {
   MultiInformantAssessmentId = 'Multi-informant Assessment ID',
   TotalResponseReports = 'Total Response Reports',
   SubmitId = 'Submit ID',
+  ProlificPid = 'Study User ID',
+  ProlificStudyId = 'Study Reference',
 }
 
 export enum MixpanelFeature {
@@ -43,6 +45,11 @@ export type WithFeature<T = object> = T & {
   [MixpanelProps.Feature]?: MixpanelFeature[];
 };
 
+export type WithProlific<T> = T & {
+  [MixpanelProps.ProlificPid]?: string;
+  [MixpanelProps.ProlificStudyId]?: string;
+};
+
 export type AppletClickEvent = WithAppletId<{
   action: MixpanelEventType.AppletClick;
 }>;
@@ -69,6 +76,8 @@ export type AssessmentStartedEvent = WithFeature<
     [MixpanelProps.ActivityFlowId]?: string;
     [MixpanelProps.MultiInformantAssessmentId]?: string;
     [MixpanelProps.ItemTypes]?: ItemResponseTypeDTO[];
+    [MixpanelProps.ProlificPid]?: string;
+    [MixpanelProps.ProlificStudyId]?: string;
   }>
 >;
 

--- a/src/shared/utils/analytics/mixpanel.types.ts
+++ b/src/shared/utils/analytics/mixpanel.types.ts
@@ -10,13 +10,14 @@ export enum MixpanelProps {
   MultiInformantAssessmentId = 'Multi-informant Assessment ID',
   TotalResponseReports = 'Total Response Reports',
   SubmitId = 'Submit ID',
-  ProlificPid = 'Study User ID',
-  ProlificStudyId = 'Study Reference',
+  StudyUserId = 'Study User ID',
+  StudyReference = 'Study Reference',
 }
 
 export enum MixpanelFeature {
   MultiInformant = 'Multi-informant',
   SSI = 'SSI',
+  Prolific = 'Prolific',
 }
 
 export enum MixpanelEventType {
@@ -46,8 +47,8 @@ export type WithFeature<T = object> = T & {
 };
 
 export type WithProlific<T> = T & {
-  [MixpanelProps.ProlificPid]?: string;
-  [MixpanelProps.ProlificStudyId]?: string;
+  [MixpanelProps.StudyUserId]?: string;
+  [MixpanelProps.StudyReference]?: string;
 };
 
 export type AppletClickEvent = WithAppletId<{
@@ -76,8 +77,8 @@ export type AssessmentStartedEvent = WithFeature<
     [MixpanelProps.ActivityFlowId]?: string;
     [MixpanelProps.MultiInformantAssessmentId]?: string;
     [MixpanelProps.ItemTypes]?: ItemResponseTypeDTO[];
-    [MixpanelProps.ProlificPid]?: string;
-    [MixpanelProps.ProlificStudyId]?: string;
+    [MixpanelProps.StudyUserId]?: string;
+    [MixpanelProps.StudyReference]?: string;
   }>
 >;
 


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [ ] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [ ] OSS packages added to MindLogger [open source credit page](https://mindlogger.atlassian.net/jira/servicedesk/projects/MLA/knowledge/articles/340623543?spaceKey=MLA)

### 📝 Description
This PR adds a tracking of prolific events. 3 Events are tracked:
- Assessment Started
- Assessment completed
- Signup Successful

2 Key metrics are sent with those events:
- Prolific PID
- Prolific Study Id

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-8751](https://mindlogger.atlassian.net/browse/M2-8751)

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->


### Notes
- User ID cannot be tracked, since the user is anonymous.