### PR TITLE
fix: Remove unwanted whitespace in component test id (M2-8988)

### DIFF
--- a/src/shared/ui/Items/SelectBase/SelectBaseBox.tsx
+++ b/src/shared/ui/Items/SelectBase/SelectBaseBox.tsx
@@ -37,8 +37,6 @@ export const SelectBaseBox = (props: Props) => {
     ? hoverBackgroundColor
     : Theme.colors.light.neutural90;
 
-  const dataTestId = `select-box ${props.color ? `bgcolor-${props.color}` : ''}`.trim();
-
   return (
     <Box
       display="flex"
@@ -52,7 +50,7 @@ export const SelectBaseBox = (props: Props) => {
       border={`2px solid ${borderColor}`}
       bgcolor={props.color ? props.color : backgroundColor}
       onClick={props.onHandleChange}
-      data-testid={dataTestId}
+      data-testid="select-box"
       sx={{
         ...(props.sx ?? {}),
         transition: 'background-color 0.2s ease-in-out',

--- a/src/shared/ui/Items/SelectBase/SelectBaseBox.tsx
+++ b/src/shared/ui/Items/SelectBase/SelectBaseBox.tsx
@@ -37,6 +37,8 @@ export const SelectBaseBox = (props: Props) => {
     ? hoverBackgroundColor
     : Theme.colors.light.neutural90;
 
+  const dataTestId = `select-box ${props.color ? `bgcolor-${props.color}` : ''}`.trim();
+
   return (
     <Box
       display="flex"
@@ -50,7 +52,7 @@ export const SelectBaseBox = (props: Props) => {
       border={`2px solid ${borderColor}`}
       bgcolor={props.color ? props.color : backgroundColor}
       onClick={props.onHandleChange}
-      data-testid={`select-box ${props.color ? `bgcolor-${props.color}` : ''}`}
+      data-testid={dataTestId}
       sx={{
         ...(props.sx ?? {}),
         transition: 'background-color 0.2s ease-in-out',


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-8988](https://mindlogger.atlassian.net/browse/M2-8988)

This PR adds a simple fix to an issue that was causing extra whitespace to be rendered in some components' test IDs.

A simple `trim()` prevents extra whitespace from being rendered when the conditional test id assignment returns `undefined`.

### 🪤 Peer Testing

This was causing some tests to fail, so running the whole test suite successfully, without any issues related to whitespace or missmatched test ids, should work as a clear indicator this specific issue is solved.
