### PR TITLE
fix: Update last user event for paragraph text (M2-9704)

### DIFF
--- a/src/entities/applet/model/hooks/useUserEvents.ts
+++ b/src/entities/applet/model/hooks/useUserEvents.ts
@@ -57,7 +57,10 @@ export const useUserEvents = (props: Props) => {
 
       const activityItemScreenId = getActivityItemScreenId(props.activityId, item.id);
 
-      if (item.responseType === 'text' && userEvents.length > 0) {
+      if (
+        (item.responseType === 'text' || item.responseType === 'paragraphText') &&
+        userEvents.length > 0
+      ) {
         const lastUserEvent = userEvents[userEvents.length - 1];
 
         // We're only interested in updated the previous event if it is a text item


### PR DESCRIPTION

### 📝 Description

🔗 [Jira Ticket M2-9704](https://mindlogger.atlassian.net/browse/M2-9704)

We have been correctly updating the last user event for short text, but incorrectly *added* a new user event for each keystroke on paragraph text, resulting in user journey exports with one entry per keystroke. Fixed by  updating `paragraphText` to use the same user event code path as `text`.

**activity_user_journey.json** before:

    value: D
    value: Do
    value: Doe
    value: Does
    value: Does
    value: Does t
    value: Does th
    value: Does thi
    value: Does this
    value: Does this
    value: Does this s
    value: Does this sa
    value: Does this sav
    value: Does this save
    value: Does this save
    value: Does this save a
    value: Does this save an
    value: Does this save an
    value: Does this save an e
    value: Does this save an ev
    value: Does this save an eve
    value: Does this save an even
    value: Does this save an event
    value: Does this save an event
    value: Does this save an event p
    value: Does this save an event pe
    value: Does this save an event per
    value: Does this save an event per
    value: Does this save an event per k
    value: Does this save an event per ke
    value: Does this save an event per key
    value: Does this save an event per keys
    value: Does this save an event per keyst
    value: Does this save an event per keystr
    value: Does this save an event per keystro
    value: Does this save an event per keystrok
    value: Does this save an event per keystroke
    value: Does this save an event per keystroke?

**activity_user_journey.json** after:

    How about now after the one-liner fix?