### PR TITLE
chore: Upgrade axios to ^1.8.2 (M2-9142)

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"@types/mixpanel-browser": "^2.50.0",
 		"@types/node": "^20.10.4",
 		"@uiw/react-md-editor": "^3.20.5",
-		"axios": "^1.7.7",
+		"axios": "^1.8.2",
 		"buffer": "^6.0.3",
 		"date-fns": "^2.29.3",
 		"dayspan": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2193,10 +2193,10 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
-axios@^1.7.7:
-  version "1.7.7"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.7.tgz#2f554296f9892a72ac8d8e4c5b79c14a91d0a47f"
-  integrity sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==
+axios@^1.8.2:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.9.0.tgz#25534e3b72b54540077d33046f77e3b8d7081901"
+  integrity sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==
   dependencies:
     follow-redirects "^1.15.6"
     form-data "^4.0.0"


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-9142](https://mindlogger.atlassian.net/browse/M2-9142)

This PR updates the `axios` entry in the `package.json` file to `^1.8.2`, up from `^1.7.7`. As at today, this will install version 1.9.0 and the `yarn.lock` file has also been updated to reflect that.

I've performed the following verification steps to build confidence that this doesn't break anything:
- [x] Read the axios changelog between versions 1.7.7 and 1.9.0 for any breaking changes relative to this repo
- [x] Run the dev server
- [x] Build the code
- [x] Run the production server on the build output
- [x] Complete a few activity submissions
- [x] Run the tests

### 📸 Screenshots

N/A

### 🪤 Peer Testing

Poke it and see if it breaks

### ✏️ Notes

N/A