### PR TITLE
fix: activity reappearance across versions (M2-9510)

### DIFF
--- a/src/entities/activity/api/useCompletedEntitiesQuery.ts
+++ b/src/entities/activity/api/useCompletedEntitiesQuery.ts
@@ -5,7 +5,7 @@ type Options<TData> = QueryOptions<FetchFn, TData>;
 
 type Params = {
   appletId: string;
-  version: string;
+  version?: string;
   fromDate: string;
 };
 

--- a/src/shared/api/types/activity.ts
+++ b/src/shared/api/types/activity.ts
@@ -24,13 +24,7 @@ export type ID = string;
 
 export interface GetCompletedEntitiesPayload {
   appletId: ID;
-  version: string;
-  fromDate: string; // example: 2022-01-01
-}
-
-export interface GetCompletedEntitiesPayload {
-  appletId: ID;
-  version: string;
+  version?: string;
   fromDate: string; // example: 2022-01-01
 }
 

--- a/src/widgets/ActivityGroups/ui/ActivityGroupList.tsx
+++ b/src/widgets/ActivityGroups/ui/ActivityGroupList.tsx
@@ -29,7 +29,6 @@ export const ActivityGroupList = () => {
     useCompletedEntitiesQuery(
       {
         appletId: applet.id,
-        version: applet.version,
         fromDate: formatToDtoDate(subMonths(new Date(), 1)),
       },
       { select: (data) => data.data.result, enabled: !isPublic },


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [ ] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [ ] OSS packages added to Curious [open source credit page](https://mindlogger.atlassian.net/jira/servicedesk/projects/MLA/knowledge/articles/340623543?spaceKey=MLA)

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 Jira Tickets:  
- [M2-9510](https://mindlogger.atlassian.net/browse/M2-9510) – Web  


Make activity completions fetch **version-optional** by omitting the `version` query param when not provided. This lets the backend return completions across **all applet versions**, preventing completed activities from reappearing after a version bump.
<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

#### Changes
- `activityService.getCompletedEntities` now builds params as:
  - `fromDate` always
  - `version` only when explicitly provided
- `ActivityGroupList` uses last-month `fromDate` and feeds results into local state via `useEntitiesSync`


### 📸 Screenshots

<img width="1492" height="667" alt="image" src="https://github.com/user-attachments/assets/853d39e5-476d-468d-9e43-ed739ad1d5d1" />




### 🪤 Peer Testing

<!-- If peer testing is not needed, then delete this section -->
<!-- Uncomment out any of the following as needed:           -->
<!-- **Requires `yarn install`**     -->

<!--
Replace this with a series of test steps & expected outcomes.

Example test step:

- This is a test step.  Highlight actions **in bold**.

    **Expected outcome:** This is what to expect after the step
-->

**Steps to reproduce:**
1. Create an applet with one scheduled activity.  
2. Complete the activity on web.  
3. In admin panel, add another activity and save.  
4. Log out, clear cache, and log back in.  

**Expected:**  
- The completed activity should **not reappear**.  
- Both old and new activities show correct availability. 

### ✏️ Notes

- This PR pairs with the backend fix for M2-9510/8170 that supports completions across versions when `version` is omitted.  
- No UI/UX changes other than correct availability state.

[M2-9510]: https://mindlogger.atlassian.net/browse/M2-9510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
