### PR TITLE
feat(M2-10358): add French MFA translations

### DIFF
--- a/src/i18n/fr/translation.json
+++ b/src/i18n/fr/translation.json
@@ -90,7 +90,32 @@
       "invalidEmail": "L'e-mail doit être valide.",
       "firstNameRequired": "First name is required.",
       "lastNameRequired": "Last name is required.",
-      "passwordShouldNotContainSpaces": "Le mot de passe ne doit pas contenir d'espaces."
+      "passwordShouldNotContainSpaces": "Le mot de passe ne doit pas contenir d'espaces.",
+      "mfaCodeRequired": "Le code de vérification est requis.",
+      "mfaCodeFormat": "Le code de vérification doit comporter 6 chiffres.",
+      "recoveryCodeRequired": "Le code de récupération est requis.",
+      "recoveryCodeFormat": "Le code de récupération doit être au format XXXXX-XXXXX."
+    },
+    "MFA": {
+      "confirmYourIdentity": "Confirmez votre identité",
+      "enterVerificationCode": "Veuillez entrer le code de vérification affiché dans votre application d'authentification.",
+      "enterRecoveryCode": "Veuillez entrer un code de récupération de compte.",
+      "verificationCode": "Entrez le code de vérification",
+      "recoveryCode": "Code de récupération",
+      "cantAccessAuthenticator": "Je n'ai pas accès à mon application d'authentification",
+      "backToAuthenticator": "Retour",
+      "backToLogin": "Retour à la connexion",
+      "continue": "Continuer",
+      "invalidCode": "Code de vérification invalide",
+      "invalidRecoveryCode": "Code de récupération invalide",
+      "mfaSessionExpired": "Votre session a expiré. Veuillez vous reconnecter.",
+      "tooManyAttempts": "Trop de tentatives échouées. Veuillez réessayer plus tard.",
+      "attemptsRemaining_one": "{{count}} tentative restante",
+      "attemptsRemaining_other": "{{count}} tentatives restantes",
+      "sessionAttemptsRemaining_one": "{{count}} tentative de session restante",
+      "sessionAttemptsRemaining_other": "{{count}} tentatives de session restantes",
+      "globalAttemptsRemaining_one": "{{count}} tentative restante avant le verrouillage du compte",
+      "globalAttemptsRemaining_other": "{{count}} tentatives restantes avant le verrouillage du compte"
     },
     "transferOwnership": {
       "adminPanel": "Panneau d'Administration",


### PR DESCRIPTION
 PR description:                                                                                                                                                                                                                                    
  ## Summary                                                                                                                                                                                                                                         
  Added missing French translations for MFA login flow on web. Previously used English placeholders. 
  
 ## Jira                                                                                                                                                                                                                                            
  [M2-10358](https://mindlogger.atlassian.net/browse/M2-10358)    

[M2-10358]: https://mindlogger.atlassian.net/browse/M2-10358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