### PR TITLE
feat: Fetch flows from server (M2-10229)

### DIFF
--- a/src/entities/activity/api/useCompletedEntitiesQuery.ts
+++ b/src/entities/activity/api/useCompletedEntitiesQuery.ts
@@ -10,6 +10,7 @@ type Params = {
   appletId: string;
   version?: string;
   fromDate: string;
+  includeInProgress?: boolean;
 };
 
 export const useCompletedEntitiesQuery = <TData = ReturnAwaited<FetchFn>>(

--- a/src/shared/api/services/activity.service.ts
+++ b/src/shared/api/services/activity.service.ts
@@ -25,7 +25,11 @@ function activityService() {
       return axiosService.get<CompletedEntitiesDTOSuccessResponse>(
         `/answers/applet/${payload.appletId}/completions`,
         {
-          params: { version: payload.version, fromDate: payload.fromDate },
+          params: {
+            version: payload.version,
+            fromDate: payload.fromDate,
+            includeInProgress: payload.includeInProgress,
+          },
         },
       );
     },

--- a/src/shared/api/types/activity.ts
+++ b/src/shared/api/types/activity.ts
@@ -235,8 +235,6 @@ export type CompletedEntityDTO = {
   id: string;
   answerId: string;
   submitId: string;
-  activityHistoryId: string;
-  flowHistoryId: string | null;
   targetSubjectId: string | null;
   scheduledEventId: string;
   localEndDate: string;

--- a/src/shared/api/types/activity.ts
+++ b/src/shared/api/types/activity.ts
@@ -26,6 +26,7 @@ export interface GetCompletedEntitiesPayload {
   appletId: ID;
   version?: string;
   fromDate: string; // example: 2022-01-01
+  includeInProgress?: boolean;
 }
 
 export type SuccessResponseActivityById = BaseSuccessResponse<ActivityDTO>;

--- a/src/shared/api/types/activity.ts
+++ b/src/shared/api/types/activity.ts
@@ -232,11 +232,9 @@ export type MatrixMultiSelectAnswerPayload = {
 };
 
 export type CompletedEntityDTO = {
-  /** @deprecated Use activityHistoryId and flowHistoryId instead. For activities, this is the activityHistoryId. For flows, this is the flowHistoryId. */
-  id: string;
   answerId: string;
   submitId: string;
-  activityHistoryId: string | null;
+  activityHistoryId: string;
   flowHistoryId: string | null;
   targetSubjectId: string | null;
   scheduledEventId: string;

--- a/src/shared/api/types/activity.ts
+++ b/src/shared/api/types/activity.ts
@@ -234,8 +234,8 @@ export type MatrixMultiSelectAnswerPayload = {
 export type CompletedEntityDTO = {
   answerId: string;
   submitId: string;
-  activityId: string;
-  flowId: string | null;
+  activityHistoryId: string;
+  flowHistoryId: string | null;
   targetSubjectId: string | null;
   scheduledEventId: string;
   localEndDate: string;

--- a/src/shared/api/types/activity.ts
+++ b/src/shared/api/types/activity.ts
@@ -232,6 +232,7 @@ export type MatrixMultiSelectAnswerPayload = {
 };
 
 export type CompletedEntityDTO = {
+  id: string;
   answerId: string;
   submitId: string;
   activityHistoryId: string;

--- a/src/shared/api/types/activity.ts
+++ b/src/shared/api/types/activity.ts
@@ -232,9 +232,12 @@ export type MatrixMultiSelectAnswerPayload = {
 };
 
 export type CompletedEntityDTO = {
+  /** @deprecated Use activityHistoryId and flowHistoryId instead. For activities, this is the activityHistoryId. For flows, this is the flowHistoryId. */
   id: string;
   answerId: string;
   submitId: string;
+  activityHistoryId: string | null;
+  flowHistoryId: string | null;
   targetSubjectId: string | null;
   scheduledEventId: string;
   localEndDate: string;

--- a/src/shared/api/types/activity.ts
+++ b/src/shared/api/types/activity.ts
@@ -234,8 +234,8 @@ export type MatrixMultiSelectAnswerPayload = {
 export type CompletedEntityDTO = {
   answerId: string;
   submitId: string;
-  activityHistoryId: string;
-  flowHistoryId: string | null;
+  activityId: string;
+  flowId: string | null;
   targetSubjectId: string | null;
   scheduledEventId: string;
   localEndDate: string;

--- a/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.ts
+++ b/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.ts
@@ -1,19 +1,22 @@
-import { useCallback, useContext, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 import { v4 as uuidV4 } from 'uuid';
 
-import { AppletDetailsContext } from '../../lib';
-
 import { ActivityPipelineType } from '~/abstract/lib';
 import { appletModel } from '~/entities/applet';
-import { CompletedEntitiesDTO, CompletedEntityDTO } from '~/shared/api';
+import { CompletedEntitiesDTO, CompletedEntityDTO, ScheduleEventDto } from '~/shared/api';
 
-type FilterCompletedEntitiesProps = {
-  completedEntities?: CompletedEntitiesDTO;
+type EntitiesSyncProps = {
+  completedEntities: CompletedEntitiesDTO | undefined;
+  respondentSubjectId: string | null;
+  events: ScheduleEventDto[];
 };
 
-export const useEntitiesSync = ({ completedEntities }: FilterCompletedEntitiesProps) => {
-  const { applet, events } = useContext(AppletDetailsContext);
+export const useEntitiesSync = ({
+  completedEntities,
+  respondentSubjectId,
+  events,
+}: EntitiesSyncProps) => {
   const { saveGroupProgress, getGroupProgress } = appletModel.hooks.useGroupProgressStateManager();
 
   // Create ref to exclude from callback dependencies to avoid infinite loop
@@ -31,7 +34,7 @@ export const useEntitiesSync = ({ completedEntities }: FilterCompletedEntitiesPr
       const eventId = entity.scheduledEventId;
       // Normalize targetSubjectId to null for self-reports
       const targetSubjectId =
-        entity.targetSubjectId === applet.respondentMeta?.subjectId ? null : entity.targetSubjectId;
+        entity.targetSubjectId === respondentSubjectId ? null : entity.targetSubjectId;
 
       const groupProgress = getGroupProgressRef.current({
         entityId,
@@ -39,7 +42,7 @@ export const useEntitiesSync = ({ completedEntities }: FilterCompletedEntitiesPr
         targetSubjectId,
       });
 
-      const event = events.events.find(({ id }) => id === eventId) ?? null;
+      const event = events.find(({ id }) => id === eventId) ?? null;
 
       if (!groupProgress) {
         return saveGroupProgress({
@@ -78,7 +81,7 @@ export const useEntitiesSync = ({ completedEntities }: FilterCompletedEntitiesPr
         });
       }
     },
-    [applet.respondentMeta?.subjectId, events.events, saveGroupProgress],
+    [respondentSubjectId, events, saveGroupProgress],
   );
 
   useEffect(() => {

--- a/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.ts
+++ b/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.ts
@@ -30,8 +30,9 @@ export const useEntitiesSync = ({
       const endAtDate = new Date(`${entity.localEndDate}T${entity.localEndTime}`);
       const endAtTimestamp = endAtDate.getTime();
 
-      const entityId = entity.flowHistoryId ?? entity.activityHistoryId;
+      const entityId = entity.id; // TODO: Switch to `entity.flowHistoryId ?? entity.activityHistoryId` to fully support versions
       const eventId = entity.scheduledEventId;
+
       // Normalize targetSubjectId to null for self-reports
       const targetSubjectId =
         entity.targetSubjectId === respondentSubjectId ? null : entity.targetSubjectId;

--- a/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.ts
+++ b/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.ts
@@ -30,7 +30,7 @@ export const useEntitiesSync = ({
       const endAtDate = new Date(`${entity.localEndDate}T${entity.localEndTime}`);
       const endAtTimestamp = endAtDate.getTime();
 
-      const entityId = entity.flowHistoryId ?? entity.activityHistoryId;
+      const entityId = entity.flowId ?? entity.activityId;
       const eventId = entity.scheduledEventId;
       // Normalize targetSubjectId to null for self-reports
       const targetSubjectId =

--- a/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.ts
+++ b/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.ts
@@ -30,7 +30,7 @@ export const useEntitiesSync = ({
       const endAtDate = new Date(`${entity.localEndDate}T${entity.localEndTime}`);
       const endAtTimestamp = endAtDate.getTime();
 
-      const entityId = entity.flowId ?? entity.activityId;
+      const entityId = entity.flowHistoryId ?? entity.activityHistoryId;
       const eventId = entity.scheduledEventId;
       // Normalize targetSubjectId to null for self-reports
       const targetSubjectId =

--- a/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.ts
+++ b/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.ts
@@ -30,7 +30,7 @@ export const useEntitiesSync = ({
       const endAtDate = new Date(`${entity.localEndDate}T${entity.localEndTime}`);
       const endAtTimestamp = endAtDate.getTime();
 
-      const entityId = entity.id;
+      const entityId = entity.flowHistoryId ?? entity.activityHistoryId;
       const eventId = entity.scheduledEventId;
       // Normalize targetSubjectId to null for self-reports
       const targetSubjectId =

--- a/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.ts
+++ b/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.ts
@@ -30,7 +30,7 @@ export const useEntitiesSync = ({
       const endAtDate = new Date(`${entity.localEndDate}T${entity.localEndTime}`);
       const endAtTimestamp = endAtDate.getTime();
 
-      const entityId = entity.id; // TODO: Switch to `entity.flowHistoryId ?? entity.activityHistoryId` to fully support versions
+      const entityId = entity.id;
       const eventId = entity.scheduledEventId;
 
       // Normalize targetSubjectId to null for self-reports

--- a/src/widgets/ActivityGroups/ui/ActivityGroupList.tsx
+++ b/src/widgets/ActivityGroups/ui/ActivityGroupList.tsx
@@ -68,7 +68,11 @@ export const ActivityGroupList = () => {
     setIsAboutOpen(true);
   };
 
-  useEntitiesSync({ completedEntities });
+  useEntitiesSync({
+    completedEntities,
+    respondentSubjectId: applet.respondentMeta?.subjectId ?? null,
+    events: events.events,
+  });
 
   if (isCompletedEntitiesFetching) {
     return <Loader />;

--- a/src/widgets/ActivityGroups/ui/ActivityGroupList.tsx
+++ b/src/widgets/ActivityGroups/ui/ActivityGroupList.tsx
@@ -30,6 +30,7 @@ export const ActivityGroupList = () => {
       {
         appletId: applet.id,
         fromDate: formatToDtoDate(subMonths(new Date(), 1)),
+        includeInProgress: true,
       },
       { select: (data) => data.data.result, enabled: !isPublic },
     );

--- a/src/widgets/Survey/ui/index.tsx
+++ b/src/widgets/Survey/ui/index.tsx
@@ -99,6 +99,7 @@ export const SurveyWidget = (props: Props) => {
     {
       appletId,
       fromDate: formatToDtoDate(subMonths(new Date(), 1)),
+      includeInProgress: true,
     },
     { select: (data) => data.data.result, enabled: !publicAppletKey },
   );

--- a/src/widgets/Survey/ui/index.tsx
+++ b/src/widgets/Survey/ui/index.tsx
@@ -1,9 +1,12 @@
 import { useCallback } from 'react';
 
+import { subMonths } from 'date-fns';
+
 import { ErrorScreen } from './ErrorScreen';
 import LoadingScreen from './LoadingScreen';
 import { ScreenManager } from './ScreenManager';
 
+import { useCompletedEntitiesQuery } from '~/entities/activity';
 import { useBanners } from '~/entities/banner/model';
 import { AutoCompletionModel } from '~/features/AutoCompletion';
 import {
@@ -13,7 +16,14 @@ import {
 } from '~/features/PassSurvey';
 import ROUTES from '~/shared/constants/routes';
 import { MuiModal } from '~/shared/ui';
-import { useCustomNavigation, useCustomTranslation, useModal, useOnceEffect } from '~/shared/utils';
+import {
+  formatToDtoDate,
+  useCustomNavigation,
+  useCustomTranslation,
+  useModal,
+  useOnceEffect,
+} from '~/shared/utils';
+import { useEntitiesSync } from '~/widgets/ActivityGroups/model/hooks';
 
 type Props = {
   publicAppletKey: string | null;
@@ -84,6 +94,20 @@ export const SurveyWidget = (props: Props) => {
     isError,
     error,
   } = useSurveyDataQuery({ publicAppletKey, appletId, activityId, targetSubjectId });
+
+  const { data: completedEntities } = useCompletedEntitiesQuery(
+    {
+      appletId,
+      fromDate: formatToDtoDate(subMonths(new Date(), 1)),
+    },
+    { select: (data) => data.data.result, enabled: !publicAppletKey },
+  );
+
+  useEntitiesSync({
+    completedEntities,
+    respondentSubjectId: respondentMeta?.subjectId ?? null,
+    events: eventsDTO?.events ?? [],
+  });
 
   const responseError = error?.evaluatedMessage ?? '';
 


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-10229](https://mindlogger.atlassian.net/browse/M2-10229)

Add fetching in-progress flows from server:

- Fetch completed answers from server in `Survey` component
- `includeInProgress=true` when fetching completed answers

Depends on ChildMindInstitute/mindlogger-backend-refactor#1994.

### ✏️ Notes

This PR does not fully implement flow resume yet. The next PR #691 will resolve server vs. local state and check to make sure the activity can be resumed according to schedule.