### PR TITLE
fix: Greek language display issue (M2-9724)

### DIFF
--- a/src/i18n/pt/translation.json
+++ b/src/i18n/pt/translation.json
@@ -78,7 +78,7 @@
     "Language": {
       "english": "English",
       "french": "Français",
-      "greek": "Grego",
+      "greek": "Ελληνικά",
       "spanish": "Español",
       "portuguese": "Português"
     },


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [ ] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [ ] OSS packages added to Curious [open source credit page](https://mindlogger.atlassian.net/jira/servicedesk/projects/MLA/knowledge/articles/340623543?spaceKey=MLA)

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-9724](https://mindlogger.atlassian.net/browse/M2-9724)

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

This PR corrects the display name of the Greek language in the language selection dropdown.
Previously, after selecting Portuguese, Greek was incorrectly shown as "Grego" instead of "Ελληνικά".

Changes include:

- Fixed Greek label fallback to correctly show 'ελληνικά'
- Ensured consistent rendering across all supported language selections

### 📸 Screenshots

<!--
If your work here contains visual changes, provide before (optional) and after screenshots, GIFs, or videos.

If not, then delete this section
-->

| Before (Optional)                      | After                                 |
| -------------------------------------- | ------------------------------------- |
| <img width="1485" height="692" alt="image" src="https://github.com/user-attachments/assets/16f4b538-7cfa-4ca8-9b36-64bb4f12b212" /> | <img width="1476" height="681" alt="image" src="https://github.com/user-attachments/assets/d0f949f0-89f0-4081-9437-b4f5e937cebf" /> |

### 🪤 Peer Testing

<!-- If peer testing is not needed, then delete this section -->
<!-- Uncomment out any of the following as needed:           -->
<!-- **Requires `yarn install`**     -->

<!--
Replace this with a series of test steps & expected outcomes.

Example test step:

- This is a test step.  Highlight actions **in bold**.

    **Expected outcome:** This is what to expect after the step
-->

- Preconditions:

1. Log in to the web app

- Steps to Reproduce:

1.   Click the language dropdown (defaults to English)
2.   Observe the available language options 
3.   Select Portuguese  
4.   Open the dropdown again 
5.   Check how Greek is displayed

- Expected Result:

1. Greek is shown as ‘ελληνικά’
2. Selecting any language does not alter the list of available language names

### ✏️ Notes

<!--
Replace this line with anything else you think may be relevant or related PRs

If there are no notes, then delete this section.
-->

- This was caused by language fallback issues specific to the pt localization file
- This fix ensures consistent language key handling across all translations
