### PR TITLE
Always use `string[]` for `EnableFlowResume` flag

### DIFF
--- a/src/shared/utils/featureFlags/isFlowResumeEnabled.test.ts
+++ b/src/shared/utils/featureFlags/isFlowResumeEnabled.test.ts
@@ -3,19 +3,15 @@ import { describe, expect, it } from 'vitest';
 import { isFlowResumeEnabled } from './isFlowResumeEnabled';
 
 describe('isFlowResumeEnabled', () => {
-  it('should return true when flag is true', () => {
-    expect(isFlowResumeEnabled(true, 'applet-1')).toBe(true);
+  it('should return true when flag contains wildcard', () => {
+    expect(isFlowResumeEnabled(['*'], 'applet-1')).toBe(true);
   });
 
-  it('should return false when flag is false', () => {
-    expect(isFlowResumeEnabled(false, 'applet-1')).toBe(false);
-  });
-
-  it('should return true when flag is an array containing the applet ID', () => {
+  it('should return true when flag contains the applet ID', () => {
     expect(isFlowResumeEnabled(['applet-1', 'applet-2'], 'applet-1')).toBe(true);
   });
 
-  it('should return false when flag is an array not containing the applet ID', () => {
+  it('should return false when flag does not contain the applet ID', () => {
     expect(isFlowResumeEnabled(['applet-2', 'applet-3'], 'applet-1')).toBe(false);
   });
 

--- a/src/shared/utils/featureFlags/isFlowResumeEnabled.ts
+++ b/src/shared/utils/featureFlags/isFlowResumeEnabled.ts
@@ -4,5 +4,5 @@ export const isFlowResumeEnabled = (
   flag: FeatureFlagType[FeatureFlag.EnableFlowResume],
   appletId: string,
 ): boolean => {
-  return flag === true || (Array.isArray(flag) && flag.includes(appletId));
+  return flag.includes('*') || flag.includes(appletId);
 };

--- a/src/shared/utils/types/featureFlags.ts
+++ b/src/shared/utils/types/featureFlags.ts
@@ -9,7 +9,7 @@ export type FeatureFlagType = {
   [FeatureFlag.EnableParticipantMultiInformant]: boolean;
   [FeatureFlag.EnablePhrasalTemplate]: boolean;
   [FeatureFlag.EnableActivityAssign]: boolean;
-  [FeatureFlag.EnableFlowResume]: string[] | boolean;
+  [FeatureFlag.EnableFlowResume]: string[];
 };
 
 // Mapping between the feature flag we want to use in code, to the

--- a/src/widgets/ActivityGroups/ui/ActivityGroupList.tsx
+++ b/src/widgets/ActivityGroups/ui/ActivityGroupList.tsx
@@ -26,7 +26,7 @@ export const ActivityGroupList = () => {
 
   const { applet, events, assignments, isPublic } = useContext(AppletDetailsContext);
   const { featureFlag } = useFeatureFlags();
-  const flowResumeFlag = featureFlag(FeatureFlag.EnableFlowResume, false);
+  const flowResumeFlag = featureFlag(FeatureFlag.EnableFlowResume, []);
   const flowResumeEnabled = isFlowResumeEnabled(flowResumeFlag, applet.id);
 
   useIntegrationsSync({ appletDetails: applet });

--- a/src/widgets/Survey/ui/index.tsx
+++ b/src/widgets/Survey/ui/index.tsx
@@ -105,7 +105,7 @@ export const SurveyWidget = (props: Props) => {
   } = useSurveyDataQuery({ publicAppletKey, appletId, activityId, targetSubjectId });
 
   const { featureFlag } = useFeatureFlags();
-  const flowResumeFlag = featureFlag(FeatureFlag.EnableFlowResume, false);
+  const flowResumeFlag = featureFlag(FeatureFlag.EnableFlowResume, []);
   const flowResumeEnabled = isFlowResumeEnabled(flowResumeFlag, appletId);
 
   const { data: completedEntities, isFetching } = useCompletedEntitiesQuery(


### PR DESCRIPTION
- [x] Tests for the changes have been added

🔗 [Jira Ticket M2-10402](https://mindlogger.atlassian.net/browse/M2-10402)

Changes include:

- `true` → `["*"]` to enable flow resume for all applets
- `false` → `[]` to disable flow resume  for all applets
- `["applet-id-foo", "applet-id-bar"]` to enable flow resume for specific applets 

This complies with LaunchDarkly’s constraint that all JSON variation values must be of the same type.

Related to #697.