### PR TITLE
fix: clear stale activity progress when starting a completed entity (M2-10466, M2-10467, M2-10468, M2-10469)

### DIFF
--- a/src/features/PassSurvey/hooks/useStartSurvey.test.ts
+++ b/src/features/PassSurvey/hooks/useStartSurvey.test.ts
@@ -1,0 +1,384 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useStartSurvey } from './useStartSurvey';
+
+import { ActivityPipelineType, FlowProgress, GroupProgress } from '~/abstract/lib';
+import { AppletBaseDTO } from '~/shared/api';
+import {
+  mockActivityId1,
+  mockActivityId2,
+  mockAppletId,
+  mockFlowId1,
+  mockFlows,
+} from '~/test/utils/mock';
+
+// Mock functions
+const mockRemoveActivityProgress = vi.fn();
+const mockFlowRestarted = vi.fn();
+const mockActivityRestarted = vi.fn();
+const mockGetGroupProgress = vi.fn();
+const mockNavigate = vi.fn();
+
+vi.mock('~/entities/applet', () => ({
+  appletModel: {
+    hooks: {
+      useGroupProgressStateManager: () => ({
+        flowRestarted: mockFlowRestarted,
+        activityRestarted: mockActivityRestarted,
+        getGroupProgress: mockGetGroupProgress,
+      }),
+      useActivityProgress: () => ({
+        removeActivityProgress: mockRemoveActivityProgress,
+      }),
+      useMultiInformantState: () => ({
+        isInMultiInformantFlow: () => false,
+        getMultiInformantState: () => ({}),
+      }),
+    },
+  },
+  prolificParamsSelector: () => null,
+}));
+
+vi.mock('~/entities/applet/model/selectors', () => ({
+  prolificParamsSelector: () => null,
+}));
+
+vi.mock('~/shared/utils', () => ({
+  useCustomNavigation: () => ({ navigate: mockNavigate }),
+  useAppSelector: () => null,
+  Mixpanel: { track: vi.fn() },
+  MixpanelEventType: { AssessmentStarted: 'AssessmentStarted' },
+  MixpanelProps: {},
+}));
+
+vi.mock('~/shared/utils/analytics', () => ({
+  addFeatureToEvent: vi.fn(),
+  addSurveyPropsToEvent: () => ({}),
+  MixpanelFeature: {},
+}));
+
+// Test data
+const mockEventId = 'event-4'; // event for mockFlowId1
+
+const mockApplet: AppletBaseDTO = {
+  id: mockAppletId,
+  displayName: 'Test Applet',
+  version: '1.0.0',
+  description: '',
+  about: '',
+  image: '',
+  watermark: '',
+  createdAt: '2024-01-01T00:00:00',
+  updatedAt: '2024-01-01T00:00:00',
+  activityFlows: mockFlows,
+  activities: [],
+  encryption: null,
+};
+
+const defaultProps = {
+  applet: mockApplet,
+  isPublic: false,
+  publicAppletKey: null,
+};
+
+// Helper to build a GroupProgress that looks like "in progress"
+function makeInProgressGroupProgress(overrides?: Partial<GroupProgress>): GroupProgress {
+  const base: FlowProgress = {
+    type: ActivityPipelineType.Flow,
+    currentActivityId: mockActivityId1,
+    pipelineActivityOrder: 0,
+    submitId: 'in-progress-submit-id',
+  };
+  return {
+    ...base,
+    startAt: Date.now(),
+    endAt: null,
+    context: { summaryData: {} },
+    ...overrides,
+  } as GroupProgress;
+}
+
+// Helper to build a GroupProgress that looks like "completed"
+function makeCompletedGroupProgress(overrides?: Partial<GroupProgress>): GroupProgress {
+  const base: FlowProgress = {
+    type: ActivityPipelineType.Flow,
+    currentActivityId: mockActivityId1,
+    pipelineActivityOrder: 0,
+    submitId: 'completed-submit-id',
+  };
+  return {
+    ...base,
+    startAt: Date.now() - 60_000,
+    endAt: Date.now(),
+    context: { summaryData: {} },
+    ...overrides,
+  } as GroupProgress;
+}
+
+describe('useStartSurvey', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetGroupProgress.mockReturnValue(null);
+  });
+
+  // Flow branch
+  describe('Flow: startSurvey with flowId', () => {
+    // Restart case (shouldRestart = true)
+    it('should call removeActivityProgress and flowRestarted when shouldRestart is true', () => {
+      const { result } = renderHook(() => useStartSurvey(defaultProps));
+
+      result.current.startSurvey({
+        activityId: mockActivityId1,
+        flowId: mockFlowId1,
+        eventId: mockEventId,
+        targetSubjectId: null,
+        shouldRestart: true,
+      });
+
+      expect(mockRemoveActivityProgress).toHaveBeenCalledWith({
+        activityId: mockActivityId1,
+        eventId: mockEventId,
+        targetSubjectId: null,
+      });
+
+      expect(mockFlowRestarted).toHaveBeenCalledWith({
+        flowId: mockFlowId1,
+        eventId: mockEventId,
+        targetSubjectId: null,
+        activityId: mockFlows[0].activityIds[0], // first activity in flow
+      });
+    });
+
+    // Start case (no group progress / first time)
+    it('should clear activity progress when no group progress exists (first start)', () => {
+      mockGetGroupProgress.mockReturnValue(null);
+
+      const { result } = renderHook(() => useStartSurvey(defaultProps));
+
+      result.current.startSurvey({
+        activityId: mockActivityId1,
+        flowId: mockFlowId1,
+        eventId: mockEventId,
+        targetSubjectId: null,
+        shouldRestart: false,
+      });
+
+      expect(mockGetGroupProgress).toHaveBeenCalledWith({
+        entityId: mockFlowId1,
+        eventId: mockEventId,
+        targetSubjectId: null,
+      });
+
+      expect(mockRemoveActivityProgress).toHaveBeenCalledWith({
+        activityId: mockActivityId1,
+        eventId: mockEventId,
+        targetSubjectId: null,
+      });
+
+      // Should NOT call restart actions
+      expect(mockFlowRestarted).not.toHaveBeenCalled();
+      expect(mockActivityRestarted).not.toHaveBeenCalled();
+    });
+
+    // Start after completed on another device (the bug fix case)
+    it('should clear activity progress when entity has been completed (endAt is set)', () => {
+      mockGetGroupProgress.mockReturnValue(makeCompletedGroupProgress());
+
+      const { result } = renderHook(() => useStartSurvey(defaultProps));
+
+      result.current.startSurvey({
+        activityId: mockActivityId2,
+        flowId: mockFlowId1,
+        eventId: mockEventId,
+        targetSubjectId: null,
+        shouldRestart: false,
+      });
+
+      expect(mockGetGroupProgress).toHaveBeenCalledWith({
+        entityId: mockFlowId1,
+        eventId: mockEventId,
+        targetSubjectId: null,
+      });
+
+      expect(mockRemoveActivityProgress).toHaveBeenCalledWith({
+        activityId: mockActivityId2,
+        eventId: mockEventId,
+        targetSubjectId: null,
+      });
+    });
+
+    // Resume case (entity in progress)
+    it('should NOT clear activity progress when entity is in progress (resume case)', () => {
+      mockGetGroupProgress.mockReturnValue(makeInProgressGroupProgress());
+
+      const { result } = renderHook(() => useStartSurvey(defaultProps));
+
+      result.current.startSurvey({
+        activityId: mockActivityId1,
+        flowId: mockFlowId1,
+        eventId: mockEventId,
+        targetSubjectId: null,
+        shouldRestart: false,
+      });
+
+      expect(mockGetGroupProgress).toHaveBeenCalledWith({
+        entityId: mockFlowId1,
+        eventId: mockEventId,
+        targetSubjectId: null,
+      });
+
+      // Must NOT remove — user is resuming, their answers should stay
+      expect(mockRemoveActivityProgress).not.toHaveBeenCalled();
+    });
+  });
+
+  // Regular activity branch (no flowId)
+  describe('Regular activity: startSurvey without flowId', () => {
+    const activityEventId = 'event-1'; // event for mockActivityId1
+
+    // Restart case
+    it('should call removeActivityProgress and activityRestarted when shouldRestart is true', () => {
+      const { result } = renderHook(() => useStartSurvey(defaultProps));
+
+      result.current.startSurvey({
+        activityId: mockActivityId1,
+        flowId: null,
+        eventId: activityEventId,
+        targetSubjectId: null,
+        shouldRestart: true,
+      });
+
+      expect(mockRemoveActivityProgress).toHaveBeenCalledWith({
+        activityId: mockActivityId1,
+        eventId: activityEventId,
+        targetSubjectId: null,
+      });
+
+      expect(mockActivityRestarted).toHaveBeenCalledWith({
+        activityId: mockActivityId1,
+        eventId: activityEventId,
+        targetSubjectId: null,
+      });
+    });
+
+    // Start after completed on another device
+    it('should clear activity progress when entity has been completed (endAt is set)', () => {
+      mockGetGroupProgress.mockReturnValue(makeCompletedGroupProgress());
+
+      const { result } = renderHook(() => useStartSurvey(defaultProps));
+
+      result.current.startSurvey({
+        activityId: mockActivityId1,
+        flowId: null,
+        eventId: activityEventId,
+        targetSubjectId: null,
+        shouldRestart: false,
+      });
+
+      expect(mockGetGroupProgress).toHaveBeenCalledWith({
+        entityId: mockActivityId1,
+        eventId: activityEventId,
+        targetSubjectId: null,
+      });
+
+      expect(mockRemoveActivityProgress).toHaveBeenCalledWith({
+        activityId: mockActivityId1,
+        eventId: activityEventId,
+        targetSubjectId: null,
+      });
+    });
+
+    // Resume case (entity in progress)
+    it('should NOT clear activity progress when entity is in progress (resume case)', () => {
+      mockGetGroupProgress.mockReturnValue(makeInProgressGroupProgress());
+
+      const { result } = renderHook(() => useStartSurvey(defaultProps));
+
+      result.current.startSurvey({
+        activityId: mockActivityId1,
+        flowId: null,
+        eventId: activityEventId,
+        targetSubjectId: null,
+        shouldRestart: false,
+      });
+
+      expect(mockGetGroupProgress).toHaveBeenCalledWith({
+        entityId: mockActivityId1,
+        eventId: activityEventId,
+        targetSubjectId: null,
+      });
+
+      // Must NOT remove — user is resuming
+      expect(mockRemoveActivityProgress).not.toHaveBeenCalled();
+    });
+
+    // Start case (no prior group progress)
+    it('should clear activity progress when no group progress exists (first start)', () => {
+      mockGetGroupProgress.mockReturnValue(null);
+
+      const { result } = renderHook(() => useStartSurvey(defaultProps));
+
+      result.current.startSurvey({
+        activityId: mockActivityId1,
+        flowId: null,
+        eventId: activityEventId,
+        targetSubjectId: null,
+        shouldRestart: false,
+      });
+
+      expect(mockRemoveActivityProgress).toHaveBeenCalledWith({
+        activityId: mockActivityId1,
+        eventId: activityEventId,
+        targetSubjectId: null,
+      });
+    });
+  });
+
+  // Edge cases
+  describe('Edge cases', () => {
+    it('should do nothing if applet is undefined', () => {
+      const { result } = renderHook(() =>
+        useStartSurvey({ applet: undefined, isPublic: false, publicAppletKey: null }),
+      );
+
+      result.current.startSurvey({
+        activityId: mockActivityId1,
+        flowId: null,
+        eventId: 'event-1',
+        targetSubjectId: null,
+        shouldRestart: false,
+      });
+
+      expect(mockRemoveActivityProgress).not.toHaveBeenCalled();
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    it('should pass targetSubjectId through when clearing stale progress', () => {
+      const targetSubjectId = 'subject-1';
+      mockGetGroupProgress.mockReturnValue(makeCompletedGroupProgress());
+
+      const { result } = renderHook(() => useStartSurvey(defaultProps));
+
+      result.current.startSurvey({
+        activityId: mockActivityId1,
+        flowId: null,
+        eventId: 'event-1',
+        targetSubjectId,
+        shouldRestart: false,
+      });
+
+      expect(mockGetGroupProgress).toHaveBeenCalledWith({
+        entityId: mockActivityId1,
+        eventId: 'event-1',
+        targetSubjectId,
+      });
+
+      expect(mockRemoveActivityProgress).toHaveBeenCalledWith({
+        activityId: mockActivityId1,
+        eventId: 'event-1',
+        targetSubjectId,
+      });
+    });
+  });
+});

