### PR TITLE
feat: `EnableFlowResume` feature flag (M2-10402)

### DIFF
--- a/src/shared/utils/featureFlags/index.ts
+++ b/src/shared/utils/featureFlags/index.ts
@@ -1,1 +1,2 @@
 export * from './featureFlags';
+export * from './isFlowResumeEnabled';

--- a/src/shared/utils/featureFlags/isFlowResumeEnabled.test.ts
+++ b/src/shared/utils/featureFlags/isFlowResumeEnabled.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { isFlowResumeEnabled } from './isFlowResumeEnabled';
+
+describe('isFlowResumeEnabled', () => {
+  it('should return true when flag is true', () => {
+    expect(isFlowResumeEnabled(true, 'applet-1')).toBe(true);
+  });
+
+  it('should return false when flag is false', () => {
+    expect(isFlowResumeEnabled(false, 'applet-1')).toBe(false);
+  });
+
+  it('should return true when flag is an array containing the applet ID', () => {
+    expect(isFlowResumeEnabled(['applet-1', 'applet-2'], 'applet-1')).toBe(true);
+  });
+
+  it('should return false when flag is an array not containing the applet ID', () => {
+    expect(isFlowResumeEnabled(['applet-2', 'applet-3'], 'applet-1')).toBe(false);
+  });
+
+  it('should return false when flag is an empty array', () => {
+    expect(isFlowResumeEnabled([], 'applet-1')).toBe(false);
+  });
+});

--- a/src/shared/utils/featureFlags/isFlowResumeEnabled.ts
+++ b/src/shared/utils/featureFlags/isFlowResumeEnabled.ts
@@ -1,0 +1,8 @@
+import { FeatureFlagType, FeatureFlag } from '../types/featureFlags';
+
+export const isFlowResumeEnabled = (
+  flag: FeatureFlagType[FeatureFlag.EnableFlowResume],
+  appletId: string,
+): boolean => {
+  return flag === true || (Array.isArray(flag) && flag.includes(appletId));
+};

--- a/src/shared/utils/types/featureFlags.ts
+++ b/src/shared/utils/types/featureFlags.ts
@@ -2,12 +2,14 @@ export enum FeatureFlag {
   EnableParticipantMultiInformant = 'EnableParticipantMultiInformant',
   EnablePhrasalTemplate = 'EnablePhrasalTemplate',
   EnableActivityAssign = 'EnableActivityAssign',
+  EnableFlowResume = 'EnableFlowResume',
 }
 
 export type FeatureFlagType = {
   [FeatureFlag.EnableParticipantMultiInformant]: boolean;
   [FeatureFlag.EnablePhrasalTemplate]: boolean;
   [FeatureFlag.EnableActivityAssign]: boolean;
+  [FeatureFlag.EnableFlowResume]: string[] | boolean;
 };
 
 // Mapping between the feature flag we want to use in code, to the
@@ -25,4 +27,5 @@ export const LaunchDarkyFlagsMap = {
 
   // TODO: https://mindlogger.atlassian.net/browse/M2-6518 Assign Activity flag cleanup
   [FeatureFlag.EnableActivityAssign]: 'enableActivityAssign',
+  [FeatureFlag.EnableFlowResume]: 'enableFlowResume',
 };

