### PR TITLE
fix: isolate completedEntities query cache key per userId (M2-9741)

### DIFF
--- a/src/entities/activity/api/useCompletedEntitiesQuery.ts
+++ b/src/entities/activity/api/useCompletedEntitiesQuery.ts
@@ -1,3 +1,6 @@
+import { useSelector } from 'react-redux';
+
+import { userIdSelector } from '~/entities/user/model/selectors';
 import { QueryOptions, ReturnAwaited, activityService, useBaseQuery } from '~/shared/api';
 
 type FetchFn = typeof activityService.getCompletedEntities;
@@ -13,9 +16,15 @@ export const useCompletedEntitiesQuery = <TData = ReturnAwaited<FetchFn>>(
   params: Params,
   options?: Options<TData>,
 ) => {
-  return useBaseQuery(
-    ['completedEntities', params],
-    () => activityService.getCompletedEntities(params),
-    options,
-  );
+  const userId = useSelector(userIdSelector);
+
+  const key: [string, Record<string, unknown>] = [
+    'completedEntities',
+    { userId: userId ?? '', ...params },
+  ];
+
+  return useBaseQuery(key, () => activityService.getCompletedEntities(params), {
+    ...options,
+    enabled: !!userId && (options?.enabled ?? true),
+  });
 };


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [ ] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [ ] OSS packages added to Curious [open source credit page](https://mindlogger.atlassian.net/jira/servicedesk/projects/MLA/knowledge/articles/340623543?spaceKey=MLA)

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-9741](https://mindlogger.atlassian.net/browse/M2-9741)

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

This PR addresses a caching issue where `useCompletedEntitiesQuery` was returning stale or incorrect results when switching users on the same device/browser session.



Changes include:

- Scoped the query key to `userId` to isolate `completedEntities` cache per user.
- Added fallback for `userId` in the query key to ensure key stability during initial login.
- Enabled query conditionally to avoid firing without an authenticated user.

### 📸 Screenshots

<!--
If your work here contains visual changes, provide before (optional) and after screenshots, GIFs, or videos.

If not, then delete this section
-->

| Before (Optional)                      | After                                 |
| -------------------------------------- | ------------------------------------- |
| **User 1:** <img width="1493" height="581" alt="image" src="https://github.com/user-attachments/assets/db6ad811-28a4-4c0d-bf5a-ae339e45b2b3" /> **User 2:** <img width="1491" height="651" alt="image" src="https://github.com/user-attachments/assets/b49083bb-bcd8-437e-b1f5-b424acbd2024" /><!-- Paste before image/video here --> |**User:1** <img width="1480" height="515" alt="image" src="https://github.com/user-attachments/assets/74c43dac-404a-4217-a672-d71129bd6c75" /> **User: 2** <img width="1483" height="666" alt="image" src="https://github.com/user-attachments/assets/4fb5080a-eff8-499f-a27a-a75d128293a9" />

 <!-- Paste after image/video here --> 

### 🪤 Peer Testing

<!-- If peer testing is not needed, then delete this section -->
<!-- Uncomment out any of the following as needed:           -->
<!-- **Requires `yarn install`**     -->

<!--
Replace this with a series of test steps & expected outcomes.

Example test step:

- This is a test step.  Highlight actions **in bold**.

    **Expected outcome:** This is what to expect after the step
-->

- Log in as **User1**, complete a scheduled activity, and log out.
- Log in as **User2** on the same browser/device.

    **Expected outcome:** User2's own scheduled activities should be shown (not affected by User1's actions).


### ✏️ Notes

<!--
Replace this line with anything else you think may be relevant or related PRs

If there are no notes, then delete this section.
-->
- This change leverages `userIdSelector` from Redux and is implemented entirely in `useCompletedEntitiesQuery.ts`. No backend changes required. Also verified that logout clears related client state.
- These changes do not directly address the activity reappearance issue. They only ensure completedEntities are fetched and cached correctly on a per-user basis, which was a separate underlying concern.