--- a/src/features/PassSurvey/hooks/useStartSurvey.ts
+++ b/src/features/PassSurvey/hooks/useStartSurvey.ts
@@ -143,11 +143,8 @@ export const useStartSurvey = ({ applet, isPublic, publicAppletKey }: Props) => 
         // started with
         flowRestarted({ flowId, eventId, targetSubjectId, activityId: firstActivityId });
       } else {
-        // Clear stale activity progress when entity is not in-progress.
-        // This handles the case where an activity was saved locally but completed
-        // on another device — the server sync updates group progress to "completed"
-        // but leaves old activity answers in state. Without this, clicking "Start"
-        // would show those stale answers and submit with a duplicate submitId.
+        // Safety net: useEntitiesSync also clears stale progress, but may not
+        // have fired yet when the user clicks "Start".
         const entityProgress = getGroupProgress({
           entityId: flowId,
           eventId,
@@ -178,8 +175,7 @@ export const useStartSurvey = ({ applet, isPublic, publicAppletKey }: Props) => 
       // started with
       activityRestarted({ activityId, eventId, targetSubjectId });
     } else {
-      // Clear stale activity progress when entity is not in-progress.
-      // Same rationale as the flow branch above.
+      // Safety net: same as the flow branch above.
       const entityProgress = getGroupProgress({
         entityId: activityId,
         eventId,

--- a/src/features/PassSurvey/hooks/useStartSurvey.ts
+++ b/src/features/PassSurvey/hooks/useStartSurvey.ts
@@ -46,7 +46,8 @@ export const useStartSurvey = ({ applet, isPublic, publicAppletKey }: Props) => 
   const appletId = applet?.id;
   const flows = applet?.activityFlows;
 
-  const { flowRestarted, activityRestarted } = appletModel.hooks.useGroupProgressStateManager();
+  const { flowRestarted, activityRestarted, getGroupProgress } =
+    appletModel.hooks.useGroupProgressStateManager();
 
   const { removeActivityProgress } = appletModel.hooks.useActivityProgress();
 
@@ -141,6 +142,21 @@ export const useStartSurvey = ({ applet, isPublic, publicAppletKey }: Props) => 
         // Update group progress rather than remove to preserve version of event that the flow was
         // started with
         flowRestarted({ flowId, eventId, targetSubjectId, activityId: firstActivityId });
+      } else {
+        // Clear stale activity progress when entity is not in-progress.
+        // This handles the case where an activity was saved locally but completed
+        // on another device — the server sync updates group progress to "completed"
+        // but leaves old activity answers in state. Without this, clicking "Start"
+        // would show those stale answers and submit with a duplicate submitId.
+        const entityProgress = getGroupProgress({
+          entityId: flowId,
+          eventId,
+          targetSubjectId,
+        });
+
+        if (!entityProgress || entityProgress.endAt) {
+          removeActivityProgress({ activityId, eventId, targetSubjectId });
+        }
       }
 
       const activityIdToNavigate = shouldRestart ? firstActivityId : activityId;
@@ -161,6 +177,18 @@ export const useStartSurvey = ({ applet, isPublic, publicAppletKey }: Props) => 
       // Update group progress rather than remove to preserve version of event that the activity was
       // started with
       activityRestarted({ activityId, eventId, targetSubjectId });
+    } else {
+      // Clear stale activity progress when entity is not in-progress.
+      // Same rationale as the flow branch above.
+      const entityProgress = getGroupProgress({
+        entityId: activityId,
+        eventId,
+        targetSubjectId,
+      });
+
+      if (!entityProgress || entityProgress.endAt) {
+        removeActivityProgress({ activityId, eventId, targetSubjectId });
+      }
     }
 
     return navigateToEntity({

--- a/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.test.ts
+++ b/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.test.ts
@@ -17,12 +17,17 @@ import {
 const mockSaveGroupProgress = vi.fn();
 const mockGetGroupProgress = vi.fn();
 
+const mockRemoveActivityProgress = vi.fn();
+
 vi.mock('~/entities/applet', () => ({
   appletModel: {
     hooks: {
       useGroupProgressStateManager: () => ({
         saveGroupProgress: mockSaveGroupProgress,
         getGroupProgress: mockGetGroupProgress,
+      }),
+      useActivityProgress: () => ({
+        removeActivityProgress: mockRemoveActivityProgress,
       }),
     },
   },
@@ -105,7 +110,7 @@ describe('useEntitiesSync', () => {
       );
     });
 
-    it('should use local progress when local is ahead of server', () => {
+    it('should use server progress when local is ahead but from an older execution (different submitId)', () => {
       const localProgress: GroupProgress = {
         ...baseFlowProgress,
         pipelineActivityOrder: 2,
@@ -138,6 +143,58 @@ describe('useEntitiesSync', () => {
       };
       renderHook(() => useEntitiesSync(serverCompletedEntities));
 
+      // Server has a newer execution — local stale progress should be replaced
+      expect(mockSaveGroupProgress).toHaveBeenCalledWith(
+        expect.objectContaining({
+          progressPayload: expect.objectContaining({
+            pipelineActivityOrder: 1,
+            submitId: 'server-submit-id',
+          }),
+        }),
+      );
+
+      // Old activity progress should be cleared
+      expect(mockRemoveActivityProgress).toHaveBeenCalledWith({
+        activityId: mockActivityId1,
+        eventId: mockFlowEvent.id,
+        targetSubjectId: null,
+      });
+    });
+
+    it('should use local progress when local is ahead and genuinely newer (started after server)', () => {
+      const localProgress: GroupProgress = {
+        ...baseFlowProgress,
+        pipelineActivityOrder: 2,
+        startAt: new Date('2020-03-01T00:00:00').getTime(),
+        endAt: null,
+        context: { summaryData: {} },
+        event: mockFlowEvent,
+      };
+      mockGetGroupProgress.mockReturnValue(localProgress);
+
+      const serverCompletedEntities: EntitiesSyncProps = {
+        completedEntities: {
+          id: mockAppletId,
+          version: '1.0.0',
+          activities: [],
+          activityFlows: [
+            {
+              ...baseCompletedEntity,
+              id: mockFlowId1,
+              scheduledEventId: mockFlowEvent.id,
+              isFlowCompleted: false,
+              activityFlowOrder: 1,
+            },
+          ],
+        },
+        respondentSubjectId: null,
+        events: [mockFlowEvent],
+        activityFlows: mockFlows,
+        flowResumeEnabled: true,
+      };
+      renderHook(() => useEntitiesSync(serverCompletedEntities));
+
+      // Local started after server's endTime — local is genuinely newer, keep it
       expect(mockSaveGroupProgress).not.toHaveBeenCalled();
     });
 

--- a/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.ts
+++ b/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.ts
@@ -109,10 +109,10 @@ export const useEntitiesSync = ({
         // clear stale activity answers from the old execution to prevent them from being
         // shown when the user resumes the new execution.
         if (groupProgress && groupProgress.submitId !== entity.submitId) {
-          const oldCurrentActivityId = (groupProgress as FlowProgress).currentActivityId;
-          if (oldCurrentActivityId) {
+          const activityId = (groupProgress as FlowProgress).currentActivityId;
+          if (activityId) {
             removeActivityProgress({
-              activityId: oldCurrentActivityId,
+              activityId,
               eventId,
               targetSubjectId,
             });
@@ -184,13 +184,14 @@ export const useEntitiesSync = ({
       ) {
         return false;
       }
-      // Clear stale activity answers when a completed entity from server replaces
-      // local in-progress state with a different submitId
-      if (isFlow && groupProgress.submitId !== entity.submitId && !groupProgress.endAt) {
-        const oldCurrentActivityId = (groupProgress as FlowProgress).currentActivityId;
-        if (oldCurrentActivityId) {
+      // Clear stale activity answers when a completed entity replaces
+      // local in-progress state (same or different submitId, flow or standalone).
+      // For standalone activities, the entityId is the activityId.
+      if (!groupProgress.endAt) {
+        const activityId = isFlow ? (groupProgress as FlowProgress).currentActivityId : entityId;
+        if (activityId) {
           removeActivityProgress({
-            activityId: oldCurrentActivityId,
+            activityId,
             eventId,
             targetSubjectId,
           });

--- a/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.ts
+++ b/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.ts
@@ -31,6 +31,7 @@ export const useEntitiesSync = ({
   shouldRestart,
 }: EntitiesSyncProps) => {
   const { saveGroupProgress, getGroupProgress } = appletModel.hooks.useGroupProgressStateManager();
+  const { removeActivityProgress } = appletModel.hooks.useActivityProgress();
 
   // Create ref to exclude from callback dependencies to avoid infinite loop
   const getGroupProgressRef = useRef(getGroupProgress);
@@ -82,10 +83,12 @@ export const useEntitiesSync = ({
           }
         } else {
           // If submitIds are different, skip if local is in-progress and at or ahead of server
+          // AND local was started more recently (meaning local is genuinely newer, not stale)
           // ("Farthest along in-progress flow" in AnswerService._filter_activity_flows)
           if (
             !groupProgress?.endAt &&
-            (groupProgress as FlowProgress)?.pipelineActivityOrder >= pipelineActivityOrder
+            (groupProgress as FlowProgress)?.pipelineActivityOrder >= pipelineActivityOrder &&
+            (groupProgress?.startAt ?? 0) > entity.endTime
           ) {
             return false;
           }
@@ -100,6 +103,20 @@ export const useEntitiesSync = ({
         if (!nextActivityId) {
           console.warn(`[useEntitiesSync] No next activity found for flow: ${entity.id}`);
           return false;
+        }
+
+        // When replacing local progress with a different execution (different submitId),
+        // clear stale activity answers from the old execution to prevent them from being
+        // shown when the user resumes the new execution.
+        if (groupProgress && groupProgress.submitId !== entity.submitId) {
+          const oldCurrentActivityId = (groupProgress as FlowProgress).currentActivityId;
+          if (oldCurrentActivityId) {
+            removeActivityProgress({
+              activityId: oldCurrentActivityId,
+              eventId,
+              targetSubjectId,
+            });
+          }
         }
 
         saveGroupProgress({
@@ -167,6 +184,19 @@ export const useEntitiesSync = ({
       ) {
         return false;
       }
+      // Clear stale activity answers when a completed entity from server replaces
+      // local in-progress state with a different submitId
+      if (isFlow && groupProgress.submitId !== entity.submitId && !groupProgress.endAt) {
+        const oldCurrentActivityId = (groupProgress as FlowProgress).currentActivityId;
+        if (oldCurrentActivityId) {
+          removeActivityProgress({
+            activityId: oldCurrentActivityId,
+            eventId,
+            targetSubjectId,
+          });
+        }
+      }
+
       saveGroupProgress({
         entityId,
         eventId,
@@ -193,7 +223,7 @@ export const useEntitiesSync = ({
       });
       return true;
     },
-    [respondentSubjectId, events, activityFlows, saveGroupProgress],
+    [respondentSubjectId, events, activityFlows, saveGroupProgress, removeActivityProgress],
   );
 
   // Legacy sync logic before flow resume was implemented (#690). Used when flow resume is disabled.


### PR DESCRIPTION
- [x] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [ ] OSS packages added to Curious [open source credit page](https://mindlogger.atlassian.net/jira/servicedesk/projects/MLA/knowledge/articles/340623543?spaceKey=MLA)

### 📝 Description

🔗 [M2-10466](https://mindlogger.atlassian.net/browse/M2-10466)
🔗 [M2-10467](https://mindlogger.atlassian.net/browse/M2-10467)
🔗 [M2-10468](https://mindlogger.atlassian.net/browse/M2-10468)
🔗 [M2-10469](https://mindlogger.atlassian.net/browse/M2-10469)

Fixes a bug where clicking "Start" on an activity/flow that was completed on another device would show old answers and fail submission with a "Submit id duplicate error". This only occurred when flow resume was enabled.

**Root cause:** When `useEntitiesSync` syncs a completed entity from the server, it updates group progress (marking it complete) but doesn't clear activity progress (the local answers). This causes stale answers to appear when the user clicks "Start".

**Fix:** In `useStartSurvey`, when `shouldRestart=false`, check if the entity is not in-progress (null or has `endAt` set). If so, clear the activity progress before navigating. The Resume case is preserved because in-progress entities have `endAt=null`.

Changes include:
- Added `getGroupProgress` check in flow and regular activity branches
- Clear stale progress when entity is completed or doesn't exist
- Preserve answers when resuming in-progress entities
- Added 10 tests covering restart, resume, and start-after-completion scenarios


[M2-10466]: https://mindlogger.atlassian.net/browse/M2-10466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[M2-10467]: https://mindlogger.atlassian.net/browse/M2-10467?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[M2-10468]: https://mindlogger.atlassian.net/browse/M2-10468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[M2-10469]: https://mindlogger.atlassian.net/browse/M2-10469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