### PR TITLE
fix: Clear React Query cache on logout (M2-10447)

### DIFF
--- a/src/features/Logout/lib/useLogout.ts
+++ b/src/features/Logout/lib/useLogout.ts
@@ -2,8 +2,6 @@ import { useCallback } from 'react';
 
 import { useLocation } from 'react-router-dom';
 
-import { queryClient } from '~/app/providers/react-query';
-import { persistor } from '~/app/store';
 import { appletModel } from '~/entities/applet';
 import { useLogoutMutation, userModel } from '~/entities/user';
 import { AutoCompletionModel } from '~/features/AutoCompletion';
@@ -41,8 +39,6 @@ export const useLogout = (): UseLogoutReturn => {
     clearUser();
     clearStore();
     clearAutoCompletionState();
-    queryClient.clear();
-    persistor.purge();
     secureTokensStorage.clearTokens();
     userModel.secureUserPrivateKeyStorage.clearUserPrivateKey();
 

--- a/src/features/Logout/lib/useLogout.ts
+++ b/src/features/Logout/lib/useLogout.ts
@@ -2,6 +2,8 @@ import { useCallback } from 'react';
 
 import { useLocation } from 'react-router-dom';
 
+import { queryClient } from '~/app/providers/react-query';
+import { persistor } from '~/app/store';
 import { appletModel } from '~/entities/applet';
 import { useLogoutMutation, userModel } from '~/entities/user';
 import { AutoCompletionModel } from '~/features/AutoCompletion';
@@ -39,6 +41,8 @@ export const useLogout = (): UseLogoutReturn => {
     clearUser();
     clearStore();
     clearAutoCompletionState();
+    queryClient.clear();
+    persistor.purge();
     secureTokensStorage.clearTokens();
     userModel.secureUserPrivateKeyStorage.clearUserPrivateKey();
 

--- a/src/features/Logout/lib/useLogout.ts
+++ b/src/features/Logout/lib/useLogout.ts
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 
 import { useLocation } from 'react-router-dom';
 
+import { queryClient } from '~/app/providers/react-query';
 import { appletModel } from '~/entities/applet';
 import { useLogoutMutation, userModel } from '~/entities/user';
 import { AutoCompletionModel } from '~/features/AutoCompletion';
@@ -39,6 +40,7 @@ export const useLogout = (): UseLogoutReturn => {
     clearUser();
     clearStore();
     clearAutoCompletionState();
+    queryClient.clear();
     secureTokensStorage.clearTokens();
     userModel.secureUserPrivateKeyStorage.clearUserPrivateKey();
 


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-10447](https://mindlogger.atlassian.net/browse/M2-10447)

Clearing React Query cache on logout fixes issue where cached state would appear across login sessions.

### 🪤 Peer Testing

1. Configure an applet to have at least two participants.
2. Complete first activity of multi-activity flow as Participant A, “Submit”, and “Save & Exit”.
3. Using the same browser session, logout as Participant A and login as Participant B.
4. Complete first activity of same multi-activity flow as Participant B, “Submit”, and “Save & Exit”.
5. Using the same browser session, logout as Participant B and login as Participant A to view the same applet.
6. Using the same browser session, logout as Participant A and login as Participant B to view the same applet.
7. Repeat steps 5 and 6 as many times as you want.

Expected: When repeating steps 5 and 6, the applet shows the multi-activity flow *one time* as **In Progress**.
Observed: When repeating steps 5 and 6, the applet shows the multi-activity flow *two times* as **In Progress**.