--- a/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.test.ts
+++ b/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.test.ts
@@ -91,6 +91,7 @@ describe('useEntitiesSync', () => {
         respondentSubjectId: null,
         events: [mockFlowEvent],
         activityFlows: mockFlows,
+        flowResumeEnabled: true,
       };
       renderHook(() => useEntitiesSync(serverCompletedEntities));
 
@@ -133,6 +134,7 @@ describe('useEntitiesSync', () => {
         respondentSubjectId: null,
         events: [mockFlowEvent],
         activityFlows: mockFlows,
+        flowResumeEnabled: true,
       };
       renderHook(() => useEntitiesSync(serverCompletedEntities));
 
@@ -168,6 +170,7 @@ describe('useEntitiesSync', () => {
         respondentSubjectId: null,
         events: [mockFlowEvent],
         activityFlows: mockFlows,
+        flowResumeEnabled: true,
       };
       renderHook(() => useEntitiesSync(serverCompletedEntities));
 
@@ -194,6 +197,7 @@ describe('useEntitiesSync', () => {
         respondentSubjectId: null,
         events: [mockFlowEvent],
         activityFlows: mockFlows,
+        flowResumeEnabled: true,
       };
       renderHook(() => useEntitiesSync(serverCompletedEntities));
 
@@ -227,6 +231,7 @@ describe('useEntitiesSync', () => {
         respondentSubjectId: null,
         events: [mockActivityEvent],
         activityFlows: mockFlows,
+        flowResumeEnabled: true,
       };
       renderHook(() => useEntitiesSync(serverCompletedEntities));
 
@@ -272,6 +277,7 @@ describe('useEntitiesSync', () => {
         respondentSubjectId: null,
         events: [mockFlowEvent],
         activityFlows: mockFlows,
+        flowResumeEnabled: true,
       };
       renderHook(() => useEntitiesSync(serverCompletedEntities));
 
@@ -312,6 +318,7 @@ describe('useEntitiesSync', () => {
         respondentSubjectId: null,
         events: [mockActivityEvent],
         activityFlows: mockFlows,
+        flowResumeEnabled: true,
       };
       renderHook(() => useEntitiesSync(serverCompletedEntities));
 
@@ -352,6 +359,7 @@ describe('useEntitiesSync', () => {
         respondentSubjectId: null,
         events: [mockFlowEvent],
         activityFlows: mockFlows,
+        flowResumeEnabled: true,
       };
       renderHook(() => useEntitiesSync(serverCompletedEntities));
 
@@ -392,6 +400,7 @@ describe('useEntitiesSync', () => {
         respondentSubjectId: null,
         events: [mockActivityEvent],
         activityFlows: mockFlows,
+        flowResumeEnabled: true,
       };
       renderHook(() => useEntitiesSync(serverCompletedEntities));
 

--- a/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.ts
+++ b/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.ts
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useRef } from 'react';
 
+import { v4 as uuidV4 } from 'uuid';
+
 import { ActivityPipelineType, FlowProgress } from '~/abstract/lib';
 import { appletModel } from '~/entities/applet';
 import {
@@ -14,6 +16,7 @@ export type EntitiesSyncProps = {
   respondentSubjectId: string | null;
   events: ScheduleEventDto[];
   activityFlows: ActivityFlowDTO[];
+  flowResumeEnabled: boolean;
 };
 
 export const useEntitiesSync = ({
@@ -21,6 +24,7 @@ export const useEntitiesSync = ({
   respondentSubjectId,
   events,
   activityFlows,
+  flowResumeEnabled,
 }: EntitiesSyncProps) => {
   const { saveGroupProgress, getGroupProgress } = appletModel.hooks.useGroupProgressStateManager();
 
@@ -28,7 +32,6 @@ export const useEntitiesSync = ({
   const getGroupProgressRef = useRef(getGroupProgress);
 
   // Syncs local GroupProgress state with server completions data.
-  // Ensures the most recent event data is used the next time the activity/flow is started.
   const syncEntity = useCallback(
     (entity: CompletedEntityDTO, isFlow: boolean) => {
       const entityId = entity.id;
@@ -150,13 +153,82 @@ export const useEntitiesSync = ({
             },
       });
     },
-    [respondentSubjectId, events, activityFlows],
+    [respondentSubjectId, events, activityFlows, saveGroupProgress],
+  );
+
+  // Legacy sync logic before flow resume was implemented (#690). Used when flow resume is disabled.
+  const syncEntityLegacy = useCallback(
+    (entity: CompletedEntityDTO) => {
+      const endAtDate = new Date(`${entity.localEndDate}T${entity.localEndTime}`);
+      const endAtTimestamp = endAtDate.getTime();
+
+      const entityId = entity.id;
+      const eventId = entity.scheduledEventId;
+
+      // Normalize targetSubjectId to null for self-reports
+      const targetSubjectId =
+        entity.targetSubjectId === respondentSubjectId ? null : entity.targetSubjectId;
+
+      const groupProgress = getGroupProgressRef.current({
+        entityId,
+        eventId,
+        targetSubjectId,
+      });
+
+      const event = events.find(({ id }) => id === eventId) ?? null;
+
+      if (!groupProgress) {
+        return saveGroupProgress({
+          entityId,
+          eventId,
+          targetSubjectId,
+          progressPayload: {
+            type: ActivityPipelineType.Regular,
+            startAt: null,
+            endAt: endAtTimestamp,
+            submitId: uuidV4(),
+            context: {
+              summaryData: {},
+            },
+            event,
+          },
+        });
+      } else if (groupProgress.endAt) {
+        let { endAt } = groupProgress;
+
+        const isServerEndAtBigger = endAtTimestamp > new Date(groupProgress.endAt).getTime();
+
+        if (isServerEndAtBigger) {
+          endAt = endAtTimestamp;
+        }
+
+        return saveGroupProgress({
+          entityId,
+          eventId,
+          targetSubjectId,
+          progressPayload: {
+            ...groupProgress,
+            endAt,
+            event,
+          },
+        });
+      }
+    },
+    [respondentSubjectId, events, saveGroupProgress],
   );
 
   useEffect(() => {
-    if (completedEntities) {
-      completedEntities.activities.forEach((entity) => syncEntity(entity, false));
-      completedEntities.activityFlows.forEach((entity) => syncEntity(entity, true));
+    if (flowResumeEnabled) {
+      completedEntities?.activities.forEach((entity) => syncEntity(entity, false));
+      completedEntities?.activityFlows.forEach((entity) => syncEntity(entity, true));
+    } else {
+      completedEntities?.activities.forEach(syncEntityLegacy);
+      completedEntities?.activityFlows.forEach(syncEntityLegacy);
     }
-  }, [completedEntities, syncEntity]);
+  }, [
+    completedEntities?.activities,
+    completedEntities?.activityFlows,
+    syncEntity,
+    syncEntityLegacy,
+  ]);
 };

--- a/src/widgets/ActivityGroups/ui/ActivityGroupList.tsx
+++ b/src/widgets/ActivityGroups/ui/ActivityGroupList.tsx
@@ -80,6 +80,7 @@ export const ActivityGroupList = () => {
     respondentSubjectId: applet.respondentMeta?.subjectId ?? null,
     events: events.events,
     activityFlows: applet.activityFlows,
+    flowResumeEnabled,
   });
 
   if (isCompletedEntitiesFetching) {

--- a/src/widgets/ActivityGroups/ui/ActivityGroupList.tsx
+++ b/src/widgets/ActivityGroups/ui/ActivityGroupList.tsx
@@ -17,11 +17,17 @@ import Box from '~/shared/ui/Box';
 import Loader from '~/shared/ui/Loader';
 import Text from '~/shared/ui/Text';
 import { formatToDtoDate, useCustomTranslation } from '~/shared/utils';
+import { isFlowResumeEnabled } from '~/shared/utils/featureFlags';
+import { useFeatureFlags } from '~/shared/utils/hooks';
+import { FeatureFlag } from '~/shared/utils/types/featureFlags';
 
 export const ActivityGroupList = () => {
   const { t } = useCustomTranslation();
 
   const { applet, events, assignments, isPublic } = useContext(AppletDetailsContext);
+  const { featureFlag } = useFeatureFlags();
+  const flowResumeFlag = featureFlag(FeatureFlag.EnableFlowResume, false);
+  const flowResumeEnabled = isFlowResumeEnabled(flowResumeFlag, applet.id);
 
   useIntegrationsSync({ appletDetails: applet });
 
@@ -30,7 +36,7 @@ export const ActivityGroupList = () => {
       {
         appletId: applet.id,
         fromDate: formatToDtoDate(subMonths(new Date(), 1)),
-        includeInProgress: true,
+        includeInProgress: flowResumeEnabled ? true : undefined,
       },
       { select: (data) => data.data.result, enabled: !isPublic },
     );

--- a/src/widgets/Survey/ui/index.tsx
+++ b/src/widgets/Survey/ui/index.tsx
@@ -26,6 +26,9 @@ import {
   useModal,
   useOnceEffect,
 } from '~/shared/utils';
+import { isFlowResumeEnabled } from '~/shared/utils/featureFlags';
+import { useFeatureFlags } from '~/shared/utils/hooks';
+import { FeatureFlag } from '~/shared/utils/types/featureFlags';
 import { useEntitiesSync } from '~/widgets/ActivityGroups/model/hooks';
 
 type Props = {
@@ -101,13 +104,20 @@ export const SurveyWidget = (props: Props) => {
     error,
   } = useSurveyDataQuery({ publicAppletKey, appletId, activityId, targetSubjectId });
 
+  const { featureFlag } = useFeatureFlags();
+  const flowResumeFlag = featureFlag(FeatureFlag.EnableFlowResume, false);
+  const flowResumeEnabled = isFlowResumeEnabled(flowResumeFlag, appletId);
+
   const { data: completedEntities, isFetching } = useCompletedEntitiesQuery(
     {
       appletId,
       fromDate: formatToDtoDate(subMonths(new Date(), 1)),
       includeInProgress: true,
     },
-    { select: (data) => data.data.result, enabled: !publicAppletKey && !shouldRestart },
+    {
+      select: (data) => data.data.result,
+      enabled: flowResumeEnabled && !publicAppletKey && !shouldRestart,
+    },
   );
 
   // Sync with server
@@ -131,7 +141,7 @@ export const SurveyWidget = (props: Props) => {
     : null;
 
   useEffect(() => {
-    if (!currentActivityId || currentActivityId === activityId) return;
+    if (!flowResumeEnabled || !currentActivityId || currentActivityId === activityId) return;
 
     const navigateToProps = {
       appletId,

--- a/src/widgets/Survey/ui/index.tsx
+++ b/src/widgets/Survey/ui/index.tsx
@@ -129,6 +129,7 @@ export const SurveyWidget = (props: Props) => {
     respondentSubjectId: respondentMeta?.subjectId ?? null,
     events: eventsDTO?.events ?? [],
     activityFlows: appletBaseDTO?.activityFlows ?? [],
+    flowResumeEnabled,
   });
 
   // After server sync, redirect to current activity if flow progressed on another device


### PR DESCRIPTION
- [x] Tests for the changes have been added

### 📝 Description

🔗 [Jira Ticket M2-10402](https://mindlogger.atlassian.net/browse/M2-10402)

Changes include:

- Add `EnableFlowResume` feature flag
- Use feature flag when fetching completions from server
- Use feature flag when resolving server vs. local state

Depends on #691.

### ✏️ Notes

`EnableFlowResume` can be `true`, `false`, or an array of applet IDs.