### PR TITLE
fix: Support restart action when not yet started (M2-8950)

### DIFF
--- a/src/entities/applet/model/slice.ts
+++ b/src/entities/applet/model/slice.ts
@@ -297,7 +297,9 @@ const appletsSlice = createSlice({
       const groupProgress = state.groupProgress[id] as ActivityProgress &
         EventProgressTimestampState;
 
-      groupProgress.startAt = new Date().getTime();
+      if (groupProgress) {
+        groupProgress.startAt = new Date().getTime();
+      }
     },
 
     flowRestarted: (state, { payload }: PayloadAction<FlowRestartedPayload>) => {
@@ -305,10 +307,12 @@ const appletsSlice = createSlice({
 
       const groupProgress = state.groupProgress[id] as FlowProgress & EventProgressTimestampState;
 
-      groupProgress.currentActivityId = payload.activityId;
-      groupProgress.pipelineActivityOrder = 0;
-      groupProgress.currentActivityStartAt = groupProgress.startAt = new Date().getTime();
-      groupProgress.executionGroupKey = uuidV4();
+      if (groupProgress) {
+        groupProgress.currentActivityId = payload.activityId;
+        groupProgress.pipelineActivityOrder = 0;
+        groupProgress.currentActivityStartAt = groupProgress.startAt = new Date().getTime();
+        groupProgress.executionGroupKey = uuidV4();
+      }
     },
 
     entityCompleted: (state, { payload }: PayloadAction<InProgressEntity>) => {


### PR DESCRIPTION

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-8950](https://mindlogger.atlassian.net/browse/M2-8950)

This is a hotfix for a regression introduced by #587 where Take Now fails due to an existing `groupProgress` entry being missing when requesting to restart the activity/flow. This change makes the restart actions more forgiving by not assuming an existing `groupProgress` entry exists.

### 🪤 Peer Testing

1. Perform **Take Now** on an activity.
    **Expected outcome:** The web app proceeds to load the activity and allow you to submit it.
2. Perform **Take Now** on a flow.
    **Expected outcome:** The web app proceeds to load the flow and allow you to submit it.