### PR TITLE
fix: prolific - cached answers

### DIFF
--- a/src/entities/applet/model/hooks/useEntityComplete.ts
+++ b/src/entities/applet/model/hooks/useEntityComplete.ts
@@ -73,6 +73,12 @@ export const useEntityComplete = (props: Props) => {
       }
 
       if (prolificParams && props.publicAppletKey) {
+        removeActivityProgress({
+          activityId: props.activityId,
+          eventId: props.eventId,
+          targetSubjectId: props.targetSubjectId,
+        });
+
         const { data: completionCodesReponse } = await fetchCompletionCodes();
         if (!isCompletionCodesReponseError && completionCodesReponse) {
           clearProlificParams(); // Resetting redux state after completion
@@ -121,6 +127,7 @@ export const useEntityComplete = (props: Props) => {
       isCompletionCodesReponseError,
       clearProlificParams,
       addErrorBanner,
+      removeActivityProgress,
       props.activityId,
       props.appletId,
       props.eventId,


### PR DESCRIPTION

### 📝 Description

Participants see cached answers from Study_1 when starting Study_2 if both studies use the same public link, even though they should not. This PR fixes the issue by removing the `activityProgress` of the activity once the user submit their answers.

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-8918](https://mindlogger.atlassian.net/browse/M2-8918)
