### PR TITLE
fix: start activity screen shown after submission

### DIFF
--- a/src/entities/applet/model/hooks/useEntityComplete.ts
+++ b/src/entities/applet/model/hooks/useEntityComplete.ts
@@ -73,19 +73,23 @@ export const useEntityComplete = (props: Props) => {
       }
 
       if (prolificParams && props.publicAppletKey) {
+        const { data: completionCodesReponse } = await fetchCompletionCodes();
+
         removeActivityProgress({
           activityId: props.activityId,
           eventId: props.eventId,
           targetSubjectId: props.targetSubjectId,
         });
 
-        const { data: completionCodesReponse } = await fetchCompletionCodes();
         if (!isCompletionCodesReponseError && completionCodesReponse) {
           clearProlificParams(); // Resetting redux state after completion
 
           const { completionCodes } = completionCodesReponse.data;
           for (const code of completionCodes) {
             if (code.codeType === 'COMPLETED') {
+              // There is a delay in the redirect, the start screen is shown for a second
+              // before the redirect to prolific happens. This is a workaround to hide that screen during that time.
+              document.body.innerHTML = '';
               return window.location.replace(
                 `https://app.prolific.com/submissions/complete?cc=${code.code}`,
               );


### PR DESCRIPTION
- Add a little workaround to fix this by showing a white screen right before the redirect

<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [ ] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [ ] OSS packages added to MindLogger [open source credit page](https://mindlogger.atlassian.net/jira/servicedesk/projects/MLA/knowledge/articles/340623543?spaceKey=MLA)

### 📝 Description

After a successful submission, the activity start screen is shown for a little time before redirecting to prolific. This PR fixes this issue by showing a white screen before redirecting back to prolific. Note that this is a workaround.

🔗 [Jira Ticket M2-8837](https://mindlogger.atlassian.net/browse/M2-8837)

### 📸 Screenshots

<!--
If your work here contains visual changes, provide before (optional) and after screenshots, GIFs, or videos.

If not, then delete this section
-->

| Before (Optional)                      | After                                 |
| -------------------------------------- | ------------------------------------- |
| See JIRA issue | 

https://github.com/user-attachments/assets/f6ed91b4-fe32-4e99-be92-95ebc43bf46a

 |

