### PR TITLE
fix: clear endAt when restarting a flow (M2-10471)

### DIFF
--- a/src/entities/applet/model/slice.test.ts
+++ b/src/entities/applet/model/slice.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+
+import { actions, reducer } from './slice';
+
+import { ActivityPipelineType, FlowProgress, GroupProgress, getProgressId } from '~/abstract/lib';
+
+const flowId = 'flow-1';
+const eventId = 'event-1';
+const activityId = 'activity-1';
+const firstActivityId = 'activity-first';
+const targetSubjectId = null;
+
+const progressId = getProgressId(flowId, eventId, targetSubjectId);
+
+function stateWithFlowProgress(overrides: Partial<GroupProgress> = {}) {
+  const progress: FlowProgress = {
+    type: ActivityPipelineType.Flow,
+    currentActivityId: activityId,
+    pipelineActivityOrder: 2,
+    submitId: 'old-submit-id',
+  };
+  return {
+    groupProgress: {
+      [progressId]: {
+        ...progress,
+        startAt: 1000,
+        endAt: null,
+        context: { summaryData: {} },
+        event: null,
+        ...overrides,
+      } as GroupProgress,
+    },
+    progress: {},
+    completedEntities: {},
+    completions: {},
+    multiInformantState: {},
+    consents: {},
+    activeAssessment: null,
+  };
+}
+
+describe('flowRestarted reducer', () => {
+  it('resets pipelineActivityOrder to 0', () => {
+    const state = stateWithFlowProgress();
+    const next = reducer(
+      state,
+      actions.flowRestarted({ flowId, eventId, targetSubjectId, activityId: firstActivityId }),
+    );
+    expect((next.groupProgress[progressId] as FlowProgress).pipelineActivityOrder).toBe(0);
+  });
+
+  it('updates currentActivityId to the first activity', () => {
+    const state = stateWithFlowProgress();
+    const next = reducer(
+      state,
+      actions.flowRestarted({ flowId, eventId, targetSubjectId, activityId: firstActivityId }),
+    );
+    expect((next.groupProgress[progressId] as FlowProgress).currentActivityId).toBe(
+      firstActivityId,
+    );
+  });
+
+  it('generates a new submitId', () => {
+    const state = stateWithFlowProgress();
+    const next = reducer(
+      state,
+      actions.flowRestarted({ flowId, eventId, targetSubjectId, activityId: firstActivityId }),
+    );
+    expect((next.groupProgress[progressId] as FlowProgress).submitId).not.toBe('old-submit-id');
+  });
+
+  it('updates startAt to a new timestamp', () => {
+    const state = stateWithFlowProgress({ startAt: 1000 });
+    const next = reducer(
+      state,
+      actions.flowRestarted({ flowId, eventId, targetSubjectId, activityId: firstActivityId }),
+    );
+    expect(next.groupProgress[progressId].startAt).toBeGreaterThan(1000);
+  });
+
+  // M2-10471: endAt must be cleared so consumers (ActivityGroupsBuildManager, useEntitiesSync,
+  // useStartSurvey) treat the restarted flow as in-progress rather than completed.
+  it('clears endAt to null when flow was previously completed', () => {
+    const completionTime = Date.now() - 5000;
+    const state = stateWithFlowProgress({ endAt: completionTime });
+    const next = reducer(
+      state,
+      actions.flowRestarted({ flowId, eventId, targetSubjectId, activityId: firstActivityId }),
+    );
+    expect(next.groupProgress[progressId].endAt).toBeNull();
+  });
+
+  it('leaves endAt null when flow was already in-progress', () => {
+    const state = stateWithFlowProgress({ endAt: null });
+    const next = reducer(
+      state,
+      actions.flowRestarted({ flowId, eventId, targetSubjectId, activityId: firstActivityId }),
+    );
+    expect(next.groupProgress[progressId].endAt).toBeNull();
+  });
+
+  it('does nothing when no groupProgress exists for the flow', () => {
+    const state = stateWithFlowProgress();
+    const unknownProgressId = getProgressId('unknown-flow', eventId, null);
+    const next = reducer(
+      state,
+      actions.flowRestarted({
+        flowId: 'unknown-flow',
+        eventId,
+        targetSubjectId: null,
+        activityId: firstActivityId,
+      }),
+    );
+    expect(next.groupProgress[unknownProgressId]).toBeUndefined();
+    // Original entry must be untouched
+    expect(next.groupProgress[progressId]).toEqual(state.groupProgress[progressId]);
+  });
+});

