### PR TITLE
fix: include start/end time when validating availability window

### DIFF
--- a/src/abstract/lib/GroupBuilder/GroupUtility.test.ts
+++ b/src/abstract/lib/GroupBuilder/GroupUtility.test.ts
@@ -1,0 +1,59 @@
+import { GroupUtility } from './GroupUtility';
+
+import { ScheduleEvent } from '~/entities/event';
+
+const groupUtility = new GroupUtility({
+  allAppletActivities: [],
+  progress: {},
+});
+
+const createEvent = () =>
+  ({
+    availability: {
+      startDate: new Date('2021-01-01'),
+      endDate: new Date('2021-01-02'),
+      timeFrom: { hours: 0, minutes: 0 },
+      timeTo: { hours: 23, minutes: 59 },
+    },
+  }) as ScheduleEvent;
+
+describe('isInsideValidDatesInterval', () => {
+  it('should return true when the event is between the start date-time and end date-time', () => {
+    const event = createEvent();
+
+    vi.spyOn(groupUtility, 'getNow').mockReturnValue(new Date('2021-01-01T00:00:00'));
+    const result = groupUtility.isInsideValidDatesInterval(event);
+    expect(result).toBe(true);
+  });
+
+  it('should return true when the event is on the end date but before the time to', () => {
+    const event = {
+      availability: {
+        startDate: new Date('2021-01-01'),
+        endDate: new Date('2021-01-02'),
+        timeFrom: { hours: 0, minutes: 0 },
+        timeTo: { hours: 23, minutes: 59 },
+      },
+    } as ScheduleEvent;
+
+    vi.spyOn(groupUtility, 'getNow').mockReturnValue(new Date('2021-01-02T12:00:00'));
+    const result = groupUtility.isInsideValidDatesInterval(event);
+    expect(result).toBe(true);
+  });
+
+  it('should return false when the event is before the start date-time', () => {
+    const event = createEvent();
+
+    vi.spyOn(groupUtility, 'getNow').mockReturnValue(new Date('2020-12-31T00:00:00'));
+    const result = groupUtility.isInsideValidDatesInterval(event);
+    expect(result).toBe(false);
+  });
+
+  it('should return false when the event is after the end date-time', () => {
+    const event = createEvent();
+
+    vi.spyOn(groupUtility, 'getNow').mockReturnValue(new Date('2021-01-03T00:00:00'));
+    const result = groupUtility.isInsideValidDatesInterval(event);
+    expect(result).toBe(false);
+  });
+});

--- a/src/abstract/lib/GroupBuilder/GroupUtility.ts
+++ b/src/abstract/lib/GroupBuilder/GroupUtility.ts
@@ -264,9 +264,6 @@ export class GroupUtility {
           )
         : (endDate ?? undefined);
 
-    console.log('from', from);
-    console.log('to', to);
-
     return this.isInInterval(
       {
         from,

--- a/src/abstract/lib/GroupBuilder/GroupUtility.ts
+++ b/src/abstract/lib/GroupBuilder/GroupUtility.ts
@@ -237,8 +237,7 @@ export class GroupUtility {
   }
 
   public isInsideValidDatesInterval(event: ScheduleEvent) {
-    const { startDate, endDate } = event.availability;
-    const { timeFrom, timeTo } = event.availability;
+    const { startDate, endDate, timeFrom, timeTo } = event.availability;
 
     const now = this.getNow();
 

--- a/src/abstract/lib/GroupBuilder/GroupUtility.ts
+++ b/src/abstract/lib/GroupBuilder/GroupUtility.ts
@@ -238,13 +238,39 @@ export class GroupUtility {
 
   public isInsideValidDatesInterval(event: ScheduleEvent) {
     const { startDate, endDate } = event.availability;
+    const { timeFrom, timeTo } = event.availability;
 
     const now = this.getNow();
 
+    // Time must be added to start date and end date if they are defined, otherwise the interval will be invalid.
+    const from =
+      startDate && timeFrom
+        ? new Date(
+            startDate.getFullYear(),
+            startDate.getMonth(),
+            startDate.getDate(),
+            timeFrom.hours,
+            timeFrom.minutes,
+          )
+        : (startDate ?? undefined);
+    const to =
+      endDate && timeTo
+        ? new Date(
+            endDate.getFullYear(),
+            endDate.getMonth(),
+            endDate.getDate(),
+            timeTo.hours,
+            timeTo.minutes,
+          )
+        : (endDate ?? undefined);
+
+    console.log('from', from);
+    console.log('to', to);
+
     return this.isInInterval(
       {
-        from: startDate ?? undefined,
-        to: endDate ?? undefined,
+        from,
+        to,
       },
       now,
       'both',


### PR DESCRIPTION
### 📝 Description
🔗 [Jira Ticket M2-8773](https://mindlogger.atlassian.net/browse/M2-8773)

Fixed a bug where scheduled events were not showing on the end date. For example, if the scheduled event's end date was April 1, 2026 @ 11:59 PM and on April 1, 2026 @ 5 PM the user is viewing available events, the event would not show up.  Now, when viewing the event on the last day:

- The event shows on the dashboard

### 🪤 Peer Testing

- Create a scheduled event in the admin app with an end date of today, and the end time some time in the future
- Open the web app, and select the applet with the event

**Expected Outcome:** The event should be visible

- Go back to the admin app, and set the end time to an earlier time.
- Go back to the web app and refresh.

**Expected outcome**: The event should not be visible

### ✏️ Notes

Validation was comparing only the date component and ignoring the time component.
