### PR TITLE
fix: LaunchDarkly env variable parsing correction

### DIFF
--- a/src/app/LaunchDarklyProvider.tsx
+++ b/src/app/LaunchDarklyProvider.tsx
@@ -16,7 +16,9 @@ SentryInit({
   tracesSampleRate: 1.0,
 
   tracePropagationTargets: import.meta.env.VITE_SENTRY_TRACE_PROPAGATION_TARGETS
-    ? (JSON.parse(import.meta.env.VITE_SENTRY_TRACE_PROPAGATION_TARGETS) as Array<string>)
+    ? (JSON.parse(
+        import.meta.env.VITE_SENTRY_TRACE_PROPAGATION_TARGETS.replace(/'/g, '"'),
+      ) as Array<string>)
     : [],
 
   // Capture Replay for 10% of all sessions,


### PR DESCRIPTION
### 📝 Description

This PR focuses on doing a small correction to an environment variable parsing (`VITE_SENTRY_TRACE_PROPAGATION_TARGETS`) that prompted the application to either get stuck in a loading state, or not render anything at all.

The error was shown on console as:

![70751](https://github.com/user-attachments/assets/9b9992a0-22c7-4933-8b54-83bd0e8d030d)

### ✏️ Notes

This issue was only spotted after a fresh repo clone/setup, but the fix should cover for any issues related with this, since the parsing of the variable was, in fact, incorrectly done in JS/TS conventions.