### PR TITLE
fix: Hidden item before EHR item type (M2-9269)

### DIFF
--- a/src/entities/applet/model/slice.ts
+++ b/src/entities/applet/model/slice.ts
@@ -276,9 +276,9 @@ const appletsSlice = createSlice({
       const id = getProgressId(payload.activityId, payload.eventId, payload.targetSubjectId);
 
       const activityProgress = state.progress[id];
-      const currentItem = activityProgress.items[activityProgress.step];
+      const currentItem = activityProgress.items.find(({ id }) => id === payload.item.id);
 
-      if (typeof currentItem.subStep === 'number') {
+      if (currentItem && typeof currentItem.subStep === 'number') {
         currentItem.subStep = payload.subStep;
       }
     },

--- a/src/entities/applet/model/types.ts
+++ b/src/entities/applet/model/types.ts
@@ -208,6 +208,7 @@ export type UpdateStepPayload = {
 };
 
 export type UpdateSubStepPayload = UpdateStepPayload & {
+  item: ItemRecord;
   subStep: number;
 };
 

--- a/src/widgets/Survey/model/hooks/useSubSteps/useSubSteps.test.tsx
+++ b/src/widgets/Survey/model/hooks/useSubSteps/useSubSteps.test.tsx
@@ -184,6 +184,7 @@ describe('useSubSteps', () => {
       activityId: 'activity-123',
       eventId: 'event-123',
       targetSubjectId: 'subject-123',
+      item: mockItem,
       subStep: RequestHealthRecordDataItemStep.ConsentPrompt + 1,
     });
   });
@@ -205,6 +206,7 @@ describe('useSubSteps', () => {
       activityId: 'activity-123',
       eventId: 'event-123',
       targetSubjectId: 'subject-123',
+      item: mockItem,
       subStep: RequestHealthRecordDataItemStep.OneUpHealth - 1,
     });
   });
@@ -248,6 +250,7 @@ describe('useSubSteps', () => {
       activityId: 'activity-123',
       eventId: 'event-123',
       targetSubjectId: 'subject-123',
+      item: mockItem,
       subStep: RequestHealthRecordDataItemStep.OneUpHealth,
     });
   });
@@ -269,6 +272,7 @@ describe('useSubSteps', () => {
       activityId: 'activity-123',
       eventId: 'event-123',
       targetSubjectId: 'subject-123',
+      item: mockItem,
       subStep: RequestHealthRecordDataItemStep.AdditionalPrompt,
     });
   });
@@ -290,6 +294,7 @@ describe('useSubSteps', () => {
       activityId: 'activity-123',
       eventId: 'event-123',
       targetSubjectId: 'subject-123',
+      item: mockItem,
       subStep: RequestHealthRecordDataItemStep.OneUpHealth,
     });
   });

--- a/src/widgets/Survey/model/hooks/useSubSteps/useSubSteps.ts
+++ b/src/widgets/Survey/model/hooks/useSubSteps/useSubSteps.ts
@@ -22,10 +22,11 @@ export const useSubSteps = ({ item }: UseSubStepsProps) => {
         activityId,
         eventId,
         targetSubjectId: targetSubject?.id ?? null,
+        item,
         subStep,
       });
     },
-    [activityId, eventId, targetSubject?.id, setActivitySubStep],
+    [setActivitySubStep, activityId, eventId, targetSubject?.id, item],
   );
 
   const subStep = useMemo(() => {

--- a/src/widgets/Survey/model/hooks/useSurveyState.ts
+++ b/src/widgets/Survey/model/hooks/useSurveyState.ts
@@ -5,10 +5,10 @@ import { PassSurveyModel } from '~/features/PassSurvey';
 import { useFeatureFlags } from '~/shared/utils/hooks/useFeatureFlags';
 import { FeatureFlag } from '~/shared/utils/types/featureFlags';
 
-export const useSurveyState = (activityProgress: appletModel.ActivityProgress) => {
+export const useSurveyState = (activityProgress: appletModel.ActivityProgress | null) => {
   const { featureFlag } = useFeatureFlags();
 
-  const items = useMemo(() => activityProgress?.items ?? [], [activityProgress.items]);
+  const items = useMemo(() => activityProgress?.items ?? [], [activityProgress?.items]);
 
   const availableItems = items.filter((item) => {
     if (item.isHidden) {


### PR DESCRIPTION

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-9269](https://mindlogger.atlassian.net/browse/M2-9269)

Fixes an issue whereby you can't proceed within the substeps of an EHR item – or proceed past it to any subsequent item and complete the assessment – if one or more items preceding the EHR item type are configured as hidden.

### 🪤 Peer Testing

1. Create an applet with an activity containing at least two items:
    - 1st item can be any item type, and should be hidden
    - 2nd item should be an EHR item
2. Start the activity in the Web App.
3. Click the “opt in” option on the EHR item type.
4. Click Next.
   **Expected outcome:** You're able to proceed past the consent step to the partnership step and share EHR data, and complete the assessment.