### PR TITLE
Fix: flow restart and start (M2-10515, M2-10516)

### DIFF
--- a/src/abstract/lib/GroupBuilder/ActivityGroupsBuilder.test.ts
+++ b/src/abstract/lib/GroupBuilder/ActivityGroupsBuilder.test.ts
@@ -1668,6 +1668,7 @@ describe('ActivityGroupsBuilder', () => {
             timeLeftToComplete: null,
             image: null,
             isInActivityFlow: true,
+            isDeletedFlow: false,
             activityFlowDetails: {
               showActivityFlowBadge: true,
               activityFlowName: 'test-flow-name-1',
@@ -1710,6 +1711,7 @@ describe('ActivityGroupsBuilder', () => {
             timeLeftToComplete: null,
             image: null,
             isInActivityFlow: true,
+            isDeletedFlow: false,
             activityFlowDetails: {
               showActivityFlowBadge: false,
               activityFlowName: 'test-flow-name-1',

--- a/src/abstract/lib/GroupBuilder/ListItemsFactory.ts
+++ b/src/abstract/lib/GroupBuilder/ListItemsFactory.ts
@@ -17,6 +17,7 @@ export class ListItemsFactory {
     const activityFlow = activityEvent.entity as ActivityFlow;
 
     item.isInActivityFlow = true;
+    item.isDeletedFlow = activityEvent.isDeletedFlow ?? false;
     item.activityFlowDetails = {
       showActivityFlowBadge: !activityFlow.hideBadge,
       activityFlowName: activityFlow.name,
@@ -39,6 +40,15 @@ export class ListItemsFactory {
     }
 
     if (!activity) {
+      // For deleted flows, the activity may not exist in the current applet version
+      if (activityEvent.isDeletedFlow) {
+        item.activityId = '';
+        item.activityFlowDetails.activityPositionInFlow = position;
+        item.name = activityFlow.name;
+        item.description = activityFlow.description;
+        return;
+      }
+
       throw new Error(
         '[ListItemsFactory:populateActivityFlowFields] Activity not found in activities list',
       );

--- a/src/abstract/lib/GroupBuilder/ListItemsFactory.ts
+++ b/src/abstract/lib/GroupBuilder/ListItemsFactory.ts
@@ -18,20 +18,26 @@ export class ListItemsFactory {
 
     item.isInActivityFlow = true;
     item.isDeletedFlow = activityEvent.isDeletedFlow ?? false;
+
+    const isInProgress = this.utility.isInProgress(activityEvent);
+    const progressRecord = isInProgress
+      ? (this.utility.getProgressRecord(activityEvent) as FlowProgress)
+      : undefined;
+
+    // Use stored activity IDs from progress if available (handles version changes)
+    const effectiveActivityCount =
+      progressRecord?.flowActivityIds?.length ?? activityFlow.activityIds.length;
+
     item.activityFlowDetails = {
       showActivityFlowBadge: !activityFlow.hideBadge,
       activityFlowName: activityFlow.name,
-      numberOfActivitiesInFlow: activityFlow.activityIds.length,
+      numberOfActivitiesInFlow: effectiveActivityCount,
       activityPositionInFlow: 0,
     };
 
-    const isInProgress = this.utility.isInProgress(activityEvent);
-
     let activity: Activity | undefined, position: number;
 
-    if (isInProgress) {
-      const progressRecord = this.utility.getProgressRecord(activityEvent) as FlowProgress;
-
+    if (isInProgress && progressRecord) {
       activity = this.utility.activities.find((x) => x.id === progressRecord.currentActivityId);
       position = progressRecord.pipelineActivityOrder + 1;
     } else {

--- a/src/abstract/lib/GroupBuilder/activityGroups.types.ts
+++ b/src/abstract/lib/GroupBuilder/activityGroups.types.ts
@@ -31,6 +31,8 @@ export type EventEntity = {
   event: ScheduleEvent;
   /** Target subject of assignment if not self-report, else null */
   targetSubject: SubjectDTO | null;
+  /** True when the flow was deleted in a newer applet version but is still in-progress */
+  isDeletedFlow?: boolean;
 };
 
 export type EntityType = 'regular' | 'flow';

--- a/src/abstract/lib/GroupBuilder/types.ts
+++ b/src/abstract/lib/GroupBuilder/types.ts
@@ -33,6 +33,8 @@ export type ActivityListItem = {
   isTimerSet: boolean;
   isTimerElapsed: boolean;
   timeLeftToComplete?: HourMinute | null;
+  /** True when the flow was deleted in a newer applet version but is still in-progress */
+  isDeletedFlow?: boolean;
 };
 
 export type ActivityListGroup = {

--- a/src/abstract/lib/types/entityProgress.ts
+++ b/src/abstract/lib/types/entityProgress.ts
@@ -34,11 +34,15 @@ export type FlowProgress = {
   currentActivityId: string;
   pipelineActivityOrder: number;
   submitId: string;
+  // Version of the applet when the flow was first started
+  appletVersion?: string;
 };
 
 export type ActivityProgress = {
   type: ActivityPipelineType.Regular;
   submitId: string;
+  // Version of the applet when the activity was first started
+  appletVersion?: string;
 };
 
 export type ProgressContext = {

--- a/src/abstract/lib/types/entityProgress.ts
+++ b/src/abstract/lib/types/entityProgress.ts
@@ -36,6 +36,10 @@ export type FlowProgress = {
   submitId: string;
   // Version of the applet when the flow was first started
   appletVersion?: string;
+  // Snapshot of the flow's activity IDs at start time (for deleted flow recovery)
+  flowActivityIds?: string[];
+  // Flow name at start time (for deleted flow recovery)
+  flowName?: string;
 };
 
 export type ActivityProgress = {

--- a/src/entities/activity/api/useActivityByIdQuery.ts
+++ b/src/entities/activity/api/useActivityByIdQuery.ts
@@ -6,6 +6,7 @@ type Options<TData> = QueryOptions<FetchFn, TData>;
 type Params = {
   isPublic: boolean;
   activityId: string;
+  version?: string;
 };
 
 export const useActivityByIdQuery = <TData = ReturnAwaited<FetchFn>>(
@@ -14,7 +15,11 @@ export const useActivityByIdQuery = <TData = ReturnAwaited<FetchFn>>(
 ) => {
   return useBaseQuery(
     ['activityById', params],
-    () => ActivityApiProxyService.getActivityById(params.activityId, { isPublic: params.isPublic }),
+    () =>
+      ActivityApiProxyService.getActivityById(params.activityId, {
+        isPublic: params.isPublic,
+        version: params.version,
+      }),
     options,
   );
 };

--- a/src/entities/applet/model/hooks/useEntityComplete.ts
+++ b/src/entities/applet/model/hooks/useEntityComplete.ts
@@ -184,8 +184,9 @@ export const useEntityComplete = (props: Props) => {
     (input?: CompleteOptions) => {
       const isAutoCompletion = input?.type === 'autoCompletion';
 
+      const entityId = props.flowId ? props.flowId : props.activityId;
       const groupProgress = getGroupProgress({
-        entityId: props.flowId ? props.flowId : props.activityId,
+        entityId,
         eventId: props.eventId,
         targetSubjectId: props.targetSubjectId,
       });

--- a/src/entities/applet/model/hooks/useEntityComplete.ts
+++ b/src/entities/applet/model/hooks/useEntityComplete.ts
@@ -5,7 +5,7 @@ import type { NavigateOptions } from 'react-router/dist/lib/context';
 
 import { useProlific } from './useProlific';
 
-import { ActivityPipelineType } from '~/abstract/lib';
+import { ActivityPipelineType, FlowProgress } from '~/abstract/lib';
 import { appletModel } from '~/entities/applet';
 import { useProlificCompletionCodeQuery } from '~/entities/applet/api/integrations/useProlificCompletionCodeQuery';
 import { prolificParamsSelector } from '~/entities/applet/model/selectors';
@@ -202,15 +202,20 @@ export const useEntityComplete = (props: Props) => {
 
       const currentPipelineActivityOrder = groupProgress.pipelineActivityOrder;
 
-      if (!props.flow) {
+      // Prefer stored activity IDs from when the flow was started (handles version changes)
+      const storedActivityIds = (groupProgress as FlowProgress).flowActivityIds;
+      const activityIds = storedActivityIds ?? props.flow?.activityIds ?? [];
+      const flowId = props.flow?.id ?? props.flowId;
+
+      if (!activityIds.length || !flowId) {
         throw new Error('[UseEntityComplete:completeFlow] Flow not found');
       }
 
-      const nextActivityId = props.flow.activityIds[currentPipelineActivityOrder + 1];
+      const nextActivityId = activityIds[currentPipelineActivityOrder + 1];
 
       flowUpdated({
-        activityId: nextActivityId ? nextActivityId : props.flow.activityIds[0],
-        flowId: props.flow.id,
+        activityId: nextActivityId ? nextActivityId : activityIds[0],
+        flowId,
         eventId: props.eventId,
         targetSubjectId: props.targetSubjectId,
         pipelineActivityOrder: nextActivityId ? currentPipelineActivityOrder + 1 : 0,

--- a/src/entities/applet/model/hooks/useEntityStart.ts
+++ b/src/entities/applet/model/hooks/useEntityStart.ts
@@ -22,12 +22,14 @@ export const useEntityStart = () => {
     activityId: string,
     event: ScheduleEventDto,
     targetSubjectId: string | null,
+    appletVersion: string,
   ): void {
     dispatch(
       actions.activityStarted({
         activityId,
         event,
         targetSubjectId,
+        appletVersion,
       }),
     );
   }
@@ -38,6 +40,7 @@ export const useEntityStart = () => {
     event: ScheduleEventDto,
     targetSubjectId: string | null,
     pipelineActivityOrder: number,
+    appletVersion: string,
   ): void {
     dispatch(
       actions.flowStarted({
@@ -46,6 +49,7 @@ export const useEntityStart = () => {
         event,
         targetSubjectId,
         pipelineActivityOrder,
+        appletVersion,
       }),
     );
   }
@@ -54,6 +58,7 @@ export const useEntityStart = () => {
     activityId: string,
     event: ScheduleEventDto,
     targetSubjectId: string | null,
+    appletVersion: string,
   ): void {
     const groupProgress = getProgress(activityId, event.id, targetSubjectId);
 
@@ -61,13 +66,14 @@ export const useEntityStart = () => {
       return;
     }
 
-    return activityStarted(activityId, event, targetSubjectId);
+    return activityStarted(activityId, event, targetSubjectId, appletVersion);
   }
 
   function startFlow(
     event: ScheduleEventDto,
     flow: ActivityFlowDTO,
     targetSubjectId: string | null,
+    appletVersion: string,
   ): void {
     const flowId = flow.id;
 
@@ -87,7 +93,7 @@ export const useEntityStart = () => {
 
     const firstActivityId: string = flowActivities[0];
 
-    return flowStarted(flowId, firstActivityId, event, targetSubjectId, 0);
+    return flowStarted(flowId, firstActivityId, event, targetSubjectId, 0, appletVersion);
   }
 
   return { startActivity, startFlow };

--- a/src/entities/applet/model/hooks/useEntityStart.ts
+++ b/src/entities/applet/model/hooks/useEntityStart.ts
@@ -41,6 +41,8 @@ export const useEntityStart = () => {
     targetSubjectId: string | null,
     pipelineActivityOrder: number,
     appletVersion: string,
+    flowActivityIds: string[],
+    flowName: string,
   ): void {
     dispatch(
       actions.flowStarted({
@@ -50,6 +52,8 @@ export const useEntityStart = () => {
         targetSubjectId,
         pipelineActivityOrder,
         appletVersion,
+        flowActivityIds,
+        flowName,
       }),
     );
   }
@@ -93,7 +97,16 @@ export const useEntityStart = () => {
 
     const firstActivityId: string = flowActivities[0];
 
-    return flowStarted(flowId, firstActivityId, event, targetSubjectId, 0, appletVersion);
+    return flowStarted(
+      flowId,
+      firstActivityId,
+      event,
+      targetSubjectId,
+      0,
+      appletVersion,
+      flow.activityIds,
+      flow.name,
+    );
   }
 
   return { startActivity, startFlow };

--- a/src/entities/applet/model/hooks/useGroupProgressStateManager.ts
+++ b/src/entities/applet/model/hooks/useGroupProgressStateManager.ts
@@ -10,6 +10,7 @@ import {
   RemoveGroupProgressPayload,
   SaveGroupProgressPayload,
   SaveSummaryDataInContext,
+  UpdateAppletVersionPayload,
 } from '../types';
 import { useActiveAssessment } from './useActiveAssessment';
 
@@ -27,6 +28,7 @@ type Return = {
 
   flowRestarted: (props: FlowRestartedPayload) => void;
   activityRestarted: (props: InProgressActivity) => void;
+  updateAppletVersion: (payload: UpdateAppletVersionPayload) => void;
 };
 
 export const useGroupProgressStateManager = (): Return => {
@@ -98,6 +100,13 @@ export const useGroupProgressStateManager = (): Return => {
     [dispatch],
   );
 
+  const updateAppletVersion = useCallback(
+    (payload: UpdateAppletVersionPayload) => {
+      dispatch(actions.updateAppletVersion(payload));
+    },
+    [dispatch],
+  );
+
   return {
     getGroupProgress,
 
@@ -110,5 +119,6 @@ export const useGroupProgressStateManager = (): Return => {
 
     activityRestarted,
     flowRestarted,
+    updateAppletVersion,
   };
 };

--- a/src/entities/applet/model/slice.test.ts
+++ b/src/entities/applet/model/slice.test.ts
@@ -9,6 +9,9 @@ const eventId = 'event-1';
 const activityId = 'activity-1';
 const firstActivityId = 'activity-first';
 const targetSubjectId = null;
+const appletVersion = '1.0.0';
+const flowActivityIds = ['activity-first', 'activity-1', 'activity-2'];
+const flowName = 'Test Flow';
 
 const progressId = getProgressId(flowId, eventId, targetSubjectId);
 
@@ -44,7 +47,15 @@ describe('flowRestarted reducer', () => {
     const state = stateWithFlowProgress();
     const next = reducer(
       state,
-      actions.flowRestarted({ flowId, eventId, targetSubjectId, activityId: firstActivityId }),
+      actions.flowRestarted({
+        flowId,
+        eventId,
+        targetSubjectId,
+        activityId: firstActivityId,
+        appletVersion,
+        flowActivityIds,
+        flowName,
+      }),
     );
     expect((next.groupProgress[progressId] as FlowProgress).pipelineActivityOrder).toBe(0);
   });
@@ -53,7 +64,15 @@ describe('flowRestarted reducer', () => {
     const state = stateWithFlowProgress();
     const next = reducer(
       state,
-      actions.flowRestarted({ flowId, eventId, targetSubjectId, activityId: firstActivityId }),
+      actions.flowRestarted({
+        flowId,
+        eventId,
+        targetSubjectId,
+        activityId: firstActivityId,
+        appletVersion,
+        flowActivityIds,
+        flowName,
+      }),
     );
     expect((next.groupProgress[progressId] as FlowProgress).currentActivityId).toBe(
       firstActivityId,
@@ -64,7 +83,15 @@ describe('flowRestarted reducer', () => {
     const state = stateWithFlowProgress();
     const next = reducer(
       state,
-      actions.flowRestarted({ flowId, eventId, targetSubjectId, activityId: firstActivityId }),
+      actions.flowRestarted({
+        flowId,
+        eventId,
+        targetSubjectId,
+        activityId: firstActivityId,
+        appletVersion,
+        flowActivityIds,
+        flowName,
+      }),
     );
     expect((next.groupProgress[progressId] as FlowProgress).submitId).not.toBe('old-submit-id');
   });
@@ -73,7 +100,15 @@ describe('flowRestarted reducer', () => {
     const state = stateWithFlowProgress({ startAt: 1000 });
     const next = reducer(
       state,
-      actions.flowRestarted({ flowId, eventId, targetSubjectId, activityId: firstActivityId }),
+      actions.flowRestarted({
+        flowId,
+        eventId,
+        targetSubjectId,
+        activityId: firstActivityId,
+        appletVersion,
+        flowActivityIds,
+        flowName,
+      }),
     );
     expect(next.groupProgress[progressId].startAt).toBeGreaterThan(1000);
   });
@@ -85,7 +120,15 @@ describe('flowRestarted reducer', () => {
     const state = stateWithFlowProgress({ endAt: completionTime });
     const next = reducer(
       state,
-      actions.flowRestarted({ flowId, eventId, targetSubjectId, activityId: firstActivityId }),
+      actions.flowRestarted({
+        flowId,
+        eventId,
+        targetSubjectId,
+        activityId: firstActivityId,
+        appletVersion,
+        flowActivityIds,
+        flowName,
+      }),
     );
     expect(next.groupProgress[progressId].endAt).toBeNull();
   });
@@ -94,7 +137,15 @@ describe('flowRestarted reducer', () => {
     const state = stateWithFlowProgress({ endAt: null });
     const next = reducer(
       state,
-      actions.flowRestarted({ flowId, eventId, targetSubjectId, activityId: firstActivityId }),
+      actions.flowRestarted({
+        flowId,
+        eventId,
+        targetSubjectId,
+        activityId: firstActivityId,
+        appletVersion,
+        flowActivityIds,
+        flowName,
+      }),
     );
     expect(next.groupProgress[progressId].endAt).toBeNull();
   });
@@ -109,6 +160,9 @@ describe('flowRestarted reducer', () => {
         eventId,
         targetSubjectId: null,
         activityId: firstActivityId,
+        appletVersion,
+        flowActivityIds,
+        flowName,
       }),
     );
     expect(next.groupProgress[unknownProgressId]).toBeUndefined();

--- a/src/entities/applet/model/slice.ts
+++ b/src/entities/applet/model/slice.ts
@@ -291,6 +291,7 @@ const appletsSlice = createSlice({
         startAt: new Date().getTime(),
         endAt: null,
         submitId: uuidV4(),
+        appletVersion: payload.appletVersion,
         context: {
           summaryData: {},
         },
@@ -310,6 +311,7 @@ const appletsSlice = createSlice({
         endAt: null,
         submitId: uuidV4(),
         pipelineActivityOrder: payload.pipelineActivityOrder,
+        appletVersion: payload.appletVersion,
         context: {
           summaryData: {},
         },
@@ -337,6 +339,11 @@ const appletsSlice = createSlice({
       if (groupProgress) {
         groupProgress.startAt = new Date().getTime();
         groupProgress.submitId = uuidV4();
+        // On restart, update to current applet version
+        const version = payload.appletVersion;
+        if (version) {
+          groupProgress.appletVersion = version;
+        }
       }
     },
 
@@ -351,6 +358,8 @@ const appletsSlice = createSlice({
         groupProgress.startAt = new Date().getTime();
         groupProgress.endAt = null;
         groupProgress.submitId = uuidV4();
+        // On restart, update to current applet version
+        groupProgress.appletVersion = payload.appletVersion;
       }
     },
 

--- a/src/entities/applet/model/slice.ts
+++ b/src/entities/applet/model/slice.ts
@@ -312,6 +312,8 @@ const appletsSlice = createSlice({
         submitId: uuidV4(),
         pipelineActivityOrder: payload.pipelineActivityOrder,
         appletVersion: payload.appletVersion,
+        flowActivityIds: payload.flowActivityIds,
+        flowName: payload.flowName,
         context: {
           summaryData: {},
         },
@@ -360,6 +362,8 @@ const appletsSlice = createSlice({
         groupProgress.submitId = uuidV4();
         // On restart, update to current applet version
         groupProgress.appletVersion = payload.appletVersion;
+        groupProgress.flowActivityIds = payload.flowActivityIds;
+        groupProgress.flowName = payload.flowName;
       }
     },
 

--- a/src/entities/applet/model/slice.ts
+++ b/src/entities/applet/model/slice.ts
@@ -28,6 +28,7 @@ import {
   FlowRestartedPayload,
   UpdateSubStepPayload,
   SaveItemCustomPropertyPayload,
+  UpdateAppletVersionPayload,
 } from './types';
 
 import {
@@ -95,6 +96,22 @@ const appletsSlice = createSlice({
       const id = getProgressId(payload.entityId, payload.eventId, payload.targetSubjectId);
 
       delete state.groupProgress[id];
+    },
+
+    updateAppletVersion: (state, { payload }: PayloadAction<UpdateAppletVersionPayload>) => {
+      const id = getProgressId(payload.entityId, payload.eventId, payload.targetSubjectId);
+
+      const groupProgress = state.groupProgress[id];
+      if (groupProgress) {
+        groupProgress.appletVersion = payload.appletVersion;
+        if (payload.flowActivityIds) {
+          (groupProgress as FlowProgress & EventProgressTimestampState).flowActivityIds =
+            payload.flowActivityIds;
+        }
+        if (payload.flowName) {
+          (groupProgress as FlowProgress & EventProgressTimestampState).flowName = payload.flowName;
+        }
+      }
     },
 
     saveSummaryDataInGroupContext: (

--- a/src/entities/applet/model/types.ts
+++ b/src/entities/applet/model/types.ts
@@ -285,4 +285,13 @@ export type FlowRestartedPayload = {
   flowName: string;
 };
 
+export type UpdateAppletVersionPayload = {
+  entityId: string;
+  eventId: string;
+  targetSubjectId: string | null;
+  appletVersion: string;
+  flowActivityIds?: string[];
+  flowName?: string;
+};
+
 export type MultiInformantPayload = Required<MultiInformantState>;

--- a/src/entities/applet/model/types.ts
+++ b/src/entities/applet/model/types.ts
@@ -252,6 +252,7 @@ export type InProgressActivity = {
   activityId: string;
   eventId: string;
   targetSubjectId: string | null;
+  appletVersion?: string;
 };
 
 export type InProgressFlow = {
@@ -264,10 +265,12 @@ export type InProgressFlow = {
 
 export type ActivityStartedPayload = {
   event: ScheduleEventDto;
+  appletVersion: string;
 } & Omit<InProgressActivity, 'eventId'>;
 
 export type FlowStartedPayload = {
   event: ScheduleEventDto;
+  appletVersion: string;
 } & Omit<InProgressFlow, 'eventId'>;
 
 export type FlowRestartedPayload = {
@@ -275,6 +278,7 @@ export type FlowRestartedPayload = {
   eventId: string;
   targetSubjectId: string | null;
   activityId: string;
+  appletVersion: string;
 };
 
 export type MultiInformantPayload = Required<MultiInformantState>;

--- a/src/entities/applet/model/types.ts
+++ b/src/entities/applet/model/types.ts
@@ -271,6 +271,8 @@ export type ActivityStartedPayload = {
 export type FlowStartedPayload = {
   event: ScheduleEventDto;
   appletVersion: string;
+  flowActivityIds: string[];
+  flowName: string;
 } & Omit<InProgressFlow, 'eventId'>;
 
 export type FlowRestartedPayload = {
@@ -279,6 +281,8 @@ export type FlowRestartedPayload = {
   targetSubjectId: string | null;
   activityId: string;
   appletVersion: string;
+  flowActivityIds: string[];
+  flowName: string;
 };
 
 export type MultiInformantPayload = Required<MultiInformantState>;

--- a/src/features/PassSurvey/hooks/useAnswers.ts
+++ b/src/features/PassSurvey/hooks/useAnswers.ts
@@ -3,6 +3,7 @@ import { useCallback, useContext } from 'react';
 import { SurveyContext } from '../lib';
 import AnswersConstructService from '../model/AnswersConstructService';
 
+import { ActivityPipelineType } from '~/abstract/lib';
 import { appletModel } from '~/entities/applet';
 import { ProlificUrlParamsPayload as ProlificUrlParams } from '~/entities/applet/model';
 import { ActivityFlowDTO, AnswerPayload, EncryptionDTO, ScheduleEventDto } from '~/shared/api';
@@ -55,6 +56,14 @@ export const useAnswerBuilder = (): AnswerBuilder => {
       const resolvedVersion =
         params.appletVersion ?? groupProgress.appletVersion ?? context.appletVersion;
 
+      const resolvedFlow = params.flow ?? context.flow;
+
+      // For deleted flows, context.flow is null but context.entityId still
+      // holds the original flow ID (from the URL / groupProgress key).
+      const resolvedFlowId =
+        resolvedFlow?.id ??
+        (groupProgress.type === ActivityPipelineType.Flow ? context.entityId : null);
+
       const answerConstructService = new AnswersConstructService({
         groupProgress,
         userEvents: params.userEvents,
@@ -64,7 +73,8 @@ export const useAnswerBuilder = (): AnswerBuilder => {
         appletId: params.appletId ?? context.appletId,
         // Use the version stored in progress to match the version from when the session started
         appletVersion: resolvedVersion,
-        flow: params.flow ?? context.flow,
+        flow: resolvedFlow,
+        flowId: resolvedFlowId,
         encryption,
         publicAppletKey: params.publicAppletKey ?? context.publicAppletKey,
         isFlowCompleted: params.isFlowCompleted,
@@ -98,6 +108,7 @@ export const useAnswerBuilder = (): AnswerBuilder => {
       context.event,
       context.appletId,
       context.appletVersion,
+      context.entityId,
       context.flow,
       context.publicAppletKey,
       context.integrations,

--- a/src/features/PassSurvey/hooks/useAnswers.ts
+++ b/src/features/PassSurvey/hooks/useAnswers.ts
@@ -52,6 +52,9 @@ export const useAnswerBuilder = (): AnswerBuilder => {
         throw new Error('[useAnswer:buildAnswer] Encryption is not found');
       }
 
+      const resolvedVersion =
+        params.appletVersion ?? groupProgress.appletVersion ?? context.appletVersion;
+
       const answerConstructService = new AnswersConstructService({
         groupProgress,
         userEvents: params.userEvents,
@@ -60,7 +63,7 @@ export const useAnswerBuilder = (): AnswerBuilder => {
         activityId: params.activityId,
         appletId: params.appletId ?? context.appletId,
         // Use the version stored in progress to match the version from when the session started
-        appletVersion: params.appletVersion ?? groupProgress.appletVersion ?? context.appletVersion,
+        appletVersion: resolvedVersion,
         flow: params.flow ?? context.flow,
         encryption,
         publicAppletKey: params.publicAppletKey ?? context.publicAppletKey,

--- a/src/features/PassSurvey/hooks/useAnswers.ts
+++ b/src/features/PassSurvey/hooks/useAnswers.ts
@@ -59,7 +59,8 @@ export const useAnswerBuilder = (): AnswerBuilder => {
         event: params.event ?? groupProgress.event ?? context.event,
         activityId: params.activityId,
         appletId: params.appletId ?? context.appletId,
-        appletVersion: params.appletVersion ?? context.appletVersion,
+        // Use the version stored in progress to match the version from when the session started
+        appletVersion: params.appletVersion ?? groupProgress.appletVersion ?? context.appletVersion,
         flow: params.flow ?? context.flow,
         encryption,
         publicAppletKey: params.publicAppletKey ?? context.publicAppletKey,

--- a/src/features/PassSurvey/hooks/useStartSurvey.test.ts
+++ b/src/features/PassSurvey/hooks/useStartSurvey.test.ts
@@ -147,6 +147,9 @@ describe('useStartSurvey', () => {
         eventId: mockEventId,
         targetSubjectId: null,
         activityId: mockFlows[0].activityIds[0], // first activity in flow
+        appletVersion: '1.0.0',
+        flowActivityIds: mockFlows[0].activityIds,
+        flowName: 'Test Flow',
       });
     });
 
@@ -259,6 +262,7 @@ describe('useStartSurvey', () => {
         activityId: mockActivityId1,
         eventId: activityEventId,
         targetSubjectId: null,
+        appletVersion: '1.0.0',
       });
     });
 

--- a/src/features/PassSurvey/hooks/useStartSurvey.ts
+++ b/src/features/PassSurvey/hooks/useStartSurvey.ts
@@ -141,7 +141,13 @@ export const useStartSurvey = ({ applet, isPublic, publicAppletKey }: Props) => 
 
         // Update group progress rather than remove to preserve version of event that the flow was
         // started with
-        flowRestarted({ flowId, eventId, targetSubjectId, activityId: firstActivityId });
+        flowRestarted({
+          flowId,
+          eventId,
+          targetSubjectId,
+          activityId: firstActivityId,
+          appletVersion: applet.version,
+        });
       } else {
         // Safety net: useEntitiesSync also clears stale progress, but may not
         // have fired yet when the user clicks "Start".
@@ -173,7 +179,7 @@ export const useStartSurvey = ({ applet, isPublic, publicAppletKey }: Props) => 
 
       // Update group progress rather than remove to preserve version of event that the activity was
       // started with
-      activityRestarted({ activityId, eventId, targetSubjectId });
+      activityRestarted({ activityId, eventId, targetSubjectId, appletVersion: applet.version });
     } else {
       // Safety net: same as the flow branch above.
       const entityProgress = getGroupProgress({

--- a/src/features/PassSurvey/hooks/useStartSurvey.ts
+++ b/src/features/PassSurvey/hooks/useStartSurvey.ts
@@ -33,6 +33,8 @@ type OnActivityCardClickProps = {
   targetSubjectId: string | null;
   flowId: string | null;
   shouldRestart: boolean;
+  /** Fresh activity IDs fetched from the API at restart time, bypassing stale cache */
+  freshFlowActivityIds?: string[];
 };
 
 type Props = {
@@ -96,6 +98,7 @@ export const useStartSurvey = ({ applet, isPublic, publicAppletKey }: Props) => 
     eventId,
     targetSubjectId,
     shouldRestart,
+    freshFlowActivityIds,
   }: OnActivityCardClickProps) {
     if (!applet) return;
 
@@ -140,7 +143,8 @@ export const useStartSurvey = ({ applet, isPublic, publicAppletKey }: Props) => 
       const storedFlowActivityIds = (entityProgress as Record<string, unknown> | null)
         ?.flowActivityIds as string[] | undefined;
 
-      const resolvedActivityIds = flow?.activityIds ?? storedFlowActivityIds ?? [];
+      const resolvedActivityIds =
+        freshFlowActivityIds ?? flow?.activityIds ?? storedFlowActivityIds ?? [];
       const firstActivityId: string | null = resolvedActivityIds[0] ?? null;
 
       if (!firstActivityId) {

--- a/src/features/PassSurvey/hooks/useStartSurvey.ts
+++ b/src/features/PassSurvey/hooks/useStartSurvey.ts
@@ -147,6 +147,8 @@ export const useStartSurvey = ({ applet, isPublic, publicAppletKey }: Props) => 
           targetSubjectId,
           activityId: firstActivityId,
           appletVersion: applet.version,
+          flowActivityIds: flow?.activityIds ?? [],
+          flowName: flow?.name ?? '',
         });
       } else {
         // Safety net: useEntitiesSync also clears stale progress, but may not

--- a/src/features/PassSurvey/hooks/useStartSurvey.ts
+++ b/src/features/PassSurvey/hooks/useStartSurvey.ts
@@ -128,7 +128,20 @@ export const useStartSurvey = ({ applet, isPublic, publicAppletKey }: Props) => 
 
     if (flowId) {
       const flow = flows?.find((x) => x.id === flowId);
-      const firstActivityId: string | null = flow?.activityIds[0] ?? null;
+
+      // Fall back to stored flowActivityIds from groupProgress when the flow
+      // has been deleted from the current applet version but progress still
+      // exists (synced from server).
+      const entityProgress = getGroupProgress({
+        entityId: flowId,
+        eventId,
+        targetSubjectId,
+      });
+      const storedFlowActivityIds = (entityProgress as Record<string, unknown> | null)
+        ?.flowActivityIds as string[] | undefined;
+
+      const resolvedActivityIds = flow?.activityIds ?? storedFlowActivityIds ?? [];
+      const firstActivityId: string | null = resolvedActivityIds[0] ?? null;
 
       if (!firstActivityId) {
         throw new Error(
@@ -147,18 +160,15 @@ export const useStartSurvey = ({ applet, isPublic, publicAppletKey }: Props) => 
           targetSubjectId,
           activityId: firstActivityId,
           appletVersion: applet.version,
-          flowActivityIds: flow?.activityIds ?? [],
-          flowName: flow?.name ?? '',
+          flowActivityIds: resolvedActivityIds,
+          flowName:
+            flow?.name ??
+            ((entityProgress as Record<string, unknown> | null)?.flowName as string) ??
+            '',
         });
       } else {
         // Safety net: useEntitiesSync also clears stale progress, but may not
         // have fired yet when the user clicks "Start".
-        const entityProgress = getGroupProgress({
-          entityId: flowId,
-          eventId,
-          targetSubjectId,
-        });
-
         if (!entityProgress || entityProgress.endAt) {
           removeActivityProgress({ activityId, eventId, targetSubjectId });
         }

--- a/src/features/PassSurvey/hooks/useStartSurvey.ts
+++ b/src/features/PassSurvey/hooks/useStartSurvey.ts
@@ -178,7 +178,12 @@ export const useStartSurvey = ({ applet, isPublic, publicAppletKey }: Props) => 
         }
       }
 
-      const activityIdToNavigate = shouldRestart ? firstActivityId : activityId;
+      // When fresh flow data is available, always use the first activity from
+      // the resolved list so a stale activityId from the cache is never used.
+      // On restart we already use firstActivityId; on initial start we also
+      // prefer firstActivityId when freshFlowActivityIds were provided.
+      const activityIdToNavigate =
+        shouldRestart || freshFlowActivityIds ? firstActivityId : activityId;
 
       return navigateToEntity({
         activityId: activityIdToNavigate,

--- a/src/features/PassSurvey/hooks/useSurveyDataQuery.ts
+++ b/src/features/PassSurvey/hooks/useSurveyDataQuery.ts
@@ -33,10 +33,11 @@ type Props = {
   appletId: string;
   activityId: string;
   targetSubjectId: string | null;
+  activityVersion?: string;
 };
 
 export const useSurveyDataQuery = (props: Props): Return => {
-  const { appletId, activityId, publicAppletKey, targetSubjectId } = props;
+  const { appletId, activityId, publicAppletKey, targetSubjectId, activityVersion } = props;
   const { featureFlag } = useFeatureFlags();
 
   const isAssignmentsEnabled =
@@ -68,7 +69,7 @@ export const useSurveyDataQuery = (props: Props): Return => {
     isLoading: isActivityLoading,
     error: activityError,
   } = useActivityByIdQuery(
-    { isPublic: !!publicAppletKey, activityId },
+    { isPublic: !!publicAppletKey, activityId, version: activityVersion },
     { select: ({ data }) => data.result },
   );
 

--- a/src/features/PassSurvey/lib/mappers.ts
+++ b/src/features/PassSurvey/lib/mappers.ts
@@ -40,10 +40,34 @@ export const mapRawDataToSurveyContext = ({
     throw new Error('[MapRawDataToSurveyContext] Missing required data');
   }
 
-  const event = eventsDTO.events.find((ev) => ev.id === currentEventId);
+  let event = eventsDTO.events.find((ev) => ev.id === currentEventId);
 
   if (!event) {
-    throw new Error('[MapRawDataToSurveyContext] Event not found');
+    if (flowId) {
+      // The flow was deleted from the current applet version but in-progress
+      // data still exists. Create a minimal synthetic event so the survey can
+      // render and the user can complete / submit the remaining activities.
+      // The real timer settings are stored in groupProgress.event by the sync
+      // layer, so this placeholder only needs to satisfy the type contract.
+      event = {
+        id: currentEventId,
+        entityId: flowId,
+        availabilityType: 'AlwaysAvailable',
+        availability: {
+          oneTimeCompletion: false,
+          periodicityType: 'ALWAYS',
+          timeFrom: null,
+          timeTo: null,
+          allowAccessBeforeFromTime: false,
+          startDate: null,
+          endDate: null,
+        },
+        selectedDate: null,
+        timers: { timer: null, idleTimer: null },
+      };
+    } else {
+      throw new Error('[MapRawDataToSurveyContext] Event not found');
+    }
   }
 
   let flow: ActivityFlowDTO | null = null;

--- a/src/features/PassSurvey/model/AnswersConstructService.ts
+++ b/src/features/PassSurvey/model/AnswersConstructService.ts
@@ -3,7 +3,7 @@ import { v4 as uuid } from 'uuid';
 
 import { ItemAnswer, mapAlerts, mapToAnswers } from '../helpers';
 
-import { ActivityPipelineType, GroupProgress } from '~/abstract/lib';
+import { ActivityPipelineType, FlowProgress, GroupProgress } from '~/abstract/lib';
 import { appletModel } from '~/entities/applet';
 import { ProlificUrlParamsPayload } from '~/entities/applet/model';
 import { userModel } from '~/entities/user';
@@ -260,7 +260,9 @@ export default class AnswersConstructService implements ICompletionConstructServ
       throw new Error('[AnswersConstructBuilder] Flow is not defined');
     }
 
-    const activitiesInFlow = this.flow.activityIds.length;
+    // Prefer stored activity IDs from when the flow was started (handles version changes)
+    const storedActivityIds = (this.groupProgress as FlowProgress).flowActivityIds;
+    const activitiesInFlow = storedActivityIds?.length ?? this.flow.activityIds.length;
 
     const pipelineActivityOrder = this.groupProgress.pipelineActivityOrder;
 

--- a/src/features/PassSurvey/model/AnswersConstructService.ts
+++ b/src/features/PassSurvey/model/AnswersConstructService.ts
@@ -39,6 +39,7 @@ type Input = {
   appletId: string;
   appletVersion: string;
   flow: ActivityFlowDTO | null;
+  flowId: string | null; // Resolved flowId — may differ from flow?.id when the flow was deleted
   encryption: EncryptionDTO;
 
   groupProgress: GroupProgress;
@@ -68,6 +69,8 @@ export default class AnswersConstructService implements ICompletionConstructServ
 
   private flow: ActivityFlowDTO | null;
 
+  private flowId: string | null;
+
   private encryption: EncryptionDTO;
 
   private items: ItemRecord[];
@@ -84,6 +87,7 @@ export default class AnswersConstructService implements ICompletionConstructServ
     this.groupProgress = input.groupProgress;
     this.publicAppletKey = input.publicAppletKey;
     this.flow = input.flow;
+    this.flowId = input.flowId ?? input.flow?.id ?? null;
     this.encryption = input.encryption;
     this.appletId = input.appletId;
     this.appletVersion = input.appletVersion;
@@ -125,7 +129,7 @@ export default class AnswersConstructService implements ICompletionConstructServ
     return {
       appletId: this.appletId,
       activityId: this.activityId,
-      flowId: this.flow?.id ?? null,
+      flowId: this.flowId,
       submitId: this.groupProgress.submitId,
       version: this.appletVersion,
       createdAt: new Date().getTime(),
@@ -257,7 +261,15 @@ export default class AnswersConstructService implements ICompletionConstructServ
     }
 
     if (!this.flow) {
-      throw new Error('[AnswersConstructBuilder] Flow is not defined');
+      // Flow was deleted from current applet version. Use stored activity IDs
+      // from groupProgress (synced from server) to determine completion.
+      const storedActivityIds = (this.groupProgress as FlowProgress).flowActivityIds;
+
+      if (!storedActivityIds?.length) {
+        throw new Error('[AnswersConstructBuilder] Flow is not defined and no stored activity IDs');
+      }
+
+      return storedActivityIds.length === this.groupProgress.pipelineActivityOrder + 1;
     }
 
     // Prefer stored activity IDs from when the flow was started (handles version changes)

--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -316,6 +316,8 @@
       "activity_already_completed": "<strong>Done!</strong> This survey was already completed on a different device.",
       "restart": "Restart",
       "resume": "Resume",
+      "flow_deleted_title": "Activity Flow Removed",
+      "flow_deleted_body": "This activity flow has been removed by the admin. You can still resume and complete your existing progress.",
       "in_progress": "In Progress",
       "unscheduled": "Unscheduled",
       "scheduled": "Scheduled",

--- a/src/shared/api/services/activity.service.ts
+++ b/src/shared/api/services/activity.service.ts
@@ -8,8 +8,10 @@ import {
 
 function activityService() {
   return {
-    getById(id: string) {
-      return axiosService.get<SuccessResponseActivityById>(`/activities/${id}`);
+    getById(id: string, params?: { version?: string }) {
+      return axiosService.get<SuccessResponseActivityById>(`/activities/${id}`, {
+        params,
+      });
     },
     saveAnswers(payload: AnswerPayload) {
       return axiosService.post(`/answers`, payload);

--- a/src/shared/api/services/activityProxy.service.ts
+++ b/src/shared/api/services/activityProxy.service.ts
@@ -3,12 +3,15 @@ import { AnswerPayload, GetCompletedEntitiesPayload } from '../types';
 
 type Options = {
   isPublic: boolean;
+  version?: string;
 };
 
 function ActivityApiProxyService() {
   return {
     getActivityById: (id: string, options: Options) =>
-      options.isPublic ? ActivityService.getPublicById(id) : ActivityService.getById(id),
+      options.isPublic
+        ? ActivityService.getPublicById(id)
+        : ActivityService.getById(id, options.version ? { version: options.version } : undefined),
 
     submitAnswer: (payload: AnswerPayload, options: Options) =>
       options.isPublic

--- a/src/shared/api/types/activity.ts
+++ b/src/shared/api/types/activity.ts
@@ -235,6 +235,7 @@ export type CompletedEntityDTO = {
   id: string;
   answerId: string;
   submitId: string;
+  version: string;
   targetSubjectId: string | null;
   scheduledEventId: string;
   startTime: number; // Milliseconds since Unix epoch

--- a/src/shared/api/types/activity.ts
+++ b/src/shared/api/types/activity.ts
@@ -246,6 +246,8 @@ export type CompletedEntityDTO = {
   activityFlowOrder: number | null;
   // Ordered activity IDs for the flow at the submitted version (only for in-progress flows)
   flowActivityIds: string[] | null;
+  // Name of the flow at the submitted version (only for in-progress flows)
+  flowName: string | null;
 };
 
 export type CompletedEntitiesDTO = {

--- a/src/shared/api/types/activity.ts
+++ b/src/shared/api/types/activity.ts
@@ -244,6 +244,8 @@ export type CompletedEntityDTO = {
   localEndTime: string;
   isFlowCompleted: boolean | null;
   activityFlowOrder: number | null;
+  // Ordered activity IDs for the flow at the submitted version (only for in-progress flows)
+  flowActivityIds: string[] | null;
 };
 
 export type CompletedEntitiesDTO = {

--- a/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.test.ts
+++ b/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.test.ts
@@ -51,6 +51,7 @@ const baseCompletedEntity: CompletedEntityDTO = {
   localEndTime: '02:20:00',
   isFlowCompleted: null,
   activityFlowOrder: null,
+  flowActivityIds: null,
 };
 
 // Base flow progress (local)

--- a/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.test.ts
+++ b/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.test.ts
@@ -7,6 +7,7 @@ import { ActivityPipelineType, FlowProgress, GroupProgress } from '~/abstract/li
 import { CompletedEntityDTO } from '~/shared/api';
 import {
   mockActivityId1,
+  mockActivityId2,
   mockActivityId3,
   mockAppletId,
   mockEventsResponse,
@@ -290,6 +291,134 @@ describe('useEntitiesSync', () => {
       renderHook(() => useEntitiesSync(serverCompletedEntities));
 
       expect(mockSaveGroupProgress).not.toHaveBeenCalled();
+    });
+
+    it('should return empty changes when activity list page already synced (pre-empted sync)', () => {
+      // Bug scenario: Activity list page calls useEntitiesSync first and updates Redux.
+      // When the Survey page mounts and calls useEntitiesSync with the same data,
+      // local progress already matches server → syncEntity returns false → changes is empty.
+      // The SurveyWidget redirect useEffect must handle this via hasFreshServerData fallback.
+      const localProgress: GroupProgress = {
+        ...baseFlowProgress,
+        submitId: 'same-submit-id',
+        currentActivityId: mockActivityId2,
+        pipelineActivityOrder: 1,
+        startAt: new Date('2020-01-01T00:00:00').getTime(),
+        endAt: null,
+        context: { summaryData: {} },
+        event: mockFlowEvent,
+      };
+      mockGetGroupProgress.mockReturnValue(localProgress);
+
+      const serverCompletedEntities: EntitiesSyncProps = {
+        completedEntities: {
+          id: mockAppletId,
+          version: '1.0.0',
+          activities: [],
+          activityFlows: [
+            {
+              ...baseCompletedEntity,
+              id: mockFlowId1,
+              submitId: 'same-submit-id',
+              scheduledEventId: mockFlowEvent.id,
+              isFlowCompleted: false,
+              activityFlowOrder: 1,
+            },
+          ],
+        },
+        respondentSubjectId: null,
+        events: [mockFlowEvent],
+        activityFlows: mockFlows,
+        flowResumeEnabled: true,
+      };
+      const { result } = renderHook(() => useEntitiesSync(serverCompletedEntities));
+
+      // Sync skips because local submitId matches server and local order >= server order
+      expect(mockSaveGroupProgress).not.toHaveBeenCalled();
+      // changes is empty — the flow ID is NOT included
+      expect(result.current.changes).toEqual([]);
+    });
+
+    it('should return flow ID in changes when sync actually updates progress', () => {
+      // Normal sync scenario: server is ahead, so syncEntity returns true → flow ID in changes
+      const localProgress: GroupProgress = {
+        ...baseFlowProgress,
+        submitId: 'same-submit-id',
+        currentActivityId: mockActivityId1,
+        pipelineActivityOrder: 0,
+        startAt: new Date('2020-01-01T00:00:00').getTime(),
+        endAt: null,
+        context: { summaryData: {} },
+        event: mockFlowEvent,
+      };
+      mockGetGroupProgress.mockReturnValue(localProgress);
+
+      const serverCompletedEntities: EntitiesSyncProps = {
+        completedEntities: {
+          id: mockAppletId,
+          version: '1.0.0',
+          activities: [],
+          activityFlows: [
+            {
+              ...baseCompletedEntity,
+              id: mockFlowId1,
+              submitId: 'same-submit-id',
+              scheduledEventId: mockFlowEvent.id,
+              isFlowCompleted: false,
+              activityFlowOrder: 2,
+            },
+          ],
+        },
+        respondentSubjectId: null,
+        events: [mockFlowEvent],
+        activityFlows: mockFlows,
+        flowResumeEnabled: true,
+      };
+      const { result } = renderHook(() => useEntitiesSync(serverCompletedEntities));
+
+      // Sync updates because server is ahead (order 2 > local order 0)
+      expect(mockSaveGroupProgress).toHaveBeenCalled();
+      // changes contains the flow ID
+      expect(result.current.changes).toEqual([mockFlowId1]);
+    });
+
+    it('should skip in-progress syncing when shouldRestart is true', () => {
+      const localProgress: GroupProgress = {
+        ...baseFlowProgress,
+        pipelineActivityOrder: 0,
+        startAt: new Date('2020-01-01T00:00:00').getTime(),
+        endAt: null,
+        context: { summaryData: {} },
+        event: mockFlowEvent,
+      };
+      mockGetGroupProgress.mockReturnValue(localProgress);
+
+      const serverCompletedEntities: EntitiesSyncProps = {
+        completedEntities: {
+          id: mockAppletId,
+          version: '1.0.0',
+          activities: [],
+          activityFlows: [
+            {
+              ...baseCompletedEntity,
+              id: mockFlowId1,
+              scheduledEventId: mockFlowEvent.id,
+              isFlowCompleted: false,
+              activityFlowOrder: 2,
+            },
+          ],
+        },
+        respondentSubjectId: null,
+        events: [mockFlowEvent],
+        activityFlows: mockFlows,
+        flowResumeEnabled: true,
+        shouldRestart: true,
+      };
+      const { result } = renderHook(() => useEntitiesSync(serverCompletedEntities));
+
+      // shouldRestart=true skips in-progress flow syncing entirely
+      expect(mockSaveGroupProgress).not.toHaveBeenCalled();
+      expect(result.current.changes).toEqual([]);
     });
   });
 

--- a/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.test.ts
+++ b/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.test.ts
@@ -203,12 +203,14 @@ describe('useEntitiesSync', () => {
       expect(mockSaveGroupProgress).not.toHaveBeenCalled();
     });
 
-    // Restart bug scenario (M2-10471): after a flow is completed and then restarted, the backend
-    // (with the companion fix) returns the new in-progress execution. Without clearing endAt in
-    // flowRestarted, the stale endAt from the prior completion causes this sync to be skipped.
-    it('should accept server in-progress entity even when local has stale endAt from a prior completion', () => {
+    // Restart bug scenario (M2-10471): after a flow is completed and then restarted, the
+    // flowRestarted reducer clears endAt and assigns a new submitId. This test verifies that
+    // if local somehow still has a stale endAt (from before the flowRestarted fix), syncEntity
+    // correctly skips — because the real fix is in flowRestarted (which now clears endAt).
+    it('should skip sync when local has stale endAt from a prior completion (same submitId)', () => {
       // Simulates a device that has just restarted the flow: flowRestarted set a new submitId and
       // pipelineActivityOrder=0 but (before the fix) left endAt from the previous completion.
+      // After the flowRestarted fix, this state can't occur — endAt is always cleared on restart.
       const priorCompletionTime = new Date('2020-02-01T00:00:00').getTime();
       const localProgress: GroupProgress = {
         ...baseFlowProgress,
@@ -246,15 +248,10 @@ describe('useEntitiesSync', () => {
       };
       renderHook(() => useEntitiesSync(serverCompletedEntities));
 
-      // Server is ahead (order 1 > 0) — sync must apply regardless of local endAt
-      expect(mockSaveGroupProgress).toHaveBeenCalledWith(
-        expect.objectContaining({
-          progressPayload: expect.objectContaining({
-            pipelineActivityOrder: 1,
-            endAt: null,
-          }),
-        }),
-      );
+      // Local has endAt (completed) for same submitId — syncEntity skips to avoid overwriting
+      // a completed state with in-progress. This is safe because flowRestarted now clears endAt,
+      // so this stale state won't occur in practice.
+      expect(mockSaveGroupProgress).not.toHaveBeenCalled();
     });
 
     it('should use local progress when local is at the same position as server', () => {

--- a/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.test.ts
+++ b/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.test.ts
@@ -52,6 +52,7 @@ const baseCompletedEntity: CompletedEntityDTO = {
   isFlowCompleted: null,
   activityFlowOrder: null,
   flowActivityIds: null,
+  flowName: null,
 };
 
 // Base flow progress (local)

--- a/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.test.ts
+++ b/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.test.ts
@@ -42,6 +42,7 @@ const baseCompletedEntity: CompletedEntityDTO = {
   id: mockActivityId1,
   answerId: 'answer-id',
   submitId: 'server-submit-id', // test with different submit ID
+  version: '1.0.0',
   targetSubjectId: null,
   scheduledEventId: mockActivityEvent.id,
   startTime: new Date('2020-01-01T00:00:00').getTime(),
@@ -105,6 +106,7 @@ describe('useEntitiesSync', () => {
           progressPayload: expect.objectContaining({
             pipelineActivityOrder: 2,
             currentActivityId: mockActivityId3,
+            appletVersion: '1.0.0',
           }),
         }),
       );

--- a/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.ts
+++ b/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.ts
@@ -57,12 +57,34 @@ export const useEntitiesSync = ({
         targetSubjectId,
       });
 
-      const event = events.find(({ id }) => id === eventId) ?? null;
+      let event: ScheduleEventDto | null = events.find(({ id }) => id === eventId) ?? null;
 
       // Case 1: In-progress flow (started on another device, not yet completed)
       // Create or update resumable progress so user can continue where they left off
       // Skip this case when shouldRestart=true (user wants to start fresh, not resume)
       if (isFlow && entity.isFlowCompleted === false) {
+        // If the flow was deleted from the current applet version, its schedule event
+        // no longer exists. Create a synthetic AlwaysAvailable event so that:
+        // 1. The groupProgress.event is populated (ActivityGroupsBuildManager skips entries without event)
+        // 2. The survey can render when the user resumes
+        if (!event) {
+          event = {
+            id: eventId,
+            entityId,
+            availabilityType: 'AlwaysAvailable',
+            availability: {
+              oneTimeCompletion: false,
+              periodicityType: 'ALWAYS',
+              timeFrom: null,
+              timeTo: null,
+              allowAccessBeforeFromTime: false,
+              startDate: null,
+              endDate: null,
+            },
+            selectedDate: null,
+            timers: { timer: null, idleTimer: null },
+          };
+        }
         // When restarting, skip in-progress syncing - user wants to start fresh
         if (shouldRestart) {
           return false;
@@ -75,14 +97,20 @@ export const useEntitiesSync = ({
         const localFlowProgress = groupProgress as FlowProgress | undefined;
         const flowActivityIds =
           entity.flowActivityIds ?? localFlowProgress?.flowActivityIds ?? flow?.activityIds;
-        const flowName = flow?.name ?? localFlowProgress?.flowName;
+        // Prefer the server-provided flow name (from flow_histories at the submitted version),
+        // then local stored name, then current flow version name
+        const flowName = entity.flowName ?? localFlowProgress?.flowName ?? flow?.name;
 
         if (!flowActivityIds) {
-          console.info(`[useEntitiesSync] Flow not found and no stored metadata: ${entity.id}`);
           return false;
         }
 
         if (groupProgress?.submitId === entity.submitId) {
+          // If local is already completed for this submitId, never overwrite with in-progress
+          // (the server may not have processed the final submission yet)
+          if (groupProgress.endAt) {
+            return false;
+          }
           // If submitIds match, only skip if local is at or ahead
           // ("Keep last activity in each submission" in AnswerService._filter_activity_flows)
           if ((groupProgress as FlowProgress)?.pipelineActivityOrder >= pipelineActivityOrder) {
@@ -108,7 +136,6 @@ export const useEntitiesSync = ({
 
         const nextActivityId = flowActivityIds[pipelineActivityOrder];
         if (!nextActivityId) {
-          console.info(`[useEntitiesSync] No next activity found for flow: ${entity.id}`);
           return false;
         }
 

--- a/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.ts
+++ b/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.ts
@@ -128,6 +128,7 @@ export const useEntitiesSync = ({
             currentActivityId: nextActivityId,
             pipelineActivityOrder,
             submitId: entity.submitId,
+            appletVersion: entity.version,
             startAt: groupProgress?.startAt ?? entity.startTime,
             endAt: null,
             context: groupProgress?.context ?? { summaryData: {} },

--- a/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.ts
+++ b/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.ts
@@ -70,9 +70,11 @@ export const useEntitiesSync = ({
 
         const flow = activityFlows.find((f) => f.id === entity.id);
 
-        // If flow was removed in a newer applet version, fall back to stored metadata
+        // Prefer activity IDs from the server (matches the version the flow was started at),
+        // then fall back to local stored metadata, then current flow version
         const localFlowProgress = groupProgress as FlowProgress | undefined;
-        const flowActivityIds = flow?.activityIds ?? localFlowProgress?.flowActivityIds;
+        const flowActivityIds =
+          entity.flowActivityIds ?? localFlowProgress?.flowActivityIds ?? flow?.activityIds;
         const flowName = flow?.name ?? localFlowProgress?.flowName;
 
         if (!flowActivityIds) {

--- a/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.ts
+++ b/src/widgets/ActivityGroups/model/hooks/useEntitiesSync.ts
@@ -70,8 +70,13 @@ export const useEntitiesSync = ({
 
         const flow = activityFlows.find((f) => f.id === entity.id);
 
-        if (!flow) {
-          console.warn(`[useEntitiesSync] Flow not found for entity ID: ${entity.id}`);
+        // If flow was removed in a newer applet version, fall back to stored metadata
+        const localFlowProgress = groupProgress as FlowProgress | undefined;
+        const flowActivityIds = flow?.activityIds ?? localFlowProgress?.flowActivityIds;
+        const flowName = flow?.name ?? localFlowProgress?.flowName;
+
+        if (!flowActivityIds) {
+          console.info(`[useEntitiesSync] Flow not found and no stored metadata: ${entity.id}`);
           return false;
         }
 
@@ -99,9 +104,9 @@ export const useEntitiesSync = ({
           }
         }
 
-        const nextActivityId = flow.activityIds[pipelineActivityOrder];
+        const nextActivityId = flowActivityIds[pipelineActivityOrder];
         if (!nextActivityId) {
-          console.warn(`[useEntitiesSync] No next activity found for flow: ${entity.id}`);
+          console.info(`[useEntitiesSync] No next activity found for flow: ${entity.id}`);
           return false;
         }
 
@@ -129,6 +134,8 @@ export const useEntitiesSync = ({
             pipelineActivityOrder,
             submitId: entity.submitId,
             appletVersion: entity.version,
+            flowActivityIds,
+            flowName,
             startAt: groupProgress?.startAt ?? entity.startTime,
             endAt: null,
             context: groupProgress?.context ?? { summaryData: {} },

--- a/src/widgets/ActivityGroups/model/services/ActivityGroupsBuildManager.ts
+++ b/src/widgets/ActivityGroups/model/services/ActivityGroupsBuildManager.ts
@@ -2,6 +2,7 @@ import { mapActivitiesFromDto, mapActivityFlowsFromDto } from '../mappers';
 
 import {
   ActivityPipelineType,
+  FlowProgress,
   getDataFromProgressId,
   GroupProgressId,
   GroupProgressState,
@@ -124,7 +125,29 @@ const createActivityGroupsBuildManager = () => {
 
       const event = mapEventFromDto(groupProgressItem.event);
 
-      const entity = idToEntity[entityId];
+      let entity = idToEntity[entityId];
+      let isDeletedFlow = false;
+
+      // If entity not found, check if it's a deleted flow with stored metadata
+      if (!entity && groupProgressItem.type === ActivityPipelineType.Flow) {
+        const flowProgress = groupProgressItem as FlowProgress;
+        if (flowProgress.flowActivityIds && flowProgress.flowName) {
+          entity = {
+            id: entityId,
+            name: flowProgress.flowName,
+            description: '',
+            image: null,
+            isHidden: false,
+            order: 0,
+            autoAssign: false,
+            hideBadge: false,
+            activityIds: flowProgress.flowActivityIds,
+            pipelineType: ActivityPipelineType.Flow,
+          };
+          isDeletedFlow = true;
+        }
+      }
+
       if (!entity || entity.isHidden) continue;
 
       const targetSubject = targetSubjectId
@@ -136,6 +159,7 @@ const createActivityGroupsBuildManager = () => {
         entity,
         event,
         targetSubject,
+        isDeletedFlow,
       });
     }
 

--- a/src/widgets/ActivityGroups/model/services/ActivityGroupsBuildManager.ts
+++ b/src/widgets/ActivityGroups/model/services/ActivityGroupsBuildManager.ts
@@ -131,10 +131,10 @@ const createActivityGroupsBuildManager = () => {
       // If entity not found, check if it's a deleted flow with stored metadata
       if (!entity && groupProgressItem.type === ActivityPipelineType.Flow) {
         const flowProgress = groupProgressItem as FlowProgress;
-        if (flowProgress.flowActivityIds && flowProgress.flowName) {
+        if (flowProgress.flowActivityIds) {
           entity = {
             id: entityId,
-            name: flowProgress.flowName,
+            name: flowProgress.flowName || 'Activity Flow',
             description: '',
             image: null,
             isHidden: false,

--- a/src/widgets/ActivityGroups/ui/ActivityCard/ActivityCardRestartResume.tsx
+++ b/src/widgets/ActivityGroups/ui/ActivityCard/ActivityCardRestartResume.tsx
@@ -114,7 +114,10 @@ export const ActivityCardRestartResume = ({
         onHide={closeModal}
         title={t('additional.restart_activity')}
         footerPrimaryButton={t('additional.restart')}
-        onPrimaryButtonClick={onRestartClick}
+        onPrimaryButtonClick={() => {
+          closeModal();
+          onRestartClick();
+        }}
         footerSecondaryButton={t('additional.cancel')}
         onSecondaryButtonClick={closeModal}
         showCloseIcon

--- a/src/widgets/ActivityGroups/ui/ActivityCard/ActivityCardRestartResume.tsx
+++ b/src/widgets/ActivityGroups/ui/ActivityCard/ActivityCardRestartResume.tsx
@@ -19,6 +19,7 @@ type Props = {
   onStartClick: () => void;
   isDisabled: boolean;
   isAutoCompletionRecordDefined: boolean;
+  isRestartDisabled?: boolean;
 };
 
 export const ActivityCardRestartResume = ({
@@ -29,6 +30,7 @@ export const ActivityCardRestartResume = ({
   activityName,
   isDisabled,
   isAutoCompletionRecordDefined,
+  isRestartDisabled,
 }: Props) => {
   const [isRestartConfirmationModalOpen, setIsRestartConfirmationModalOpen] = useState(false);
 
@@ -74,22 +76,24 @@ export const ActivityCardRestartResume = ({
             onClick={onResumeClick}
             text={t('additional.resume')}
           />
-          <ButtonBase
-            disabled={isDisabled}
-            onClick={openModal}
-            data-testid="assessment-restart-button"
-            sx={{
-              borderRadius: '100px',
-              padding: '10px 10px',
-              transition: 'all 0.2s',
-              minWidth: '120px',
-              mt: '20px',
-            }}
-          >
-            <img src={ActivityRestartIcon} alt={String(t('additional.restart'))} />
+          {!isRestartDisabled && (
+            <ButtonBase
+              disabled={isDisabled}
+              onClick={openModal}
+              data-testid="assessment-restart-button"
+              sx={{
+                borderRadius: '100px',
+                padding: '10px 10px',
+                transition: 'all 0.2s',
+                minWidth: '120px',
+                mt: '20px',
+              }}
+            >
+              <img src={ActivityRestartIcon} alt={String(t('additional.restart'))} />
 
-            <Text sx={{ marginLeft: 1 }}>{t('additional.restart')}</Text>
-          </ButtonBase>
+              <Text sx={{ marginLeft: 1 }}>{t('additional.restart')}</Text>
+            </ButtonBase>
+          )}
         </Box>
       ) : (
         <Box data-testid="assessment-buttons" alignSelf="center" width="120px">

--- a/src/widgets/ActivityGroups/ui/ActivityCard/index.tsx
+++ b/src/widgets/ActivityGroups/ui/ActivityCard/index.tsx
@@ -1,5 +1,6 @@
-import { useContext } from 'react';
+import { useCallback, useContext, useState } from 'react';
 
+import { useQueryClient } from '@tanstack/react-query';
 import { t } from 'i18next';
 
 import { ActivityCardBase } from './ActivityCardBase';
@@ -22,7 +23,11 @@ import { prolificParamsSelector } from '~/entities/applet/model/selectors';
 import { useBanners } from '~/entities/banner/model';
 import { useAutoCompletionRecord } from '~/features/AutoCompletion/model';
 import { useStartSurvey } from '~/features/PassSurvey';
+import appletService from '~/shared/api/services/applet.service';
+import { variables } from '~/shared/constants/theme/variables';
+import { MuiModal } from '~/shared/ui';
 import Box from '~/shared/ui/Box';
+import Text from '~/shared/ui/Text';
 import {
   MixpanelEventType,
   Mixpanel,
@@ -40,6 +45,8 @@ export const ActivityCard = ({ activityListItem }: Props) => {
   const { lessThanSM } = useCustomMediaQuery();
 
   const context = useContext(AppletDetailsContext);
+  const queryClient = useQueryClient();
+  const [isFlowDeletedAlertOpen, setIsFlowDeletedAlertOpen] = useState(false);
 
   const {
     title,
@@ -156,21 +163,62 @@ export const ActivityCard = ({ activityListItem }: Props) => {
     startActivity(false);
   };
 
-  const startActivity = (shouldRestart: boolean) => {
-    if (!isEntitySupported) {
-      return openStoreLink();
+  const startActivity = useCallback(
+    (shouldRestart: boolean) => {
+      if (!isEntitySupported) {
+        return openStoreLink();
+      }
+
+      return startSurvey({
+        activityId: activityListItem.activityId,
+        eventId: activityListItem.eventId,
+        targetSubjectId: activityListItem.targetSubject?.id ?? null,
+        flowId: activityListItem.flowId,
+        shouldRestart,
+      });
+    },
+    [isEntitySupported, startSurvey, activityListItem],
+  );
+
+  const restartActivity = useCallback(async () => {
+    const flowId = activityListItem.flowId;
+
+    // If this is a flow, check whether the admin has deleted it since the UI was last refreshed
+    if (flowId) {
+      try {
+        const appletId = context.applet.id;
+        const response = context.isPublic
+          ? await appletService.getPublicBaseDetailsByKey(context.publicAppletKey)
+          : await appletService.getBaseDetailsById(appletId);
+
+        const freshFlows = response.data.result.activityFlows;
+        const flowStillExists = freshFlows.some((f) => f.id === flowId);
+
+        if (!flowStillExists) {
+          // Flow was deleted — show alert and refresh the cached applet data
+          setIsFlowDeletedAlertOpen(true);
+
+          // Update react-query cache so UI re-renders with fresh data after modal closes
+          queryClient.setQueryData(
+            [
+              'appletBaseDetailsById',
+              context.isPublic
+                ? { isPublic: true, publicAppletKey: context.publicAppletKey }
+                : { isPublic: false, appletId },
+            ],
+            response,
+          );
+
+          // Also invalidate events since the flow's schedule event was deleted too
+          void queryClient.invalidateQueries(['eventsByAppletId']);
+
+          return;
+        }
+      } catch {
+        // If the check fails, proceed with restart as normal
+      }
     }
 
-    return startSurvey({
-      activityId: activityListItem.activityId,
-      eventId: activityListItem.eventId,
-      targetSubjectId: activityListItem.targetSubject?.id ?? null,
-      flowId: activityListItem.flowId,
-      shouldRestart,
-    });
-  };
-
-  const restartActivity = () => {
     startActivity(true);
 
     Mixpanel.track(
@@ -183,7 +231,7 @@ export const ActivityCard = ({ activityListItem }: Props) => {
         },
       ),
     );
-  };
+  }, [activityListItem.flowId, activityListItem.activityId, context, queryClient, startActivity]);
 
   const resumeActivity = () => {
     startActivity(false);
@@ -260,6 +308,29 @@ export const ActivityCard = ({ activityListItem }: Props) => {
           isRestartDisabled={activityListItem.isDeletedFlow}
         />
       </Box>
+
+      <MuiModal
+        testId="flow-deleted-alert-modal"
+        isOpen={isFlowDeletedAlertOpen}
+        onHide={() => setIsFlowDeletedAlertOpen(false)}
+        title={t('additional.flow_deleted_title')}
+        titleProps={{
+          fontWeight: '400',
+          marginY: 2,
+        }}
+        labelComponent={
+          <Text color={variables.palette.onSurface} sx={{ textTransform: 'none' }}>
+            {t('additional.flow_deleted_body')}
+          </Text>
+        }
+        footerPrimaryButton={t('additional.okay')}
+        onPrimaryButtonClick={() => setIsFlowDeletedAlertOpen(false)}
+        footerWrapperSXProps={{
+          marginLeft: 'auto',
+          marginTop: 2,
+        }}
+        maxWidth="sm"
+      />
     </ActivityCardBase>
   );
 };

--- a/src/widgets/ActivityGroups/ui/ActivityCard/index.tsx
+++ b/src/widgets/ActivityGroups/ui/ActivityCard/index.tsx
@@ -180,46 +180,61 @@ export const ActivityCard = ({ activityListItem }: Props) => {
     [isEntitySupported, startSurvey, activityListItem],
   );
 
+  const fetchFreshFlowData = useCallback(
+    async (flowId: string) => {
+      const appletId = context.applet.id;
+      const response = context.isPublic
+        ? await appletService.getPublicBaseDetailsByKey(context.publicAppletKey)
+        : await appletService.getBaseDetailsById(appletId);
+
+      const freshFlows = response.data.result.activityFlows;
+      const freshFlow = freshFlows.find((f) => f.id === flowId);
+
+      if (!freshFlow) {
+        // Flow was deleted — show alert and refresh the cached applet data
+        setIsFlowDeletedAlertOpen(true);
+
+        queryClient.setQueryData(
+          [
+            'appletBaseDetailsById',
+            context.isPublic
+              ? { isPublic: true, publicAppletKey: context.publicAppletKey }
+              : { isPublic: false, appletId },
+          ],
+          response,
+        );
+
+        void queryClient.invalidateQueries(['eventsByAppletId']);
+
+        return { deleted: true as const };
+      }
+
+      return { deleted: false as const, activityIds: freshFlow.activityIds };
+    },
+    [context, queryClient],
+  );
+
   const restartActivity = useCallback(async () => {
     const flowId = activityListItem.flowId;
 
-    // If this is a flow, check whether the admin has deleted it since the UI was last refreshed
-    if (flowId) {
-      try {
-        const appletId = context.applet.id;
-        const response = context.isPublic
-          ? await appletService.getPublicBaseDetailsByKey(context.publicAppletKey)
-          : await appletService.getBaseDetailsById(appletId);
+    const freshResult = flowId
+      ? await fetchFreshFlowData(flowId).catch(() => undefined)
+      : undefined;
 
-        const freshFlows = response.data.result.activityFlows;
-        const flowStillExists = freshFlows.some((f) => f.id === flowId);
+    if (freshResult?.deleted) return;
 
-        if (!flowStillExists) {
-          // Flow was deleted — show alert and refresh the cached applet data
-          setIsFlowDeletedAlertOpen(true);
-
-          // Update react-query cache so UI re-renders with fresh data after modal closes
-          queryClient.setQueryData(
-            [
-              'appletBaseDetailsById',
-              context.isPublic
-                ? { isPublic: true, publicAppletKey: context.publicAppletKey }
-                : { isPublic: false, appletId },
-            ],
-            response,
-          );
-
-          // Also invalidate events since the flow's schedule event was deleted too
-          void queryClient.invalidateQueries(['eventsByAppletId']);
-
-          return;
-        }
-      } catch {
-        // If the check fails, proceed with restart as normal
-      }
+    if (!isEntitySupported) {
+      return openStoreLink();
     }
 
-    startActivity(true);
+    startSurvey({
+      activityId: activityListItem.activityId,
+      eventId: activityListItem.eventId,
+      targetSubjectId: activityListItem.targetSubject?.id ?? null,
+      flowId: activityListItem.flowId,
+      shouldRestart: true,
+      freshFlowActivityIds: freshResult?.activityIds,
+    });
 
     Mixpanel.track(
       addSurveyPropsToEvent(
@@ -231,7 +246,16 @@ export const ActivityCard = ({ activityListItem }: Props) => {
         },
       ),
     );
-  }, [activityListItem.flowId, activityListItem.activityId, context, queryClient, startActivity]);
+  }, [
+    activityListItem.flowId,
+    activityListItem.activityId,
+    activityListItem.eventId,
+    activityListItem.targetSubject?.id,
+    context,
+    isEntitySupported,
+    startSurvey,
+    fetchFreshFlowData,
+  ]);
 
   const resumeActivity = () => {
     startActivity(false);

--- a/src/widgets/ActivityGroups/ui/ActivityCard/index.tsx
+++ b/src/widgets/ActivityGroups/ui/ActivityCard/index.tsx
@@ -257,6 +257,7 @@ export const ActivityCard = ({ activityListItem }: Props) => {
           activityName={title}
           isDisabled={isDisabled}
           isAutoCompletionRecordDefined={!!autoCompletionRecord}
+          isRestartDisabled={activityListItem.isDeletedFlow}
         />
       </Box>
     </ActivityCardBase>

--- a/src/widgets/ActivityGroups/ui/ActivityCard/index.tsx
+++ b/src/widgets/ActivityGroups/ui/ActivityCard/index.tsx
@@ -160,7 +160,25 @@ export const ActivityCard = ({ activityListItem }: Props) => {
       return;
     }
 
-    startActivity(false);
+    if (!isEntitySupported) {
+      return openStoreLink();
+    }
+
+    const flowId = activityListItem.flowId;
+    const freshResult = flowId
+      ? await fetchFreshFlowData(flowId).catch(() => undefined)
+      : undefined;
+
+    if (freshResult?.deleted) return;
+
+    startSurvey({
+      activityId: activityListItem.activityId,
+      eventId: activityListItem.eventId,
+      targetSubjectId: activityListItem.targetSubject?.id ?? null,
+      flowId,
+      shouldRestart: false,
+      freshFlowActivityIds: freshResult?.activityIds,
+    });
   };
 
   const startActivity = useCallback(

--- a/src/widgets/ActivityGroups/ui/ActivityGroup.tsx
+++ b/src/widgets/ActivityGroups/ui/ActivityGroup.tsx
@@ -30,9 +30,10 @@ export const ActivityGroup = ({ group: { name, activities } }: Props) => {
       <Box display="flex" flex={1} flexDirection="column">
         {activities.length ? (
           activities.map((activity) => {
+            const entityId = activity.flowId ?? activity.activityId;
             return (
               <ActivityCard
-                key={`${activity.eventId}_${activity.targetSubject?.id}`}
+                key={`${activity.eventId}_${entityId}_${activity.targetSubject?.id}`}
                 activityListItem={activity}
               />
             );

--- a/src/widgets/Survey/ui/PassingScreen.tsx
+++ b/src/widgets/Survey/ui/PassingScreen.tsx
@@ -115,7 +115,7 @@ const PassingScreen = (props: Props) => {
     eventId: context.eventId,
     targetSubjectId,
     publicAppletKey: context.publicAppletKey,
-    flowId: context.flow?.id ?? null,
+    flowId: context.flow?.id ?? (context.entityId !== context.activityId ? context.entityId : null),
     appletId: context.appletId,
     flow: context.flow,
     shouldRestart: context.shouldRestart,
@@ -139,7 +139,11 @@ const PassingScreen = (props: Props) => {
 
     const nextActivityIndex = (groupProgress as FlowProgress).pipelineActivityOrder + 1;
 
-    const nextActivity = context.flow?.activityIds[nextActivityIndex] ?? null;
+    // For deleted flows, context.flow is null — fall back to stored activity IDs from groupProgress
+    const storedFlowActivityIds = (groupProgress as FlowProgress).flowActivityIds;
+    const flowActivityIds = context.flow?.activityIds ?? storedFlowActivityIds ?? [];
+
+    const nextActivity = flowActivityIds[nextActivityIndex] ?? null;
 
     const isLastActivity = nextActivity === null;
 
@@ -182,7 +186,7 @@ const PassingScreen = (props: Props) => {
       addSuccessBanner({ children: t('toast.answers_submitted'), duration: null });
     }
 
-    if (isFlowGroup && context.flow) {
+    if (isFlowGroup) {
       if (isLastActivity && hasAnySummaryScreenResults) {
         return openSummaryScreen({
           activityId: context.activityId,

--- a/src/widgets/Survey/ui/ScreenManager.tsx
+++ b/src/widgets/Survey/ui/ScreenManager.tsx
@@ -5,7 +5,7 @@ import SummaryScreen from './SummaryScreen';
 import WelcomeScreen from './WelcomeScreen';
 import { useEntityTimer } from '../model/hooks';
 
-import { getProgressId } from '~/abstract/lib';
+import { FlowProgress, getProgressId } from '~/abstract/lib';
 import { appletModel } from '~/entities/applet';
 import { AutoCompletionModel } from '~/features/AutoCompletion';
 import { SurveyContext } from '~/features/PassSurvey';
@@ -28,11 +28,23 @@ export const ScreenManager = ({ openTimesUpModal }: Props) => {
 
   const { saveAutoCompletion } = AutoCompletionModel.useAutoCompletionStateManager();
 
+  // Read stored flow activity IDs from GroupProgress (handles version changes)
+  const groupProgressId = getProgressId(
+    context.entityId,
+    context.eventId,
+    context.targetSubject?.id ?? null,
+  );
+  const storedFlowActivityIds = useAppSelector((state) => {
+    if (!groupProgressId) return null;
+    const gp = appletModel.selectors.selectGroupProgress(state, groupProgressId);
+    return (gp as FlowProgress)?.flowActivityIds ?? null;
+  });
+
   const onTimerFinish = useCallback(() => {
     const activitiesToSubmit: string[] = AutoCompletionModel.extractActivityIdsToSubmitByParams({
       isFlow: !!context.flow,
       interruptedActivityId: context.activityId,
-      flowActivityIds: context.flow?.activityIds ?? null,
+      flowActivityIds: storedFlowActivityIds ?? context.flow?.activityIds ?? null,
       interruptedActivityProgress: activityProgress ?? null,
     });
 
@@ -56,6 +68,7 @@ export const ScreenManager = ({ openTimesUpModal }: Props) => {
     context.targetSubject?.id,
     openTimesUpModal,
     saveAutoCompletion,
+    storedFlowActivityIds,
   ]);
 
   useEntityTimer({

--- a/src/widgets/Survey/ui/WelcomeScreen.tsx
+++ b/src/widgets/Survey/ui/WelcomeScreen.tsx
@@ -85,7 +85,11 @@ const WelcomeScreen = () => {
       startFlow(event, context.flow, targetSubjectId, context.appletVersion);
     }
 
-    if (!context.flow) {
+    // Only start a standalone activity if we're NOT in a flow context.
+    // For deleted flows, context.flow is null but context.entityId still
+    // differs from context.activityId, indicating a flow-type entity.
+    const isFlowContext = context.entityId !== context.activityId;
+    if (!context.flow && !isFlowContext) {
       startActivity(context.activityId, event, targetSubjectId, context.appletVersion);
     }
 
@@ -98,6 +102,7 @@ const WelcomeScreen = () => {
     context.activity,
     context.activityId,
     context.appletVersion,
+    context.entityId,
     context.event,
     context.flow,
     targetSubjectId,

--- a/src/widgets/Survey/ui/WelcomeScreen.tsx
+++ b/src/widgets/Survey/ui/WelcomeScreen.tsx
@@ -28,6 +28,8 @@ const WelcomeScreen = () => {
 
   const { setInitialProgress } = appletModel.hooks.useActivityProgress();
 
+  const { updateAppletVersion } = appletModel.hooks.useGroupProgressStateManager();
+
   const isFlow = !!context.flow;
   const targetSubjectId = context.targetSubject?.id ?? null;
 
@@ -38,6 +40,39 @@ const WelcomeScreen = () => {
   });
 
   const isTimedActivity = !!groupProgress?.event?.timers?.timer;
+
+  // When restarting, the restart reducer (flowRestarted/activityRestarted) may have set a stale
+  // applet version from the dashboard's cached applet data. Now that we have the fresh version
+  // from the API (via SurveyContext), update the group progress to use the correct version.
+  // This runs on mount (before user clicks Start) so the version is correct for answer submission.
+  useEffect(() => {
+    const isGroupStarted = groupProgress && groupProgress.startAt && !groupProgress.endAt;
+
+    if (
+      isGroupStarted &&
+      context.shouldRestart &&
+      groupProgress.appletVersion !== context.appletVersion
+    ) {
+      updateAppletVersion({
+        entityId: context.entityId,
+        eventId: context.eventId,
+        targetSubjectId,
+        appletVersion: context.appletVersion,
+        flowActivityIds: context.flow?.activityIds,
+        flowName: context.flow?.name,
+      });
+    }
+  }, [
+    context.shouldRestart,
+    context.appletVersion,
+    context.entityId,
+    context.eventId,
+    context.flow?.activityIds,
+    context.flow?.name,
+    targetSubjectId,
+    groupProgress,
+    updateAppletVersion,
+  ]);
 
   const startAssessment = useCallback(() => {
     const isGroupDefined = !!groupProgress;

--- a/src/widgets/Survey/ui/WelcomeScreen.tsx
+++ b/src/widgets/Survey/ui/WelcomeScreen.tsx
@@ -47,11 +47,11 @@ const WelcomeScreen = () => {
     const event = groupProgress?.event ?? context.event;
 
     if (context.flow && !isGroupStarted) {
-      startFlow(event, context.flow, targetSubjectId);
+      startFlow(event, context.flow, targetSubjectId, context.appletVersion);
     }
 
     if (!context.flow) {
-      startActivity(context.activityId, event, targetSubjectId);
+      startActivity(context.activityId, event, targetSubjectId, context.appletVersion);
     }
 
     return setInitialProgress({
@@ -62,6 +62,7 @@ const WelcomeScreen = () => {
   }, [
     context.activity,
     context.activityId,
+    context.appletVersion,
     context.event,
     context.flow,
     targetSubjectId,

--- a/src/widgets/Survey/ui/index.tsx
+++ b/src/widgets/Survey/ui/index.tsx
@@ -56,8 +56,12 @@ export const SurveyWidget = (props: Props) => {
   // Read stored version from GroupProgress for version-aware activity fetch.
   // This is needed before useSurveyDataQuery so deleted activities can be
   // fetched from history using the version stored when the flow started.
+  // When shouldRestart is true, ignore the stored version — the user is starting fresh
+  // and should get the current/latest activity version, not the stale one from when the
+  // flow was originally started.
   const entityProgressId = getProgressId(flowId ?? activityId, eventId, targetSubjectId);
   const storedAppletVersion = useAppSelector((state) => {
+    if (shouldRestart) return undefined;
     if (!entityProgressId) return undefined;
     const progress = appletModel.selectors.selectGroupProgress(state, entityProgressId);
     return progress?.appletVersion;

--- a/src/widgets/Survey/ui/index.tsx
+++ b/src/widgets/Survey/ui/index.tsx
@@ -167,8 +167,21 @@ export const SurveyWidget = (props: Props) => {
     : null;
 
   useEffect(() => {
-    // Only consider redirect if progress has changed
-    if (!flowResumeEnabled || !groupProgressChanged) return;
+    // Only consider redirect if flow resume is enabled
+    if (!flowResumeEnabled) return;
+
+    // Gate on data being loaded: don't redirect before we have sync data
+    // (avoids spurious redirects when Redux has stale state from a prior session)
+    if (isLoading || isFetching) return;
+
+    // Redirect if the sync just changed progress, OR if fresh server data has loaded and the
+    // stored currentActivityId already differs from the URL (can happen when the activity list
+    // page synced server state into Redux before this Survey screen even mounted).
+    const hasFreshServerData = completedEntities !== undefined;
+    const shouldCheckRedirect =
+      groupProgressChanged ||
+      (hasFreshServerData && !!flowId && !!currentActivityId && currentActivityId !== activityId);
+    if (!shouldCheckRedirect) return;
 
     // If entity was completed on another device, redirect to activity list
     if (groupProgress?.endAt) {
@@ -192,7 +205,15 @@ export const SurveyWidget = (props: Props) => {
       navigator.navigate(screenToNavigate, { replace: true });
       return;
     }
-  }, [activityId, currentActivityId, groupProgress?.endAt, groupProgressChanged]);
+  }, [
+    activityId,
+    currentActivityId,
+    groupProgress?.endAt,
+    groupProgressChanged,
+    isLoading,
+    isFetching,
+    completedEntities,
+  ]);
 
   const responseError = error?.evaluatedMessage ?? '';
 

--- a/src/widgets/Survey/ui/index.tsx
+++ b/src/widgets/Survey/ui/index.tsx
@@ -53,6 +53,16 @@ export const SurveyWidget = (props: Props) => {
 
   const { removeAllBanners, addSuccessBanner } = useBanners();
 
+  // Read stored version from GroupProgress for version-aware activity fetch.
+  // This is needed before useSurveyDataQuery so deleted activities can be
+  // fetched from history using the version stored when the flow started.
+  const entityProgressId = getProgressId(flowId ?? activityId, eventId, targetSubjectId);
+  const storedAppletVersion = useAppSelector((state) => {
+    if (!entityProgressId) return undefined;
+    const progress = appletModel.selectors.selectGroupProgress(state, entityProgressId);
+    return progress?.appletVersion;
+  });
+
   const autoCompletionState = AutoCompletionModel.useAutoCompletionRecord({
     entityId: props.flowId ?? props.activityId,
     eventId: props.eventId,
@@ -102,7 +112,13 @@ export const SurveyWidget = (props: Props) => {
     isLoading,
     isError,
     error,
-  } = useSurveyDataQuery({ publicAppletKey, appletId, activityId, targetSubjectId });
+  } = useSurveyDataQuery({
+    publicAppletKey,
+    appletId,
+    activityId,
+    targetSubjectId,
+    activityVersion: storedAppletVersion,
+  });
 
   const { featureFlag } = useFeatureFlags();
   const flowResumeFlag = featureFlag(FeatureFlag.EnableFlowResume, []);


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-10515](https://mindlogger.atlassian.net/browse/M2-10515)
🔗 [Jira Ticket M2-10516](https://mindlogger.atlassian.net/browse/M2-10516)

Fixes bugs where activity flow restart/start uses stale cached activity list when admin modifies the flow without user refreshing the browser.

Changes include:

- Fetch fresh flow data from API on flow restart to bypass stale React Query cache
- Fetch fresh flow data on initial flow start to handle reordered activities
- Pass fresh activity IDs directly to `startSurvey` to ensure correct navigation

### 🪤 Peer Testing

1. As admin, create a flow with 3 activities [A, B, C]
2. As user (different browser), **start the flow** and complete A
3. As admin, **remove activity A** from the flow (now [B, C])
4. As user (without refresh), **restart the flow**

   **Expected outcome:** Flow restarts with activity B (no error about missing activity A)

5. As admin, **reorder the flow** to [C, B]
6. As user (without refresh), **restart the flow** again

   **Expected outcome:** Flow restarts with activity C