--- a/src/entities/applet/model/slice.ts
+++ b/src/entities/applet/model/slice.ts
@@ -349,6 +349,7 @@ const appletsSlice = createSlice({
         groupProgress.currentActivityId = payload.activityId;
         groupProgress.pipelineActivityOrder = 0;
         groupProgress.startAt = new Date().getTime();
+        groupProgress.endAt = null;
         groupProgress.submitId = uuidV4();
       }
     },

--- a/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.test.ts
+++ b/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.test.ts
@@ -198,6 +198,60 @@ describe('useEntitiesSync', () => {
       expect(mockSaveGroupProgress).not.toHaveBeenCalled();
     });
 
+    // Restart bug scenario (M2-10471): after a flow is completed and then restarted, the backend
+    // (with the companion fix) returns the new in-progress execution. Without clearing endAt in
+    // flowRestarted, the stale endAt from the prior completion causes this sync to be skipped.
+    it('should accept server in-progress entity even when local has stale endAt from a prior completion', () => {
+      // Simulates a device that has just restarted the flow: flowRestarted set a new submitId and
+      // pipelineActivityOrder=0 but (before the fix) left endAt from the previous completion.
+      const priorCompletionTime = new Date('2020-02-01T00:00:00').getTime();
+      const localProgress: GroupProgress = {
+        ...baseFlowProgress,
+        submitId: 'new-restart-submit-id',
+        pipelineActivityOrder: 0,
+        startAt: new Date('2020-02-05T00:00:00').getTime(),
+        endAt: priorCompletionTime, // stale — not cleared by flowRestarted before the fix
+        context: { summaryData: {} },
+        event: mockFlowEvent,
+      };
+      mockGetGroupProgress.mockReturnValue(localProgress);
+
+      // Server returns the same new in-progress execution at order 1
+      const serverCompletedEntities: EntitiesSyncProps = {
+        completedEntities: {
+          id: mockAppletId,
+          version: '1.0.0',
+          activities: [],
+          activityFlows: [
+            {
+              ...baseCompletedEntity,
+              id: mockFlowId1,
+              submitId: 'new-restart-submit-id',
+              scheduledEventId: mockFlowEvent.id,
+              isFlowCompleted: false,
+              activityFlowOrder: 1,
+              endTime: new Date('2020-02-06T00:00:00').getTime(),
+            },
+          ],
+        },
+        respondentSubjectId: null,
+        events: [mockFlowEvent],
+        activityFlows: mockFlows,
+        flowResumeEnabled: true,
+      };
+      renderHook(() => useEntitiesSync(serverCompletedEntities));
+
+      // Server is ahead (order 1 > 0) — sync must apply regardless of local endAt
+      expect(mockSaveGroupProgress).toHaveBeenCalledWith(
+        expect.objectContaining({
+          progressPayload: expect.objectContaining({
+            pipelineActivityOrder: 1,
+            endAt: null,
+          }),
+        }),
+      );
+    });
+
     it('should use local progress when local is at the same position as server', () => {
       const localProgress: GroupProgress = {
         ...baseFlowProgress,


### PR DESCRIPTION
- [x] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [ ] OSS packages added to Curious [open source credit page](https://mindlogger.atlassian.net/jira/servicedesk/projects/MLA/knowledge/articles/340623543?spaceKey=MLA)

### 📝 Description

🔗 [Jira Ticket M2-10471](https://mindlogger.atlassian.net/browse/M2-10471)

The `flowRestarted` reducer updated `pipelineActivityOrder`, `startAt`, and `submitId` on restart, but left `endAt` from the prior completion intact. Any code that checks `endAt` to determine whether a flow is in-progress would therefore treat the restarted flow as still completed.

Changes include:

- Add `groupProgress.endAt = null` in the `flowRestarted` reducer (mirrors `flowStarted` / `activityStarted`)
- Unit tests for the `flowRestarted` reducer (`slice.test.ts`)
- New test case in `useEntitiesSync.test.ts` covering the restart scenario (local has stale `endAt`, server sends a newer in-progress entity)


### ✏️ Notes

Depends on / related to: [mindlogger-backend-refactor#2023](https://github.com/ChildMindInstitute/mindlogger-backend-refactor/pull/2023) — without that backend fix, the server may still return the stale completed entity instead of the new in-