### PR TITLE
fix: Redirect when completed on different device (M2-10434, M2-10441)

### DIFF
--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -313,6 +313,7 @@
       "restart_activity": "Restart activity",
       "cancel": "Cancel",
       "activity_resume_restart": "Are you sure you want clear all progress and restart",
+      "activity_already_completed": "<strong>Done!</strong> This survey was already completed on a different device.",
       "restart": "Restart",
       "resume": "Resume",
       "in_progress": "In Progress",

--- a/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.ts
+++ b/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { v4 as uuidV4 } from 'uuid';
 
@@ -33,8 +33,9 @@ export const useEntitiesSync = ({
   getGroupProgressRef.current = getGroupProgress;
 
   // Syncs local GroupProgress state with server completions data.
+  // Returns true if local GroupProgress state was updated or false if skipped.
   const syncEntity = useCallback(
-    (entity: CompletedEntityDTO, isFlow: boolean) => {
+    (entity: CompletedEntityDTO, isFlow: boolean): boolean => {
       const entityId = entity.id;
       const eventId = entity.scheduledEventId;
 
@@ -60,14 +61,14 @@ export const useEntitiesSync = ({
 
         if (!flow) {
           console.warn(`[useEntitiesSync] Flow not found for entity ID: ${entity.id}`);
-          return;
+          return false;
         }
 
         if (groupProgress?.submitId === entity.submitId) {
           // If submitIds match, only skip if local is at or ahead
           // ("Keep last activity in each submission" in AnswerService._filter_activity_flows)
           if ((groupProgress as FlowProgress)?.pipelineActivityOrder >= pipelineActivityOrder) {
-            return;
+            return false;
           }
         } else {
           // If submitIds are different, skip if local is in-progress and at or ahead of server
@@ -76,22 +77,22 @@ export const useEntitiesSync = ({
             !groupProgress?.endAt &&
             (groupProgress as FlowProgress)?.pipelineActivityOrder >= pipelineActivityOrder
           ) {
-            return;
+            return false;
           }
           // If submitIds are different, skip if local is completed and as recent or more recent than server
           // ("More recent between best completed flow and best in-progress flow" in AnswerService._filter_activity_flows)
           if ((groupProgress?.endAt ?? 0) >= entity.endTime) {
-            return;
+            return false;
           }
         }
 
         const nextActivityId = flow.activityIds[pipelineActivityOrder];
         if (!nextActivityId) {
           console.warn(`[useEntitiesSync] No next activity found for flow: ${entity.id}`);
-          return;
+          return false;
         }
 
-        return saveGroupProgress({
+        saveGroupProgress({
           entityId,
           eventId,
           targetSubjectId,
@@ -106,12 +107,13 @@ export const useEntitiesSync = ({
             event,
           },
         });
+        return true;
       }
 
       // Case 2: Completed entity with no local progress
       // Create a new completed record
       if (!groupProgress) {
-        return saveGroupProgress({
+        saveGroupProgress({
           entityId,
           eventId,
           targetSubjectId,
@@ -135,18 +137,19 @@ export const useEntitiesSync = ({
                 event,
               },
         });
+        return true;
       }
 
       // Case 3: Completed entity with local progress
       // Skip if local is completed and as recent or more recent than server (nothing to update)
       if ((groupProgress.endAt ?? 0) >= entity.endTime) {
-        return;
+        return false;
       }
       // Skip if local is in-progress and started more recently than server completed
       if (!groupProgress.endAt && (groupProgress.startAt ?? 0) > entity.endTime) {
-        return;
+        return false;
       }
-      return saveGroupProgress({
+      saveGroupProgress({
         entityId,
         eventId,
         targetSubjectId,
@@ -170,6 +173,7 @@ export const useEntitiesSync = ({
               event,
             },
       });
+      return true;
     },
     [respondentSubjectId, events, activityFlows, saveGroupProgress],
   );
@@ -235,10 +239,18 @@ export const useEntitiesSync = ({
     [respondentSubjectId, events, saveGroupProgress],
   );
 
+  const [changes, setChanges] = useState<string[]>([]);
+
   useEffect(() => {
     if (flowResumeEnabled) {
-      completedEntities?.activities.forEach((entity) => syncEntity(entity, false));
-      completedEntities?.activityFlows.forEach((entity) => syncEntity(entity, true));
+      const changedIds: string[] = [];
+      completedEntities?.activities.forEach((entity) => {
+        if (syncEntity(entity, false)) changedIds.push(entity.id);
+      });
+      completedEntities?.activityFlows.forEach((entity) => {
+        if (syncEntity(entity, true)) changedIds.push(entity.id);
+      });
+      setChanges(changedIds);
     } else {
       completedEntities?.activities.forEach(syncEntityLegacy);
       completedEntities?.activityFlows.forEach(syncEntityLegacy);
@@ -249,4 +261,6 @@ export const useEntitiesSync = ({
     syncEntity,
     syncEntityLegacy,
   ]);
+
+  return { changes };
 };

--- a/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.ts
+++ b/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.ts
@@ -147,10 +147,12 @@ export const useEntitiesSync = ({
       }
       // Skip if local is in-progress and started more recently than server completed
       // (but never skip for one-time entities that cannot be restarted after completion)
+      const isOneTimeCompletion =
+        event?.availability.oneTimeCompletion || event?.availability.periodicityType === 'ONCE';
       if (
         !groupProgress.endAt &&
         (groupProgress.startAt ?? 0) > entity.endTime &&
-        !event?.availability.oneTimeCompletion
+        !isOneTimeCompletion
       ) {
         return false;
       }

--- a/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.ts
+++ b/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.ts
@@ -146,7 +146,12 @@ export const useEntitiesSync = ({
         return false;
       }
       // Skip if local is in-progress and started more recently than server completed
-      if (!groupProgress.endAt && (groupProgress.startAt ?? 0) > entity.endTime) {
+      // (but never skip for one-time entities that cannot be restarted after completion)
+      if (
+        !groupProgress.endAt &&
+        (groupProgress.startAt ?? 0) > entity.endTime &&
+        !event?.availability.oneTimeCompletion
+      ) {
         return false;
       }
       saveGroupProgress({

--- a/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.ts
+++ b/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.ts
@@ -4,6 +4,7 @@ import { v4 as uuidV4 } from 'uuid';
 
 import { ActivityPipelineType, FlowProgress } from '~/abstract/lib';
 import { appletModel } from '~/entities/applet';
+import { PeriodicityType } from '~/entities/event';
 import {
   ActivityFlowDTO,
   CompletedEntitiesDTO,
@@ -148,7 +149,8 @@ export const useEntitiesSync = ({
       // Skip if local is in-progress and started more recently than server completed
       // (but never skip for one-time entities that cannot be restarted after completion)
       const isOneTimeCompletion =
-        event?.availability.oneTimeCompletion || event?.availability.periodicityType === 'ONCE';
+        event?.availability.oneTimeCompletion ||
+        event?.availability.periodicityType === PeriodicityType.Once;
       if (
         !groupProgress.endAt &&
         (groupProgress.startAt ?? 0) > entity.endTime &&

--- a/src/widgets/Survey/ui/WelcomeScreen.tsx
+++ b/src/widgets/Survey/ui/WelcomeScreen.tsx
@@ -77,6 +77,8 @@ const WelcomeScreen = () => {
     }
 
     if (groupProgress?.type === ActivityPipelineType.Flow) {
+      // If flow is completed, the next start will be from Activity 1
+      if (groupProgress.endAt) return 1;
       return groupProgress.pipelineActivityOrder + 1;
     }
 

--- a/src/widgets/Survey/ui/index.tsx
+++ b/src/widgets/Survey/ui/index.tsx
@@ -10,6 +10,7 @@ import { FlowProgress, getProgressId } from '~/abstract/lib';
 import { useCompletedEntitiesQuery } from '~/entities/activity';
 import { appletModel } from '~/entities/applet';
 import { useBanners } from '~/entities/banner/model';
+import { PeriodicityType } from '~/entities/event';
 import { AutoCompletionModel } from '~/features/AutoCompletion';
 import {
   SurveyContext,
@@ -112,7 +113,8 @@ export const SurveyWidget = (props: Props) => {
   // (but never skip for one-time entities that cannot be restarted after completion)
   const event = eventsDTO?.events.find((e) => e.id === eventId);
   const isOneTimeCompletion =
-    event?.availability.oneTimeCompletion || event?.availability.periodicityType === 'ONCE';
+    event?.availability.oneTimeCompletion ||
+    event?.availability.periodicityType === PeriodicityType.Once;
   const shouldFetchCompletedEntities = flowResumeEnabled && (!shouldRestart || isOneTimeCompletion);
 
   const { data: completedEntities, isFetching } = useCompletedEntitiesQuery(

--- a/src/widgets/Survey/ui/index.tsx
+++ b/src/widgets/Survey/ui/index.tsx
@@ -51,7 +51,7 @@ export const SurveyWidget = (props: Props) => {
   const { t } = useCustomTranslation();
   const navigator = useCustomNavigation();
 
-  const { removeAllBanners } = useBanners();
+  const { removeAllBanners, addSuccessBanner } = useBanners();
 
   const autoCompletionState = AutoCompletionModel.useAutoCompletionRecord({
     entityId: props.flowId ?? props.activityId,
@@ -153,6 +153,7 @@ export const SurveyWidget = (props: Props) => {
 
     // If entity was completed on another device, redirect to activity list
     if (groupProgress?.endAt) {
+      addSuccessBanner(t('additional.activity_already_completed'));
       navigator.navigate(ROUTES.appletDetails.navigateTo(appletId), { replace: true });
       return;
     }

--- a/src/widgets/Survey/ui/index.tsx
+++ b/src/widgets/Survey/ui/index.tsx
@@ -108,11 +108,11 @@ export const SurveyWidget = (props: Props) => {
   const flowResumeFlag = featureFlag(FeatureFlag.EnableFlowResume, []);
   const flowResumeEnabled = isFlowResumeEnabled(flowResumeFlag, appletId);
 
-  const isOneTimeCompletion =
-    eventsDTO?.events.find((e) => e.id === eventId)?.availability.oneTimeCompletion ?? false;
-
   // Skip fetch on "Restart" by user
   // (but never skip for one-time entities that cannot be restarted after completion)
+  const event = eventsDTO?.events.find((e) => e.id === eventId);
+  const isOneTimeCompletion =
+    event?.availability.oneTimeCompletion || event?.availability.periodicityType === 'ONCE';
   const shouldFetchCompletedEntities = flowResumeEnabled && (!shouldRestart || isOneTimeCompletion);
 
   const { data: completedEntities, isFetching } = useCompletedEntitiesQuery(

--- a/src/widgets/Survey/ui/index.tsx
+++ b/src/widgets/Survey/ui/index.tsx
@@ -108,7 +108,13 @@ export const SurveyWidget = (props: Props) => {
   const flowResumeFlag = featureFlag(FeatureFlag.EnableFlowResume, []);
   const flowResumeEnabled = isFlowResumeEnabled(flowResumeFlag, appletId);
 
-  const shouldFetchCompletedEntities = flowResumeEnabled && !publicAppletKey && !shouldRestart;
+  const isOneTimeCompletion =
+    eventsDTO?.events.find((e) => e.id === eventId)?.availability.oneTimeCompletion ?? false;
+
+  // Skip fetch for public applets and on "Restart" by user
+  // (but never skip for one-time entities that cannot be restarted after completion)
+  const shouldFetchCompletedEntities =
+    flowResumeEnabled && !publicAppletKey && (!shouldRestart || isOneTimeCompletion);
 
   const { data: completedEntities, isFetching } = useCompletedEntitiesQuery(
     {
@@ -158,8 +164,8 @@ export const SurveyWidget = (props: Props) => {
       return;
     }
 
-    // If flow progressed on another device, redirect to latest activity
-    if (currentActivityId && currentActivityId !== activityId) {
+    // If flow progressed on another device and this is not a restart, redirect to latest activity
+    if (!shouldRestart && currentActivityId && currentActivityId !== activityId) {
       const navigateToProps = {
         appletId,
         activityId: currentActivityId,

--- a/src/widgets/Survey/ui/index.tsx
+++ b/src/widgets/Survey/ui/index.tsx
@@ -149,7 +149,7 @@ export const SurveyWidget = (props: Props) => {
 
   useEffect(() => {
     // Only consider redirect if progress has changed
-    if (!groupProgressChanged) return;
+    if (!flowResumeEnabled || !groupProgressChanged) return;
 
     // If entity was completed on another device, redirect to activity list
     if (groupProgress?.endAt) {

--- a/src/widgets/Survey/ui/index.tsx
+++ b/src/widgets/Survey/ui/index.tsx
@@ -111,10 +111,9 @@ export const SurveyWidget = (props: Props) => {
   const isOneTimeCompletion =
     eventsDTO?.events.find((e) => e.id === eventId)?.availability.oneTimeCompletion ?? false;
 
-  // Skip fetch for public applets and on "Restart" by user
+  // Skip fetch on "Restart" by user
   // (but never skip for one-time entities that cannot be restarted after completion)
-  const shouldFetchCompletedEntities =
-    flowResumeEnabled && !publicAppletKey && (!shouldRestart || isOneTimeCompletion);
+  const shouldFetchCompletedEntities = flowResumeEnabled && (!shouldRestart || isOneTimeCompletion);
 
   const { data: completedEntities, isFetching } = useCompletedEntitiesQuery(
     {

--- a/src/widgets/Survey/ui/index.tsx
+++ b/src/widgets/Survey/ui/index.tsx
@@ -108,6 +108,8 @@ export const SurveyWidget = (props: Props) => {
   const flowResumeFlag = featureFlag(FeatureFlag.EnableFlowResume, []);
   const flowResumeEnabled = isFlowResumeEnabled(flowResumeFlag, appletId);
 
+  const shouldFetchCompletedEntities = flowResumeEnabled && !publicAppletKey && !shouldRestart;
+
   const { data: completedEntities, isFetching } = useCompletedEntitiesQuery(
     {
       appletId,
@@ -116,7 +118,7 @@ export const SurveyWidget = (props: Props) => {
     },
     {
       select: (data) => data.data.result,
-      enabled: flowResumeEnabled && !publicAppletKey && !shouldRestart,
+      enabled: shouldFetchCompletedEntities,
     },
   );
 
@@ -125,7 +127,8 @@ export const SurveyWidget = (props: Props) => {
   // - gate on applet loading to ensure respondentMeta?.subjectId is available
   // - gate on fresh data to avoid syncing with stale cache
   useEntitiesSync({
-    completedEntities: shouldRestart || isLoading || isFetching ? undefined : completedEntities,
+    completedEntities:
+      !shouldFetchCompletedEntities || isLoading || isFetching ? undefined : completedEntities,
     respondentSubjectId: respondentMeta?.subjectId ?? null,
     events: eventsDTO?.events ?? [],
     activityFlows: appletBaseDTO?.activityFlows ?? [],

--- a/src/widgets/Survey/ui/index.tsx
+++ b/src/widgets/Survey/ui/index.tsx
@@ -135,37 +135,49 @@ export const SurveyWidget = (props: Props) => {
     flowResumeEnabled,
   });
 
-  // After server sync, redirect to current activity if flow progressed on another device
-  const groupProgressId = flowId ? getProgressId(flowId, eventId, targetSubjectId) : null;
+  // After server sync:
+  // - Redirect to activity list if one-time entity was completed on another device
+  // - Redirect to latest activity if flow progressed on another device
+  const groupProgressId = getProgressId(flowId ?? activityId, eventId, targetSubjectId);
   const groupProgress = useAppSelector((state) =>
     groupProgressId ? appletModel.selectors.selectGroupProgress(state, groupProgressId) : null,
   );
+  const isOneTimeCompletion =
+    eventsDTO?.events.find(({ id }) => id === eventId)?.availability.oneTimeCompletion ?? false;
   const currentActivityId = !groupProgress?.endAt
     ? (groupProgress as FlowProgress)?.currentActivityId
     : null;
 
   useEffect(() => {
-    if (!flowResumeEnabled || !currentActivityId || currentActivityId === activityId) return;
+    if (!flowResumeEnabled) return;
 
-    const navigateToProps = {
-      appletId,
-      activityId: currentActivityId,
-      entityType: 'flow' as const,
-      eventId,
-      flowId,
-    };
+    // If one-time entity was completed on another device, redirect to activity list
+    if (groupProgress?.endAt && isOneTimeCompletion) {
+      navigator.navigate(ROUTES.appletDetails.navigateTo(appletId), { replace: true });
+      return;
+    }
 
-    const screenToNavigate = publicAppletKey
-      ? ROUTES.publicSurvey.navigateTo({ ...navigateToProps, publicAppletKey })
-      : ROUTES.survey.navigateTo({ ...navigateToProps, targetSubjectId });
-
-    navigator.navigate(screenToNavigate, { replace: true });
-  }, [activityId, currentActivityId]);
+    // If flow progressed on another device, redirect to latest activity
+    if (currentActivityId && currentActivityId !== activityId) {
+      const navigateToProps = {
+        appletId,
+        activityId: currentActivityId,
+        entityType: 'flow' as const,
+        eventId,
+        flowId,
+      };
+      const screenToNavigate = publicAppletKey
+        ? ROUTES.publicSurvey.navigateTo({ ...navigateToProps, publicAppletKey })
+        : ROUTES.survey.navigateTo({ ...navigateToProps, targetSubjectId });
+      navigator.navigate(screenToNavigate, { replace: true });
+      return;
+    }
+  }, [activityId, currentActivityId, groupProgress?.endAt, isOneTimeCompletion]);
 
   const responseError = error?.evaluatedMessage ?? '';
 
-  if (isLoading || (flowId && isFetching)) {
-    // loading screen on initial load and when refetching completed entities for flows
+  if (isLoading || isFetching) {
+    // loading screen on initial load and when refetching completed entities
     return <LoadingScreen publicAppletKey={publicAppletKey} appletId={appletId} />;
   }
 

--- a/src/widgets/Survey/ui/index.tsx
+++ b/src/widgets/Survey/ui/index.tsx
@@ -133,7 +133,7 @@ export const SurveyWidget = (props: Props) => {
   // - gate on fresh data to avoid syncing with stale cache
   const { changes } = useEntitiesSync({
     completedEntities:
-      !shouldFetchCompletedEntities || isLoading || isFetching ? undefined : completedEntities,
+      shouldFetchCompletedEntities && !isLoading && !isFetching ? completedEntities : undefined,
     respondentSubjectId: respondentMeta?.subjectId ?? null,
     events: eventsDTO?.events ?? [],
     activityFlows: appletBaseDTO?.activityFlows ?? [],

--- a/src/widgets/Survey/ui/index.tsx
+++ b/src/widgets/Survey/ui/index.tsx
@@ -126,7 +126,7 @@ export const SurveyWidget = (props: Props) => {
   // - gate on shouldRestart to avoid passing in cached completedEntities
   // - gate on applet loading to ensure respondentMeta?.subjectId is available
   // - gate on fresh data to avoid syncing with stale cache
-  useEntitiesSync({
+  const { changes } = useEntitiesSync({
     completedEntities:
       !shouldFetchCompletedEntities || isLoading || isFetching ? undefined : completedEntities,
     respondentSubjectId: respondentMeta?.subjectId ?? null,
@@ -136,23 +136,23 @@ export const SurveyWidget = (props: Props) => {
   });
 
   // After server sync:
-  // - Redirect to activity list if one-time entity was completed on another device
+  // - Redirect to activity list if entity was completed on another device
   // - Redirect to latest activity if flow progressed on another device
+  const groupProgressChanged = changes.includes(flowId ?? activityId);
   const groupProgressId = getProgressId(flowId ?? activityId, eventId, targetSubjectId);
   const groupProgress = useAppSelector((state) =>
     groupProgressId ? appletModel.selectors.selectGroupProgress(state, groupProgressId) : null,
   );
-  const isOneTimeCompletion =
-    eventsDTO?.events.find(({ id }) => id === eventId)?.availability.oneTimeCompletion ?? false;
   const currentActivityId = !groupProgress?.endAt
     ? (groupProgress as FlowProgress)?.currentActivityId
     : null;
 
   useEffect(() => {
-    if (!flowResumeEnabled) return;
+    // Only consider redirect if progress has changed
+    if (!groupProgressChanged) return;
 
-    // If one-time entity was completed on another device, redirect to activity list
-    if (groupProgress?.endAt && isOneTimeCompletion) {
+    // If entity was completed on another device, redirect to activity list
+    if (groupProgress?.endAt) {
       navigator.navigate(ROUTES.appletDetails.navigateTo(appletId), { replace: true });
       return;
     }
@@ -172,7 +172,7 @@ export const SurveyWidget = (props: Props) => {
       navigator.navigate(screenToNavigate, { replace: true });
       return;
     }
-  }, [activityId, currentActivityId, groupProgress?.endAt, isOneTimeCompletion]);
+  }, [activityId, currentActivityId, groupProgress?.endAt, groupProgressChanged]);
 
   const responseError = error?.evaluatedMessage ?? '';
 


### PR DESCRIPTION
🔗 [Jira Ticket M2-10434](https://mindlogger.atlassian.net/browse/M2-10434)
🔗 [Jira Ticket M2-10441](https://mindlogger.atlassian.net/browse/M2-10441)

Changes include:

- Modify `useEntitiesSync` to return an array of changed activity/flow IDs
- Redirect `Survey` to activity list if changes indicate a completion on a different device
- Show “**Done!** This survey was already completed on a different device.” on redirect
- Set activity order to display “Activity 1” if user starts activity/flow again

### 📸 Screenshots

Banner displayed if user is redirected back to activity list after completion on a different device:

<img width="1104" height="742" alt="2026-02-11 Activity Already Completed Banner (M2-10434)" src="https://github.com/user-attachments/assets/dc41882b-762b-46ef-b81b-d090e1c24496" />