### PR TITLE
fix: Prevent app crash with missing DD variables

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -19,34 +19,40 @@ import './index.css';
 const isProduction = import.meta.env.VITE_ENV === 'prod';
 const isDev = import.meta.env.VITE_ENV === 'dev';
 
-datadogLogs.init({
-  clientToken: import.meta.env.VITE_DD_CLIENT_TOKEN as string,
-  site: 'datadoghq.com',
-  forwardErrorsToLogs: true,
-  sessionSampleRate: 100,
-  service: 'mindlogger-web',
-  env: import.meta.env.VITE_ENV,
-  version: import.meta.env.VITE_DD_VERSION as string,
-});
+if (import.meta.env.VITE_DD_CLIENT_TOKEN) {
+  datadogLogs.init({
+    clientToken: import.meta.env.VITE_DD_CLIENT_TOKEN,
+    site: 'datadoghq.com',
+    forwardErrorsToLogs: true,
+    sessionSampleRate: 100,
+    service: 'mindlogger-web',
+    env: import.meta.env.VITE_ENV,
+    version: import.meta.env.VITE_DD_VERSION,
+  });
+}
 
-if (isDev || isProduction) {
+if (
+  import.meta.env.VITE_DD_APP_ID &&
+  import.meta.env.VITE_DD_CLIENT_TOKEN &&
+  (isDev || isProduction)
+) {
   datadogRum.init({
-    applicationId: import.meta.env.VITE_DD_APP_ID as string,
-    clientToken: import.meta.env.VITE_DD_CLIENT_TOKEN as string,
+    applicationId: import.meta.env.VITE_DD_APP_ID,
+    clientToken: import.meta.env.VITE_DD_CLIENT_TOKEN,
     // `site` refers to the Datadog site parameter of your organization
     // see https://docs.datadoghq.com/getting_started/site/
     site: 'datadoghq.com',
     service: 'mindlogger-web',
     env: import.meta.env.VITE_ENV,
     // Specify a version number to identify the deployed version of your application in Datadog
-    version: import.meta.env.VITE_DD_VERSION as string,
+    version: import.meta.env.VITE_DD_VERSION,
     sessionSampleRate: 100,
     sessionReplaySampleRate: 0,
     defaultPrivacyLevel: 'mask',
     trackResources: true,
     trackLongTasks: true,
     trackUserInteractions: false,
-    allowedTracingUrls: (import.meta.env.VITE_DD_TRACING_URLS as string)
+    allowedTracingUrls: (import.meta.env.VITE_DD_TRACING_URLS ?? '')
       .split(',')
       .map((it: string) => it.trim()),
   });

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -12,6 +12,11 @@ interface ImportMetaEnv {
 
   readonly VITE_SENTRY_DSN: string;
   readonly VITE_SENTRY_TRACE_PROPAGATION_TARGETS: string; // List of domains Array<string>
+
+  readonly VITE_DD_CLIENT_TOKEN: string | undefined;
+  readonly VITE_DD_APP_ID: string | undefined;
+  readonly VITE_DD_VERSION: string | undefined;
+  readonly VITE_DD_TRACING_URLS: string | undefined;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
### 📝 Description

This changes allows Amplify preview environments to continue to work, which do not have Datadog environment variables set.

### 🪤 Peer Testing

- Open the Amplify environment associated with this PR.
    **Expected outcome:** Admin App should load normally, without a JS error displayed in DevTools.