### PR TITLE
fix: Inactivity Tracker logout memoization (M2-9446)

### DIFF
--- a/src/widgets/InactivityTracker/InactivityTracker.tsx
+++ b/src/widgets/InactivityTracker/InactivityTracker.tsx
@@ -25,10 +25,7 @@ export const InactivityTracker = ({ children }: InactivityTrackerProps) => {
     return () => {
       IdleTimer.stop(listener);
     };
-
-    // Should only run once
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [IdleTimer, logout]);
 
   return children as JSX.Element;
 };


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-9446](https://mindlogger.atlassian.net/browse/M2-9446)

This PR just adds a dependency array to the useEffect in the InactivityTracker. The lack of a dependency array caused the `IdleTimer.createListener` callback to be using an outdated version of the `logout` function, which has a reference to the URL that existed when the page first loaded.

### 📸 Screenshots

#### Before

https://github.com/user-attachments/assets/d5718b3e-82fb-4730-9fb1-19f030879de5

#### After

https://github.com/user-attachments/assets/fc67da6c-5194-4cbd-9ec2-faede9826c8a

### 🪤 Peer Testing

1. Temporarily edit the file [InactivityTracker.tsx:19](https://github.com/ChildMindInstitute/mindlogger-web-refactor/blob/98979e1b648774c9cf0bda3f738eea3189c0de59/src/widgets/InactivityTracker/InactivityTracker.tsx#L19) and set it to 1 minute to make testing easier
2. Create an activity with an EHR item
3. Complete and submit the activity, opting to share health data. You should have navigated through the interstitial screen and clicked continue in browser.
4. Wait for the timeout
5. Sign back in.
6. Confirm that you do not land on the interstitial page

### ✏️ Notes

N/A
