### PR TITLE
fix: show deleted alert and hide card on resume if activity is removed (M2-10564, M2-10555)

### DIFF
--- a/src/widgets/ActivityGroups/ui/ActivityCard/index.tsx
+++ b/src/widgets/ActivityGroups/ui/ActivityCard/index.tsx
@@ -295,6 +295,11 @@ export const ActivityCard = ({ activityListItem }: Props) => {
       );
 
       void queryClient.invalidateQueries(['eventsByAppletId']);
+      // Invalidate completedEntities so useEntitiesSync refetches from the server.
+      // This allows it to discover in-progress flow data and create a GroupProgress
+      // entry with flowActivityIds, enabling the "deleted flow" recovery path in
+      // ActivityGroupsBuildManager to show the card as in-progress.
+      void queryClient.invalidateQueries(['completedEntities']);
       setPendingFreshResponse(null);
     }
   }, [pendingFreshResponse, context, queryClient]);
@@ -372,7 +377,29 @@ export const ActivityCard = ({ activityListItem }: Props) => {
     queryClient,
   ]);
 
-  const resumeActivity = () => {
+  const resumeActivity = async () => {
+    if (!isEntitySupported) {
+      return openStoreLink();
+    }
+
+    const flowId = activityListItem.flowId;
+
+    if (flowId) {
+      const freshResult = await fetchFreshEntityData(flowId, 'flow').catch((error) => {
+        console.error(error);
+        return undefined;
+      });
+      if (!freshResult || freshResult.deleted) return;
+    } else {
+      const freshResult = await fetchFreshEntityData(activityListItem.activityId, 'activity').catch(
+        (error) => {
+          console.error(error);
+          return undefined;
+        },
+      );
+      if (!freshResult || freshResult.deleted) return;
+    }
+
     startActivity(false);
 
     Mixpanel.track(


### PR DESCRIPTION
### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-10564](https://mindlogger.atlassian.net/browse/M2-10564)
🔗 [Jira Ticket M2-10555](https://mindlogger.atlassian.net/browse/M2-10555)

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

### 📝 Description

Fixes a bug where resuming an activity that has been deleted from the applet (via admin panel) would cause a 503 error and blank page. Now, if the activity or flow is deleted, an alert is shown and the card disappears after dismissing the alert.

- Show deleted alert on resume/restart/start if activity/flow is removed
- Hide card after alert is dismissed (no synthetic event needed)
- No change to synthetic event logic for flows


### 🪤 Peer Testing

- Start an activity, answer some questions, and save & close
- Remove the activity from the applet in the admin panel
- Resume the activity in the web app
    - **Expected:** Alert is shown, and after dismissing, the card disappears

### ✏️ Notes

<!--
Replace this line with anything else you think may be relevant or related PRs

If there are no notes, then delete this section.
-->

No synthetic event is created for deleted activities. Flows retain existing recovery logic.

