### PR TITLE
fix: propagate shouldRestart flag through activity flow navigation

### DIFF
--- a/src/entities/applet/model/hooks/useEntityComplete.ts
+++ b/src/entities/applet/model/hooks/useEntityComplete.ts
@@ -26,6 +26,8 @@ type Props = {
 
   appletId: string;
   flow: ActivityFlowDTO | null;
+
+  shouldRestart?: boolean; // Flag to propagate through flow navigation to skip sync
 };
 
 type CompleteOptions = {
@@ -148,6 +150,7 @@ export const useEntityComplete = (props: Props) => {
             entityType: 'flow',
             publicAppletKey: props.publicAppletKey,
             flowId: props.flowId,
+            shouldRestart: props.shouldRestart,
           }),
           { replace: true },
         );
@@ -161,6 +164,7 @@ export const useEntityComplete = (props: Props) => {
           targetSubjectId: props.targetSubjectId,
           entityType: 'flow',
           flowId: props.flowId,
+          shouldRestart: props.shouldRestart,
         }),
         { replace: true },
       );
@@ -172,6 +176,7 @@ export const useEntityComplete = (props: Props) => {
       props.flowId,
       props.publicAppletKey,
       props.targetSubjectId,
+      props.shouldRestart,
     ],
   );
 

--- a/src/features/PassSurvey/lib/SurveyContext.ts
+++ b/src/features/PassSurvey/lib/SurveyContext.ts
@@ -36,6 +36,8 @@ export type SurveyContext = {
   flow: ActivityFlowDTO | null;
 
   integrations: AppletDTO['integrations'];
+
+  shouldRestart?: boolean; // Flag to indicate if the flow was restarted, used to skip sync during session
 };
 
 export const SurveyContext = createContext<SurveyContext>({} as SurveyContext);

