### PR TITLE
fix: Report Summary styling fixes (M2-9468)

### DIFF
--- a/src/widgets/Survey/ui/SummaryScreen/Alerts.tsx
+++ b/src/widgets/Survey/ui/SummaryScreen/Alerts.tsx
@@ -15,7 +15,7 @@ export const Alerts = ({ alerts }: Props) => {
   return (
     <Box
       padding="24px 32px"
-      bgcolor={variables.palette.error50}
+      bgcolor={variables.palette.errorContainer}
       borderRadius="12px"
       data-testid="alerts-container"
     >
@@ -26,11 +26,11 @@ export const Alerts = ({ alerts }: Props) => {
         {alerts.map((alert, index) => (
           <Box display="flex" gap="8px" key={index} marginTop="16px" data-testid="alert-item">
             <NotificationImportantIcon
-              fontSize="small"
-              sx={{ color: variables.palette.error50 }}
+              fontSize="medium"
+              sx={{ color: variables.palette.error }}
               data-testid="alert-item-icon"
             />
-            <Text variant="bodyLarge" testid="alert-item-label">
+            <Text variant="bodyLarger" testid="alert-item-label">
               {alert}
             </Text>
           </Box>

--- a/src/widgets/Survey/ui/SummaryScreen/ScoreSection.tsx
+++ b/src/widgets/Survey/ui/SummaryScreen/ScoreSection.tsx
@@ -10,7 +10,7 @@ type Props = {
 
 export const ScoreSection = (props: Props) => {
   return (
-    <Box padding="0px 16px" data-testid="score-section">
+    <Box data-testid="score-section">
       <Text
         variant="headlineSmall"
         margin="0px 0px 16px 0px"

--- a/src/widgets/Survey/ui/SummaryScreen/Scores.tsx
+++ b/src/widgets/Survey/ui/SummaryScreen/Scores.tsx
@@ -23,14 +23,14 @@ export const Scores = (props: Props) => {
           <Box display="flex" gap="8px" alignItems="center">
             {score.highlighted && (
               <NotificationImportantIcon
-                fontSize="small"
-                sx={{ color: variables.palette.error50 }}
+                fontSize="medium"
+                sx={{ color: variables.palette.error }}
                 data-testid="score-item-highlighted-icon"
               />
             )}
             <Text
-              variant="bodyMedium"
-              color={score.highlighted ? variables.palette.error50 : undefined}
+              variant="titleLargishBold"
+              color={score.highlighted ? variables.palette.error : undefined}
               testid="score-item-label"
             >
               {score.label}
@@ -39,13 +39,19 @@ export const Scores = (props: Props) => {
           <Box
             display="flex"
             justifyContent="center"
-            width="136px"
+            minWidth="120px"
             padding="4px 0px"
-            bgcolor={score.highlighted ? variables.palette.error50 : undefined}
+            bgcolor={
+              score.highlighted ? variables.palette.errorContainer : variables.palette.surface1
+            }
             borderRadius="100px"
             data-testid="score-item-value-container"
           >
-            <Text variant="headlineMedium" testid="score-item-value">
+            <Text
+              variant="titleLargeBold"
+              color={score.highlighted ? variables.palette.error : undefined}
+              testid="score-item-value"
+            >
               {score.value}
             </Text>
           </Box>

--- a/src/widgets/Survey/ui/SummaryScreen/index.tsx
+++ b/src/widgets/Survey/ui/SummaryScreen/index.tsx
@@ -80,7 +80,7 @@ const SummaryScreen = () => {
             {t('reportSummary')}
           </Text>
           {summaryData && summaryData.alerts.length > 0 && (
-            <Box margin="16px 0px">
+            <Box my="24px">
               <Alerts alerts={summaryData.alerts} />
             </Box>
           )}
@@ -89,7 +89,7 @@ const SummaryScreen = () => {
               summaryData.scores.length > 0 &&
               summaryData.scores.map((score, index) => (
                 <Box key={index}>
-                  <Divider sx={{ margin: '16px 0px' }} />
+                  <Divider sx={{ margin: '24px 0px' }} />
                   <ScoreSection score={score} />
                 </Box>
               ))}


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-9468](https://mindlogger.atlassian.net/browse/M2-9468)

Fixes the styling of the Report Summary screen so that it matches the mobile app more closely.

### 📸 Screenshots

| Before                      | After                                 |
| -------------------------------------- | ------------------------------------- |
| ![CleanShot 2025-06-26 at 09 47 12@2x](https://github.com/user-attachments/assets/85a55216-940e-4841-8a8d-28bb554ffef6) | ![CleanShot 2025-06-26 at 09 46 56@2x](https://github.com/user-attachments/assets/42728f5c-10ff-453f-991f-be46be9514d6) |
