### PR TITLE
fix: activity start page shown on activity submission

### DIFF
--- a/src/entities/applet/model/hooks/useEntityComplete.ts
+++ b/src/entities/applet/model/hooks/useEntityComplete.ts
@@ -79,10 +79,9 @@ export const useEntityComplete = (props: Props) => {
           const { completionCodes } = completionCodesReponse.data;
           for (const code of completionCodes) {
             if (code.codeType === 'COMPLETED') {
-              window.location.replace(
+              return window.location.replace(
                 `https://app.prolific.com/submissions/complete?cc=${code.code}`,
               );
-              return;
             }
           }
 
@@ -234,11 +233,13 @@ export const useEntityComplete = (props: Props) => {
 
   const completeActivity = useCallback(
     (input?: CompleteOptions) => {
-      removeActivityProgress({
-        activityId: props.activityId,
-        eventId: props.eventId,
-        targetSubjectId: props.targetSubjectId,
-      });
+      if (!prolificParams) {
+        removeActivityProgress({
+          activityId: props.activityId,
+          eventId: props.eventId,
+          targetSubjectId: props.targetSubjectId,
+        });
+      }
 
       return completeEntityAndRedirect(input?.type || 'regular');
     },
@@ -248,6 +249,7 @@ export const useEntityComplete = (props: Props) => {
       props.eventId,
       props.targetSubjectId,
       removeActivityProgress,
+      prolificParams,
     ],
   );
 


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [ ] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [ ] OSS packages added to MindLogger [open source credit page](https://mindlogger.atlassian.net/jira/servicedesk/projects/MLA/knowledge/articles/340623543?spaceKey=MLA)

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->
There is a delay in between submission and the redirection to an external website. During this delay, the activity start page is shown. The fix introduced is to keep the loading page until we are redirected to Prolific.
🔗 [Jira Ticket M2-8837](https://mindlogger.atlassian.net/browse/M2-8837)

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

Changes include:

- Removing the activity progress only if we are not in the Prolific Flow
