### PR TITLE
fix: Local vs. server sync logic for in-progress flow (M2-10383, M2-10429)

### DIFF
--- a/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.ts
+++ b/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.ts
@@ -30,6 +30,7 @@ export const useEntitiesSync = ({
 
   // Create ref to exclude from callback dependencies to avoid infinite loop
   const getGroupProgressRef = useRef(getGroupProgress);
+  getGroupProgressRef.current = getGroupProgress;
 
   // Syncs local GroupProgress state with server completions data.
   const syncEntity = useCallback(
@@ -56,20 +57,27 @@ export const useEntitiesSync = ({
       // Create or update resumable progress so user can continue where they left off
       if (isFlow && entity.isFlowCompleted === false) {
         const flow = activityFlows.find((f) => f.id === entity.id);
+
         if (!flow) {
           console.warn(`[useEntitiesSync] Flow not found for entity ID: ${entity.id}`);
           return;
         }
 
-        // Skip if local is completed and as recent or more recent than server (nothing to update)
-        if ((groupProgress?.endAt ?? 0) >= entity.endTime) {
-          return;
-        }
+        // If submitIds match, only skip if local is at or ahead
+        const isSameSubmission = groupProgress?.submitId === entity.submitId;
 
-        // Skip if local is in-progress and at or ahead of server (nothing to update)
-        if ((groupProgress as FlowProgress)?.pipelineActivityOrder >= pipelineActivityOrder) {
-          return;
+        if (isSameSubmission) {
+          // Same submission: Skip if local is completed and as recent or more recent than server
+          if ((groupProgress?.endAt ?? 0) >= entity.endTime) {
+            return;
+          }
+
+          // Same submission: Skip if local is in-progress and at or ahead of server
+          if ((groupProgress as FlowProgress)?.pipelineActivityOrder >= pipelineActivityOrder) {
+            return;
+          }
         }
+        // Different submission: Always replace local with server data (continue to save)
 
         const nextActivityId = flow.activityIds[pipelineActivityOrder];
         if (!nextActivityId) {

--- a/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.ts
+++ b/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.ts
@@ -70,7 +70,10 @@ export const useEntitiesSync = ({
           }
         } else {
           // If submitIds are different, skip if local is in-progress and at or ahead of server
-          if ((groupProgress as FlowProgress)?.pipelineActivityOrder >= pipelineActivityOrder) {
+          if (
+            !groupProgress?.endAt &&
+            (groupProgress as FlowProgress)?.pipelineActivityOrder >= pipelineActivityOrder
+          ) {
             return;
           }
           // If submitIds are different, skip if local is completed and as recent or more recent than server

--- a/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.ts
+++ b/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.ts
@@ -142,6 +142,10 @@ export const useEntitiesSync = ({
       if ((groupProgress.endAt ?? 0) >= entity.endTime) {
         return;
       }
+      // Skip if local is in-progress and started more recently than server completed
+      if (!groupProgress.endAt && (groupProgress.startAt ?? 0) > entity.endTime) {
+        return;
+      }
       return saveGroupProgress({
         entityId,
         eventId,

--- a/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.ts
+++ b/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.ts
@@ -65,11 +65,13 @@ export const useEntitiesSync = ({
 
         if (groupProgress?.submitId === entity.submitId) {
           // If submitIds match, only skip if local is at or ahead
+          // ("Keep last activity in each submission" in AnswerService._filter_activity_flows)
           if ((groupProgress as FlowProgress)?.pipelineActivityOrder >= pipelineActivityOrder) {
             return;
           }
         } else {
           // If submitIds are different, skip if local is in-progress and at or ahead of server
+          // ("Farthest along in-progress flow" in AnswerService._filter_activity_flows)
           if (
             !groupProgress?.endAt &&
             (groupProgress as FlowProgress)?.pipelineActivityOrder >= pipelineActivityOrder
@@ -77,6 +79,7 @@ export const useEntitiesSync = ({
             return;
           }
           // If submitIds are different, skip if local is completed and as recent or more recent than server
+          // ("More recent between best completed flow and best in-progress flow" in AnswerService._filter_activity_flows)
           if ((groupProgress?.endAt ?? 0) >= entity.endTime) {
             return;
           }

--- a/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.ts
+++ b/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.ts
@@ -63,21 +63,21 @@ export const useEntitiesSync = ({
           return;
         }
 
-        // If submitIds match, only skip if local is at or ahead
-        const isSameSubmission = groupProgress?.submitId === entity.submitId;
-
-        if (isSameSubmission) {
-          // Same submission: Skip if local is completed and as recent or more recent than server
-          if ((groupProgress?.endAt ?? 0) >= entity.endTime) {
-            return;
-          }
-
-          // Same submission: Skip if local is in-progress and at or ahead of server
+        if (groupProgress?.submitId === entity.submitId) {
+          // If submitIds match, only skip if local is at or ahead
           if ((groupProgress as FlowProgress)?.pipelineActivityOrder >= pipelineActivityOrder) {
             return;
           }
+        } else {
+          // If submitIds are different, skip if local is in-progress and at or ahead of server
+          if ((groupProgress as FlowProgress)?.pipelineActivityOrder >= pipelineActivityOrder) {
+            return;
+          }
+          // If submitIds are different, skip if local is completed and as recent or more recent than server
+          if ((groupProgress?.endAt ?? 0) >= entity.endTime) {
+            return;
+          }
         }
-        // Different submission: Always replace local with server data (continue to save)
 
         const nextActivityId = flow.activityIds[pipelineActivityOrder];
         if (!nextActivityId) {


### PR DESCRIPTION
🔗 [Jira Ticket M2-10383](https://mindlogger.atlassian.net/browse/M2-10383)
🔗 [Jira Ticket M2-10429](https://mindlogger.atlassian.net/browse/M2-10429)

Fixed local vs. server activity flow sync logic as follows: 
- Separate logic for same vs. different submissions
- Add missing check if local flow is in-progress and server flow is in-progress
- Add missing check if local flow is in-progress and server flow is completed