### PR TITLE
fix: Problems saving phrase-builder action plan on mobile browser (M2-9181)

### DIFF
--- a/src/entities/activity/lib/downloadPhrasalTemplateItem.ts
+++ b/src/entities/activity/lib/downloadPhrasalTemplateItem.ts
@@ -39,7 +39,14 @@ const getDocumentImageDataUris: DocumentImageDataUrisGetter = async (options) =>
         // scaling), then this would only make the image 50% larger.
         scale: 3,
       });
-      return canvas.toDataURL('image/jpeg');
+      // Convert canvas to a Blob and create an object URL
+      const blob = await new Promise<Blob | null>((resolve) =>
+        canvas.toBlob(resolve, 'image/jpeg'),
+      );
+      if (!blob) {
+        throw new Error('Canvas toBlob failed');
+      }
+      return URL.createObjectURL(blob);
     }),
   );
 };

--- a/src/entities/activity/lib/downloadPhrasalTemplateItem.ts
+++ b/src/entities/activity/lib/downloadPhrasalTemplateItem.ts
@@ -51,19 +51,10 @@ const getDocumentImageDataUris: DocumentImageDataUrisGetter = async (options) =>
   );
 };
 
-const dataUriToFile = (dataURI: string, filename: string): File => {
-  const byteString = atob(dataURI.split(',')[1]);
-  const mimeString = dataURI.split(',')[0].split(':')[1].split(';')[0];
-
-  const byteBuffer = new ArrayBuffer(byteString.length);
-  const byteArray = new Uint8Array(byteBuffer);
-
-  for (let byteIndex = 0; byteIndex < byteString.length; byteIndex++) {
-    // Convert each character in the data-uti string to the character's byte value.
-    byteArray[byteIndex] = byteString.charCodeAt(byteIndex);
-  }
-
-  return new File([byteArray], filename, { type: mimeString });
+const objectUrlToFile = async (objectUrl: string, filename: string): Promise<File> => {
+  const response = await fetch(objectUrl);
+  const blob = await response.blob();
+  return new File([blob], filename, { type: blob.type });
 };
 
 type CardImageDownloaderOptions = {
@@ -92,7 +83,8 @@ export const downloadPhrasalTemplateItem: CardImageDownloader = async (options) 
   if (options.share) {
     const imageFiles: File[] = [];
     for (let dataUriIndex = 0; dataUriIndex < dataUris.length; dataUriIndex++) {
-      imageFiles.push(dataUriToFile(dataUris[dataUriIndex], getFilename(dataUriIndex)));
+      const file = await objectUrlToFile(dataUris[dataUriIndex], getFilename(dataUriIndex));
+      imageFiles.push(file);
     }
 
     if (imageFiles.length > 0) {

--- a/src/entities/activity/lib/downloadPhrasalTemplateItem.ts
+++ b/src/entities/activity/lib/downloadPhrasalTemplateItem.ts
@@ -7,7 +7,7 @@ type GetDocumentImageDataUrisOptions = {
 
 type DocumentImageDataUrisGetter = (options: GetDocumentImageDataUrisOptions) => Promise<string[]>;
 
-const getDocumentImageDataUris: DocumentImageDataUrisGetter = async (options) => {
+export const getDocumentImageDataUris: DocumentImageDataUrisGetter = async (options) => {
   let nodes: HTMLElement[];
   if (options.single) {
     const documentNode = document.querySelector<HTMLElement>(
@@ -51,7 +51,7 @@ const getDocumentImageDataUris: DocumentImageDataUrisGetter = async (options) =>
   );
 };
 
-const objectUrlToFile = async (objectUrl: string, filename: string): Promise<File> => {
+export const objectUrlToFile = async (objectUrl: string, filename: string): Promise<File> => {
   const response = await fetch(objectUrl);
   const blob = await response.blob();
   return new File([blob], filename, { type: blob.type });

--- a/src/entities/activity/lib/downloadPhrasalTemplateItem.ts
+++ b/src/entities/activity/lib/downloadPhrasalTemplateItem.ts
@@ -63,12 +63,11 @@ type CardImageDownloaderOptions = {
   documentId: string;
   filename: string;
   single: boolean;
-  share: boolean;
 };
 
 type CardImageDownloader = (options: CardImageDownloaderOptions) => Promise<void>;
 
-export const downloadPhrasalTemplateItem: CardImageDownloader = async (options) => {
+export const downloadPhrasalTemplateItemDesktop: CardImageDownloader = async (options) => {
   const dataUris = await getDocumentImageDataUris({
     documentId: options.documentId,
     single: options.single,
@@ -82,32 +81,21 @@ export const downloadPhrasalTemplateItem: CardImageDownloader = async (options) 
     return `${filename}.jpg`;
   };
 
-  if (options.share) {
-    const imageFiles: File[] = [];
-    for (let dataUriIndex = 0; dataUriIndex < dataUris.length; dataUriIndex++) {
-      imageFiles.push(dataUriToFile(dataUris[dataUriIndex], getFilename(dataUriIndex)));
-    }
+  for (let dataUriIndex = 0; dataUriIndex < dataUris.length; dataUriIndex++) {
+    const dataUri = dataUris[dataUriIndex];
+    const downloadLink = document.createElement('a');
+    downloadLink.setAttribute('href', dataUri);
+    downloadLink.setAttribute('download', getFilename(dataUriIndex));
 
-    if (imageFiles.length > 0) {
-      await navigator.share({ files: imageFiles });
-    }
-  } else {
-    for (let dataUriIndex = 0; dataUriIndex < dataUris.length; dataUriIndex++) {
-      const dataUri = dataUris[dataUriIndex];
-      const downloadLink = document.createElement('a');
-      downloadLink.setAttribute('href', dataUri);
-      downloadLink.setAttribute('download', getFilename(dataUriIndex));
+    document.body.appendChild(downloadLink);
+    downloadLink.click();
 
-      document.body.appendChild(downloadLink);
-      downloadLink.click();
+    // Add some delay before removing the link so Safari wouldn't end up skipping items.
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    document.body.removeChild(downloadLink);
 
-      // Add some delay before removing the link so Safari wouldn't end up skipping items.
-      await new Promise((resolve) => setTimeout(resolve, 500));
-      document.body.removeChild(downloadLink);
-
-      if (dataUriIndex < dataUris.length - 1) {
-        await new Promise((resolve) => setTimeout(resolve, 100));
-      }
+    if (dataUriIndex < dataUris.length - 1) {
+      await new Promise((resolve) => setTimeout(resolve, 100));
     }
   }
 };

--- a/src/entities/activity/lib/downloadPhrasalTemplateItem.ts
+++ b/src/entities/activity/lib/downloadPhrasalTemplateItem.ts
@@ -8,7 +8,6 @@ type GetDocumentImageDataUrisOptions = {
 type DocumentImageDataUrisGetter = (options: GetDocumentImageDataUrisOptions) => Promise<string[]>;
 
 export const getDocumentImageDataUris: DocumentImageDataUrisGetter = async (options) => {
-  console.log('getDocumentImageDataUris', options);
   let nodes: HTMLElement[];
   if (options.single) {
     const documentNode = document.querySelector<HTMLElement>(
@@ -28,8 +27,6 @@ export const getDocumentImageDataUris: DocumentImageDataUrisGetter = async (opti
       ),
     );
   }
-
-  console.log('nodes', nodes);
 
   return Promise.all(
     nodes.map(async (node) => {

--- a/src/entities/activity/lib/downloadPhrasalTemplateItem.ts
+++ b/src/entities/activity/lib/downloadPhrasalTemplateItem.ts
@@ -8,6 +8,7 @@ type GetDocumentImageDataUrisOptions = {
 type DocumentImageDataUrisGetter = (options: GetDocumentImageDataUrisOptions) => Promise<string[]>;
 
 export const getDocumentImageDataUris: DocumentImageDataUrisGetter = async (options) => {
+  console.log('getDocumentImageDataUris', options);
   let nodes: HTMLElement[];
   if (options.single) {
     const documentNode = document.querySelector<HTMLElement>(
@@ -27,6 +28,8 @@ export const getDocumentImageDataUris: DocumentImageDataUrisGetter = async (opti
       ),
     );
   }
+
+  console.log('nodes', nodes);
 
   return Promise.all(
     nodes.map(async (node) => {

--- a/src/entities/activity/ui/items/PhrasalTemplateItem.tsx
+++ b/src/entities/activity/ui/items/PhrasalTemplateItem.tsx
@@ -41,7 +41,7 @@ export const PhrasalTemplateItem = ({ item, replaceText }: PhrasalTemplateItemPr
     (i) => i.responseType === 'phrasalTemplate',
   ).length;
 
-  const handleDownloadImage = useCallback(() => {
+  const handleDownloadImage = useCallback(async () => {
     Mixpanel.track(
       addSurveyPropsToEvent(
         {
@@ -53,19 +53,16 @@ export const PhrasalTemplateItem = ({ item, replaceText }: PhrasalTemplateItemPr
       ),
     );
 
-    // Schedule the async download to preserve gesture context
-    setTimeout(() => {
-      void downloadPhrasalTemplateItem({
-        documentId: documentIdRef.current,
-        filename: [
-          appletDisplayName,
-          phrasalTemplateCardTitle,
-          formatDate(new Date(), 'MM_dd_yyyy'),
-        ].join('_'),
-        share: isMobile,
-        single: false,
-      });
-    }, 0);
+    await downloadPhrasalTemplateItem({
+      documentId: documentIdRef.current,
+      filename: [
+        appletDisplayName,
+        phrasalTemplateCardTitle,
+        formatDate(new Date(), 'MM_dd_yyyy'),
+      ].join('_'),
+      share: isMobile,
+      single: false,
+    });
   }, [
     activityId,
     applet,

--- a/src/entities/activity/ui/items/PhrasalTemplateItem.tsx
+++ b/src/entities/activity/ui/items/PhrasalTemplateItem.tsx
@@ -105,6 +105,10 @@ export const PhrasalTemplateItem = ({ item, replaceText }: PhrasalTemplateItemPr
   });
 
   useLayoutEffect(() => {
+    if (!isMobile) {
+      return;
+    }
+
     // Fetch mobile download files
     async function effect() {
       if (documentIdRef.current) {
@@ -140,7 +144,7 @@ export const PhrasalTemplateItem = ({ item, replaceText }: PhrasalTemplateItemPr
       }
     }
 
-    const timeout = setTimeout(effect, 3000);
+    const timeout = setTimeout(effect, 0);
 
     return () => clearTimeout(timeout);
   }, [appletDisplayName, documentIdRef, phrasalTemplateCardTitle]);

--- a/src/entities/activity/ui/items/PhrasalTemplateItem.tsx
+++ b/src/entities/activity/ui/items/PhrasalTemplateItem.tsx
@@ -12,7 +12,7 @@ import downloadIconLight from '~/assets/download-icon-light.svg';
 import downloadIconDark from '~/assets/download-icon.svg';
 import { PhrasalTemplateItem as PhrasalTemplateItemType } from '~/entities/activity/lib';
 import {
-  downloadPhrasalTemplateItem,
+  downloadPhrasalTemplateItemDesktop,
   getDocumentImageDataUris,
   dataUriToFile,
 } from '~/entities/activity/lib/downloadPhrasalTemplateItem';
@@ -63,7 +63,7 @@ export const PhrasalTemplateItem = ({ item, replaceText }: PhrasalTemplateItemPr
         void navigator.share({ files: mobileDownloadFiles });
       }
     } else {
-      void downloadPhrasalTemplateItem({
+      void downloadPhrasalTemplateItemDesktop({
         documentId: documentIdRef.current,
         filename: [
           appletDisplayName,

--- a/src/entities/activity/ui/items/PhrasalTemplateItem.tsx
+++ b/src/entities/activity/ui/items/PhrasalTemplateItem.tsx
@@ -110,7 +110,7 @@ export const PhrasalTemplateItem = ({ item, replaceText }: PhrasalTemplateItemPr
     }
 
     // Fetch mobile download files
-    async function effect() {
+    const interval = setInterval(async () => {
       if (documentIdRef.current) {
         console.log('Fetching mobile download files');
         const dataUris = await getDocumentImageDataUris({
@@ -140,13 +140,14 @@ export const PhrasalTemplateItem = ({ item, replaceText }: PhrasalTemplateItemPr
 
         console.log('imageFiles:', imageFiles);
 
-        setMobileDownloadFiles(imageFiles);
+        if (imageFiles.length > 0) {
+          clearInterval(interval);
+          setMobileDownloadFiles(imageFiles);
+        }
       }
-    }
+    }, 0);
 
-    const timeout = setTimeout(effect, 0);
-
-    return () => clearTimeout(timeout);
+    return () => clearInterval(interval);
   }, [appletDisplayName, documentIdRef, phrasalTemplateCardTitle]);
 
   return (

--- a/src/entities/activity/ui/items/PhrasalTemplateItem.tsx
+++ b/src/entities/activity/ui/items/PhrasalTemplateItem.tsx
@@ -70,7 +70,6 @@ export const PhrasalTemplateItem = ({ item, replaceText }: PhrasalTemplateItemPr
           phrasalTemplateCardTitle,
           formatDate(new Date(), 'MM_dd_yyyy'),
         ].join('_'),
-        share: false,
         single: false,
       });
     }

--- a/src/entities/activity/ui/items/PhrasalTemplateItem.tsx
+++ b/src/entities/activity/ui/items/PhrasalTemplateItem.tsx
@@ -41,7 +41,7 @@ export const PhrasalTemplateItem = ({ item, replaceText }: PhrasalTemplateItemPr
     (i) => i.responseType === 'phrasalTemplate',
   ).length;
 
-  const handleDownloadImage = useCallback(async () => {
+  const handleDownloadImage = useCallback(() => {
     Mixpanel.track(
       addSurveyPropsToEvent(
         {
@@ -53,16 +53,19 @@ export const PhrasalTemplateItem = ({ item, replaceText }: PhrasalTemplateItemPr
       ),
     );
 
-    await downloadPhrasalTemplateItem({
-      documentId: documentIdRef.current,
-      filename: [
-        appletDisplayName,
-        phrasalTemplateCardTitle,
-        formatDate(new Date(), 'MM_dd_yyyy'),
-      ].join('_'),
-      share: isMobile,
-      single: false,
-    });
+    // Schedule the async download to preserve gesture context
+    setTimeout(() => {
+      downloadPhrasalTemplateItem({
+        documentId: documentIdRef.current,
+        filename: [
+          appletDisplayName,
+          phrasalTemplateCardTitle,
+          formatDate(new Date(), 'MM_dd_yyyy'),
+        ].join('_'),
+        share: isMobile,
+        single: false,
+      });
+    }, 0);
   }, [
     activityId,
     applet,

--- a/src/entities/activity/ui/items/PhrasalTemplateItem.tsx
+++ b/src/entities/activity/ui/items/PhrasalTemplateItem.tsx
@@ -140,7 +140,9 @@ export const PhrasalTemplateItem = ({ item, replaceText }: PhrasalTemplateItemPr
       }
     }
 
-    void effect();
+    const timeout = setTimeout(effect, 3000);
+
+    return () => clearTimeout(timeout);
   }, [appletDisplayName, documentIdRef, phrasalTemplateCardTitle]);
 
   return (

--- a/src/entities/activity/ui/items/PhrasalTemplateItem.tsx
+++ b/src/entities/activity/ui/items/PhrasalTemplateItem.tsx
@@ -55,7 +55,7 @@ export const PhrasalTemplateItem = ({ item, replaceText }: PhrasalTemplateItemPr
 
     // Schedule the async download to preserve gesture context
     setTimeout(() => {
-      downloadPhrasalTemplateItem({
+      void downloadPhrasalTemplateItem({
         documentId: documentIdRef.current,
         filename: [
           appletDisplayName,

--- a/src/entities/activity/ui/items/PhrasalTemplateItem.tsx
+++ b/src/entities/activity/ui/items/PhrasalTemplateItem.tsx
@@ -58,8 +58,16 @@ export const PhrasalTemplateItem = ({ item, replaceText }: PhrasalTemplateItemPr
       ),
     );
 
-    if (isMobile && mobileDownloadFiles && mobileDownloadFiles.length > 0) {
-      void navigator.share({ files: mobileDownloadFiles });
+    console.log('Downloading image files');
+    console.log('isMobile:', isMobile);
+
+    if (isMobile) {
+      if (mobileDownloadFiles && mobileDownloadFiles.length > 0) {
+        console.log(`Downloading ${mobileDownloadFiles.length} files`);
+        void navigator.share({ files: mobileDownloadFiles });
+      } else {
+        console.log('No files to download');
+      }
     } else {
       void downloadPhrasalTemplateItem({
         documentId: documentIdRef.current,
@@ -100,10 +108,13 @@ export const PhrasalTemplateItem = ({ item, replaceText }: PhrasalTemplateItemPr
     // Fetch mobile download files
     async function effect() {
       if (documentIdRef.current) {
+        console.log('Fetching mobile download files');
         const dataUris = await getDocumentImageDataUris({
           documentId: documentIdRef.current,
           single: false,
         });
+
+        console.log('dataUris:', dataUris);
 
         const fileName = [
           appletDisplayName,
@@ -122,6 +133,8 @@ export const PhrasalTemplateItem = ({ item, replaceText }: PhrasalTemplateItemPr
           const file = await objectUrlToFile(dataUris[dataUriIndex], getFilename(dataUriIndex));
           imageFiles.push(file);
         }
+
+        console.log('imageFiles:', imageFiles);
 
         setMobileDownloadFiles(imageFiles);
       }

--- a/src/entities/activity/ui/items/PhrasalTemplateItem.tsx
+++ b/src/entities/activity/ui/items/PhrasalTemplateItem.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useContext, useCallback, useRef, useState, useEffect } from 'react';
+import { useMemo, useContext, useCallback, useRef, useState, useLayoutEffect } from 'react';
 
 import { Avatar, Button } from '@mui/material';
 import { format as formatDate } from 'date-fns';
@@ -104,7 +104,7 @@ export const PhrasalTemplateItem = ({ item, replaceText }: PhrasalTemplateItemPr
     );
   });
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     // Fetch mobile download files
     async function effect() {
       if (documentIdRef.current) {

--- a/src/entities/activity/ui/items/PhrasalTemplateItem.tsx
+++ b/src/entities/activity/ui/items/PhrasalTemplateItem.tsx
@@ -14,7 +14,7 @@ import { PhrasalTemplateItem as PhrasalTemplateItemType } from '~/entities/activ
 import {
   downloadPhrasalTemplateItem,
   getDocumentImageDataUris,
-  objectUrlToFile,
+  dataUriToFile,
 } from '~/entities/activity/lib/downloadPhrasalTemplateItem';
 import { SurveyContext } from '~/features/PassSurvey';
 import { Theme } from '~/shared/constants';
@@ -130,7 +130,7 @@ export const PhrasalTemplateItem = ({ item, replaceText }: PhrasalTemplateItemPr
 
         const imageFiles: File[] = [];
         for (let dataUriIndex = 0; dataUriIndex < dataUris.length; dataUriIndex++) {
-          const file = await objectUrlToFile(dataUris[dataUriIndex], getFilename(dataUriIndex));
+          const file = dataUriToFile(dataUris[dataUriIndex], getFilename(dataUriIndex));
           imageFiles.push(file);
         }
 

--- a/src/entities/activity/ui/items/PhrasalTemplateItem.tsx
+++ b/src/entities/activity/ui/items/PhrasalTemplateItem.tsx
@@ -58,15 +58,9 @@ export const PhrasalTemplateItem = ({ item, replaceText }: PhrasalTemplateItemPr
       ),
     );
 
-    console.log('Downloading image files');
-    console.log('isMobile:', isMobile);
-
     if (isMobile) {
       if (mobileDownloadFiles && mobileDownloadFiles.length > 0) {
-        console.log(`Downloading ${mobileDownloadFiles.length} files`);
         void navigator.share({ files: mobileDownloadFiles });
-      } else {
-        console.log('No files to download');
       }
     } else {
       void downloadPhrasalTemplateItem({
@@ -112,13 +106,10 @@ export const PhrasalTemplateItem = ({ item, replaceText }: PhrasalTemplateItemPr
     // Fetch mobile download files
     const interval = setInterval(async () => {
       if (documentIdRef.current) {
-        console.log('Fetching mobile download files');
         const dataUris = await getDocumentImageDataUris({
           documentId: documentIdRef.current,
           single: false,
         });
-
-        console.log('dataUris:', dataUris);
 
         const fileName = [
           appletDisplayName,
@@ -137,8 +128,6 @@ export const PhrasalTemplateItem = ({ item, replaceText }: PhrasalTemplateItemPr
           const file = dataUriToFile(dataUris[dataUriIndex], getFilename(dataUriIndex));
           imageFiles.push(file);
         }
-
-        console.log('imageFiles:', imageFiles);
 
         if (imageFiles.length > 0) {
           clearInterval(interval);

--- a/src/entities/activity/ui/items/PhrasalTemplateItem.tsx
+++ b/src/entities/activity/ui/items/PhrasalTemplateItem.tsx
@@ -166,6 +166,7 @@ export const PhrasalTemplateItem = ({ item, replaceText }: PhrasalTemplateItemPr
         onMouseEnter={() => setDownloadIcon(downloadIconLight)}
         onMouseLeave={() => setDownloadIcon(downloadIconDark)}
         onClick={handleDownloadImage}
+        disabled={isMobile && !mobileDownloadFiles}
         sx={{
           width: '172px',
           height: '48px',


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-9181](https://mindlogger.atlassian.net/browse/M2-9181)

This PR fixes an error on Chrome iOS with the action plan download button. When users click the download button, this error is thrown:

```
Unhandled Promise Rejection: NotAllowedError: The request is not allowed by the user agent or the platform in the current context, possibly because the user denied permission.
```

I assume that recent updates to Chrome have made it more finicky to trigger file downloads, and it seems that doing so inside an async function is problematic. This PR fixes that by doing a couple things:
- Converting the callback to a regular non-async function
- Pre-rendering the image(s) for download on mobile
- Not awaiting the call to the download function on desktop (as a consequence of the first change)

The pre-rendering bit is important so that no async work needs to be done when the user clicks the download button. All we need to do at that point is download the image(s). I have disabled the download button on mobile until the images have been pre-rendered successfully.

### 📸 Screenshots

#### Before

https://github.com/user-attachments/assets/863d915c-1ab5-44d7-bf8f-84d2cf467fef

#### After

https://github.com/user-attachments/assets/d2eb2e2c-5ee0-4c3b-946a-1e44b60e481d


### 🪤 Peer Testing

1. Access the following action plan activity using Chrome on an iPhone: https://pr-621.d15zn9do8xbzga.amplifyapp.com/public/59268176-0efa-42b0-aff4-4dfc2a5a81ec
2. Click the download button on the action plan page
3. Confirm that the share sheet appears and the image can be saved
4. Repeat the test in Safari and confirm it also works
5. Repeat the test on desktop and confirm that downloading still works there

### ✏️ Notes

This PR does **not** fix the image formatting issue on mobile. There will be a separate ticket for that