--- a/src/features/PassSurvey/lib/mappers.ts
+++ b/src/features/PassSurvey/lib/mappers.ts
@@ -21,6 +21,7 @@ type Props = {
   currentEventId: string;
   flowId: string | null;
   publicAppletKey: string | null;
+  shouldRestart?: boolean;
 };
 
 export const mapRawDataToSurveyContext = ({
@@ -33,6 +34,7 @@ export const mapRawDataToSurveyContext = ({
   publicAppletKey,
   targetSubject,
   respondentMeta,
+  shouldRestart,
 }: Props): SurveyContext => {
   if (!appletDTO || !appletBaseDTO || !eventsDTO || !activityDTO) {
     throw new Error('[MapRawDataToSurveyContext] Missing required data');
@@ -72,5 +74,6 @@ export const mapRawDataToSurveyContext = ({
     appletVersion: appletDTO.version,
     flow,
     integrations: appletDTO.integrations,
+    shouldRestart,
   };
 };

--- a/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.ts
+++ b/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.ts
@@ -18,6 +18,8 @@ export type EntitiesSyncProps = {
   events: ScheduleEventDto[];
   activityFlows: ActivityFlowDTO[];
   flowResumeEnabled: boolean;
+  /** When true, skip syncing in-progress data from server (user wants to restart fresh) */
+  shouldRestart?: boolean;
 };
 
 export const useEntitiesSync = ({
@@ -26,6 +28,7 @@ export const useEntitiesSync = ({
   events,
   activityFlows,
   flowResumeEnabled,
+  shouldRestart,
 }: EntitiesSyncProps) => {
   const { saveGroupProgress, getGroupProgress } = appletModel.hooks.useGroupProgressStateManager();
 
@@ -57,7 +60,13 @@ export const useEntitiesSync = ({
 
       // Case 1: In-progress flow (started on another device, not yet completed)
       // Create or update resumable progress so user can continue where they left off
+      // Skip this case when shouldRestart=true (user wants to start fresh, not resume)
       if (isFlow && entity.isFlowCompleted === false) {
+        // When restarting, skip in-progress syncing - user wants to start fresh
+        if (shouldRestart) {
+          return false;
+        }
+
         const flow = activityFlows.find((f) => f.id === entity.id);
 
         if (!flow) {

--- a/src/widgets/Survey/ui/PassingScreen.tsx
+++ b/src/widgets/Survey/ui/PassingScreen.tsx
@@ -118,6 +118,7 @@ const PassingScreen = (props: Props) => {
     flowId: context.flow?.id ?? null,
     appletId: context.appletId,
     flow: context.flow,
+    shouldRestart: context.shouldRestart,
   });
 
   const { replaceTextVariables } = useTextVariablesReplacer({

--- a/src/widgets/Survey/ui/SummaryScreen/index.tsx
+++ b/src/widgets/Survey/ui/SummaryScreen/index.tsx
@@ -39,6 +39,7 @@ const SummaryScreen = () => {
     flowId: context.flow?.id ?? null,
     appletId: context.appletId,
     flow: context.flow,
+    shouldRestart: context.shouldRestart,
   });
 
   const onFinish = () => {

--- a/src/widgets/Survey/ui/index.tsx
+++ b/src/widgets/Survey/ui/index.tsx
@@ -108,10 +108,6 @@ export const SurveyWidget = (props: Props) => {
   const flowResumeFlag = featureFlag(FeatureFlag.EnableFlowResume, []);
   const flowResumeEnabled = isFlowResumeEnabled(flowResumeFlag, appletId);
 
-  // Skip fetching completed entities when user explicitly clicked "Restart".
-  // This prevents the sync logic from overwriting local restart progress with server data.
-  const shouldFetchCompletedEntities = flowResumeEnabled && !shouldRestart;
-
   const { data: completedEntities, isFetching } = useCompletedEntitiesQuery(
     {
       appletId,
@@ -120,21 +116,22 @@ export const SurveyWidget = (props: Props) => {
     },
     {
       select: (data) => data.data.result,
-      enabled: shouldFetchCompletedEntities,
+      enabled: flowResumeEnabled,
     },
   );
 
   // Sync with server
-  // - gate on shouldRestart to avoid passing in cached completedEntities
   // - gate on applet loading to ensure respondentMeta?.subjectId is available
   // - gate on fresh data to avoid syncing with stale cache
+  // - pass shouldRestart to skip in-progress syncing but still check completion status
   const { changes } = useEntitiesSync({
     completedEntities:
-      shouldFetchCompletedEntities && !isLoading && !isFetching ? completedEntities : undefined,
+      flowResumeEnabled && !isLoading && !isFetching ? completedEntities : undefined,
     respondentSubjectId: respondentMeta?.subjectId ?? null,
     events: eventsDTO?.events ?? [],
     activityFlows: appletBaseDTO?.activityFlows ?? [],
     flowResumeEnabled,
+    shouldRestart,
   });
 
   // After server sync:

--- a/src/widgets/Survey/ui/index.tsx
+++ b/src/widgets/Survey/ui/index.tsx
@@ -10,7 +10,6 @@ import { FlowProgress, getProgressId } from '~/abstract/lib';
 import { useCompletedEntitiesQuery } from '~/entities/activity';
 import { appletModel } from '~/entities/applet';
 import { useBanners } from '~/entities/banner/model';
-import { PeriodicityType } from '~/entities/event';
 import { AutoCompletionModel } from '~/features/AutoCompletion';
 import {
   SurveyContext,
@@ -109,13 +108,9 @@ export const SurveyWidget = (props: Props) => {
   const flowResumeFlag = featureFlag(FeatureFlag.EnableFlowResume, []);
   const flowResumeEnabled = isFlowResumeEnabled(flowResumeFlag, appletId);
 
-  // Skip fetch on "Restart" by user
-  // (but never skip for one-time entities that cannot be restarted after completion)
-  const event = eventsDTO?.events.find((e) => e.id === eventId);
-  const isOneTimeCompletion =
-    event?.availability.oneTimeCompletion ||
-    event?.availability.periodicityType === PeriodicityType.Once;
-  const shouldFetchCompletedEntities = flowResumeEnabled && (!shouldRestart || isOneTimeCompletion);
+  // Skip fetching completed entities when user explicitly clicked "Restart".
+  // This prevents the sync logic from overwriting local restart progress with server data.
+  const shouldFetchCompletedEntities = flowResumeEnabled && !shouldRestart;
 
   const { data: completedEntities, isFetching } = useCompletedEntitiesQuery(
     {

--- a/src/widgets/Survey/ui/index.tsx
+++ b/src/widgets/Survey/ui/index.tsx
@@ -221,6 +221,7 @@ export const SurveyWidget = (props: Props) => {
         flowId,
         targetSubject,
         publicAppletKey,
+        shouldRestart,
       })}
     >
       <ScreenManager openTimesUpModal={openTimesUpModal} />


### PR DESCRIPTION
- [ ] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [ ] OSS packages added to Curious [open source credit page](https://mindlogger.atlassian.net/jira/servicedesk/projects/MLA/knowledge/articles/340623543?spaceKey=MLA)

### 📝 Description

🔗 [Jira Ticket M2-10455](https://mindlogger.atlassian.net/browse/M2-10455)

**Problem:** When restarting an activity flow on web after completing some activities on another device, users could only complete 1 activity before getting the error "activity flow has been completed on another device".

**Root Cause:** The `shouldRestart` URL parameter was only passed on the initial restart navigation but not propagated through subsequent activity navigations within the flow. This caused the sync logic to run after the first activity completion, which would overwrite the local progress with server data and block further progress.

**Solution:** Propagate the `shouldRestart` flag through the entire flow session to prevent sync interference during active flow sessions.

Changes include:

- Add `shouldRestart` to `SurveyContext` type
- Pass `shouldRestart` through `mapRawDataToSurveyContext` mapper
- Propagate `shouldRestart` in `useEntityComplete` hook for flow navigation
- Pass `shouldRestart` from `PassingScreen` and `SummaryScreen` to `useEntityComplete`

This ensures that when a user restarts an activity flow, the `shouldRestart` flag persists through all subsequent activity navigations within the flow, preventing the sync logic from interfering mid-flow and allowing the user to complete all activities in the restarted flow.

### ✏️ Notes

**Behavior Changes:**
- **Before:** Restart flow → complete activity 1 → navigate to activity 2 (sync runs, overwrites progress)
- **After:** Restart flow → complete all activities without sync interference → on Save & Exit, sync runs with "farthest progress" logic

**Files Modified:**
- `src/features/PassSurvey/lib/SurveyContext.ts`
- `src/features/PassSurvey/lib/mappers.ts`
- `src/widgets/Survey/ui/index.tsx`
- `src/entities/applet/model/hooks/useEntityComplete.ts`
- `src/widgets/Survey/ui/PassingScreen.tsx`
- `src/widgets/Survey/ui/SummaryScreen/index.tsx`
