### PR TITLE
Feat: add support for af, xh, zu languages (M2-10766)

### DIFF
--- a/src/app/system/locale/constants.ts
+++ b/src/app/system/locale/constants.ts
@@ -6,4 +6,7 @@ export enum SupportableLanguage {
   Greek = 'el',
   Spanish = 'es',
   Portuguese = 'pt',
+  Afrikaans = 'af',
+  Xhosa = 'xh',
+  Zulu = 'zu',
 }

--- a/src/app/system/locale/i18n.ts
+++ b/src/app/system/locale/i18n.ts
@@ -2,11 +2,14 @@ import i18n from 'i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import { initReactI18next } from 'react-i18next';
 
+import afResources from '~/i18n/af/translation.json';
 import elResources from '~/i18n/el/translation.json';
 import enResources from '~/i18n/en/translation.json';
 import esResources from '~/i18n/es/translation.json';
 import frResources from '~/i18n/fr/translation.json';
 import ptResources from '~/i18n/pt/translation.json';
+import xhResources from '~/i18n/xh/translation.json';
+import zuResources from '~/i18n/zu/translation.json';
 
 const i18nManager = {
   async initialize() {
@@ -21,8 +24,11 @@ const i18nManager = {
           el: elResources,
           es: esResources,
           pt: ptResources,
+          af: afResources,
+          xh: xhResources,
+          zu: zuResources,
         },
-        supportedLngs: ['en', 'fr', 'el', 'es', 'pt'],
+        supportedLngs: ['en', 'fr', 'el', 'es', 'pt', 'af', 'xh', 'zu'],
         interpolation: {
           escapeValue: false,
         },

--- a/src/features/language/lib/useLanguageList.test.ts
+++ b/src/features/language/lib/useLanguageList.test.ts
@@ -1,0 +1,41 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { useLanguageList } from './useLanguageList';
+
+import { SupportableLanguage } from '~/app/system/locale/constants';
+
+describe('useLanguageList', () => {
+  it('returns one entry per SupportableLanguage value', () => {
+    const { result } = renderHook(() => useLanguageList());
+
+    expect(result.current).toHaveLength(Object.keys(SupportableLanguage).length);
+  });
+
+  it('exposes all supported languages including Afrikaans, isiXhosa and isiZulu', () => {
+    const { result } = renderHook(() => useLanguageList());
+    const eventKeys = result.current.map((item) => item.eventKey);
+
+    expect(eventKeys).toEqual([
+      SupportableLanguage.English,
+      SupportableLanguage.French,
+      SupportableLanguage.Greek,
+      SupportableLanguage.Spanish,
+      SupportableLanguage.Portuguese,
+      SupportableLanguage.Afrikaans,
+      SupportableLanguage.Xhosa,
+      SupportableLanguage.Zulu,
+    ]);
+  });
+
+  it('uses the lowercased enum key as the label translation path', () => {
+    const { result } = renderHook(() => useLanguageList());
+    const pathsByKey = Object.fromEntries(
+      result.current.map((item) => [item.eventKey, item.localizationPath]),
+    );
+
+    expect(pathsByKey[SupportableLanguage.Afrikaans]).toBe('afrikaans');
+    expect(pathsByKey[SupportableLanguage.Xhosa]).toBe('xhosa');
+    expect(pathsByKey[SupportableLanguage.Zulu]).toBe('zulu');
+  });
+});

--- a/src/features/language/lib/useLanguageList.test.ts
+++ b/src/features/language/lib/useLanguageList.test.ts
@@ -34,6 +34,11 @@ describe('useLanguageList', () => {
       result.current.map((item) => [item.eventKey, item.localizationPath]),
     );
 
+    expect(pathsByKey[SupportableLanguage.English]).toBe('english');
+    expect(pathsByKey[SupportableLanguage.French]).toBe('french');
+    expect(pathsByKey[SupportableLanguage.Greek]).toBe('greek');
+    expect(pathsByKey[SupportableLanguage.Spanish]).toBe('spanish');
+    expect(pathsByKey[SupportableLanguage.Portuguese]).toBe('portuguese');
     expect(pathsByKey[SupportableLanguage.Afrikaans]).toBe('afrikaans');
     expect(pathsByKey[SupportableLanguage.Xhosa]).toBe('xhosa');
     expect(pathsByKey[SupportableLanguage.Zulu]).toBe('zulu');

--- a/src/i18n/af/translation.json
+++ b/src/i18n/af/translation.json
@@ -80,7 +80,10 @@
       "french": "Français",
       "greek": "Ελληνικά",
       "spanish": "Español",
-      "portuguese": "Português"
+      "portuguese": "Português",
+      "afrikaans": "Afrikaans",
+      "xhosa": "isiXhosa",
+      "zulu": "isiZulu"
     },
     "validation": {
       "passwordRequirementsMet": "Daar is aan alle vereistes voldoen.",

--- a/src/i18n/af/translation.json
+++ b/src/i18n/af/translation.json
@@ -1,0 +1,440 @@
+{
+  "translation": {
+    "downloadMobile": "Laai die weergawe vir mobiele toestelle af:",
+    "about": "Meer oor",
+    "time_to_complete": "Tyd om te voltooi",
+    "time_to_complete_hm": "Tyd om te voltooi: {{hours}} uur en {{minutes}} minute",
+    "hours": "uur",
+    "please": "Doen dit asseblief:",
+    "login": "Meld aan",
+    "or": "of",
+    "singUp": "Registreer",
+    "mobileOnly": "Slegs mobiel/selfoon",
+    "start": "Begin",
+    "startTimedActivity": "Begin tydbeperkte aktiwiteit",
+    "continue": "Gaan voort",
+    "saveAndExit": "Stoor en verlaat",
+    "optional": "Opsioneel",
+    "pleaseAnswerTheQuestion": "Beantwoord asseblief die vraag.",
+    "pleaseProvideAdditionalText": "Verskaf asseblief bykomende teks",
+    "pleaseListenToAudio": "Luister asseblief na die oudio tot aan die einde.",
+    "onlyNumbersAllowed": "Slegs syfers word toegelaat",
+    "answerTooLarge": "Verskaf asseblief ’n korter antwoord",
+    "questionCount_one": "{{count}} Vraag",
+    "questionCount_other": "{{count}} Vrae",
+    "timedActivityTitle": "is ’n tydbeperkte aktiwiteit.",
+    "youWillHaveToCompleteIt": "Jy sal {{hours}} uur {{minutes}} minute kry om dit te voltooi.",
+    "yourWorkWillBeSubmitted": "Jou werk sal outomaties ingedien word wanneer die tyd verstreke is.",
+    "countOfCompletedQuestions_one": "{{countOfCompletedQuestions}} van {{count}} vraag voltooi",
+    "countOfCompletedQuestions_other": "{{countOfCompletedQuestions}} van {{count}} vrae voltooi",
+    "activityFlowLength_one": "{{count}} Aktiwiteit",
+    "activityFlowLength_other": "{{count}} Aktiwiteite",
+    "countOfCompletedActivities_one": "{{countOfCompletedActivities}} van {{count}} aktiwiteit voltooi",
+    "countOfCompletedActivities_other": "{{countOfCompletedActivities}} van {{count}} aktiwiteite voltooi",
+    "pleaseCompleteOnThe": "Voltooi asseblief op die",
+    "curiousMobileApp": "Curious- mobiele toep",
+    "mustBeCompletedUsingMobileApp": "Gebruik asseblief die Curious- mobiele toep",
+    "completeUsingAppNow": "Kry die toep nou",
+    "common_loading_error": "Iets het fout gegaan terwyl data gelaai is :(",
+    "toast": {
+      "answers_submitted": "<strong>Klaar!</strong> Ons het jou antwoorde ontvang.",
+      "next_activity": "<strong>Klaar!</strong> Kom ons gaan na die volgende aktiwiteit."
+    },
+    "applet_list_component": {
+      "noon": "Middag",
+      "midnight": "Middernag"
+    },
+    "wrondLinkParametrError": "Jy het hierdie URL per abuis bereik. Kontak asseblief die organiseerder van hierdie minitoep vir verdere bystand.",
+    "activity_due_date": {
+      "available_all_day": "Beskikbaar: Heeldag",
+      "scheduled_at": "Geskeduleer om",
+      "available": "Beskikbaar vanaf",
+      "to": "tot",
+      "day": "dag",
+      "days": "dae",
+      "am": "vm.",
+      "the_following_day": "die volgende dag"
+    },
+    "autoCompletion": {
+      "title": "Verwerk tans antwoorde",
+      "description": "Wag asseblief en moenie die toep toemaak nie. Jou antwoorde word tans verwerk.",
+      "processInProgress": "Ons verwerk steeds jou antwoorde. Wag asseblief.",
+      "processCompleted": "Jou antwoorde is verwerk. Jy kan nou die bladsy toemaak.",
+      "processMyAnswers": "Verwerk my antwoorde",
+      "restartActivityWarning": "Jy kan nie die opname herbegin nie, want die tyd is verstreke. Hervat dit asseblief en dien jou antwoorde in."
+    },
+    "data_sharing": {
+      "consent": "Ek stem in om my antwoorde te gee",
+      "media_consent": "Ek stem in om my media-antwoorde",
+      "public": "openbaar te maak",
+      "dialog": {
+        "body": "Om antwoorde openbaar te deel, impliseer dat inligting wat deur individuele gebruikers verskaf word, bv. opname-antwoorde of terugvoer, openlik beskikbaar sal wees vir ander om te besigtig."
+      }
+    },
+    "timesupModal": {
+      "title": "Tyd is verstreke",
+      "description": "Daar is nie meer tyd oor om aan hierdie aktiwiteit te werk nie. Al die werk wat jy gedoen het, sal gestoor en ingedien word. "
+    },
+    "Language": {
+      "english": "English",
+      "french": "Français",
+      "greek": "Ελληνικά",
+      "spanish": "Español",
+      "portuguese": "Português"
+    },
+    "validation": {
+      "passwordRequirementsMet": "Daar is aan alle vereistes voldoen.",
+      "passwordRequired": "Wagwoord word vereis.",
+      "passwordMinLength": "Wagwoord moet ten minste {{chars}} karakters wees.",
+      "passwordsUnmatched": "Wagwoorde is nie dieselfde nie",
+      "passwordBlankSpaces": "Wagwoord mag nie spasies bevat nie.",
+      "passwordCharacterTypes": "Wagwoord moet ten minste {{types}} van die volgende bevat: hoofletter, kleinletter, syfer, simbool.",
+      "passwordMustInclude": "Wagwoord moet ten minste {{minLength}} karakters bevat, geen spasies en ten minste {{types}} van die 4 hier onder:",
+      "passwordMustIncludeMinimum": "Wagwoord moet ten minste {{minLength}} karakters bevat en geen spasies nie.",
+      "passwordReqCharTypesHeading": "Ten minste {{types}} van die onderstaande 4 tipes",
+      "passwordReqLength": "{{chars}} karakters",
+      "passwordReqNoSpaces": "geen oop spasies nie",
+      "passwordReqUppercase": "Hoofletters (A-Z)",
+      "passwordReqLowercase": "Kleinletters (a-z)",
+      "passwordReqNumbers": "Syfers (0-9)",
+      "passwordReqSymbols": "Simbole (!@#$ ...)",
+      "passwordCannotContainEmojis": "Wagwoorde mag nie emoji bevat nie.",
+      "emailRequired": "E-posadres word vereis.",
+      "invalidEmail": "E-pos moet geldig wees.",
+      "firstNameRequired": "Voornaam word vereis.",
+      "lastNameRequired": "Van word vereis.",
+      "passwordShouldNotContainSpaces": "Wagwoord moenie spasies bevat nie.",
+      "mfaCodeRequired": "Verifikasiekode word vereis.",
+      "mfaCodeFormat": "Verifikasiekode moet 6 syfers wees.",
+      "recoveryCodeRequired": "Herstelkode word vereis.",
+      "recoveryCodeFormat": "Herstelkode moet in die XXXXX-XXXXX-formaat wees."
+    },
+    "MFA": {
+      "confirmYourIdentity": "Bevestig jou identiteit",
+      "enterVerificationCode": "Voer asseblief die verifikasiekode in wat in jou waarmerkingstoep (authenticator) vertoon word.",
+      "enterRecoveryCode": "Voer asseblief ’n rekeningherstelkode in.",
+      "verificationCode": "Voer verifikasiekode in",
+      "recoveryCode": "Herstelkode",
+      "cantAccessAuthenticator": "Ek kan nie toegang tot my waarmerkingstoep (authenticator) kry nie",
+      "backToAuthenticator": "Terug",
+      "backToLogin": "Terug na aanmelding",
+      "continue": "Gaan voort",
+      "invalidCode": "Ongeldige verifikasiekode",
+      "invalidRecoveryCode": "Ongeldige herstelkode",
+      "mfaSessionExpired": "Jou sessie het verval. Meld asseblief weer aan.",
+      "tooManyAttempts": "Te veel mislukte pogings. Probeer asseblief weer later.",
+      "attemptsRemaining_one": "{{count}} poging oor",
+      "attemptsRemaining_other": "{{count}} pogings oor",
+      "sessionAttemptsRemaining_one": "{{count}} sessiepoging oor",
+      "sessionAttemptsRemaining_other": "{{count}} sessiepogings oor",
+      "globalAttemptsRemaining_one": "{{count}} poging oor voordat rekening gesluit word",
+      "globalAttemptsRemaining_other": "{{count}} pogings oor voordat rekening gesluit word"
+    },
+    "transferOwnership": {
+      "adminPanel": "Adminpaneel",
+      "notFound": "Die oordrageienaarskap-skakel is óf ongeldig óf nie meer aktief nie.",
+      "accepted": {
+        "title": "Eienaarskap aanvaar",
+        "message1": "Die minitoep is nou in jou eienaarskap en is toeganklik vanaf jou Kontrolepaneel.",
+        "message2": "Om met die minitoep te begin werk, meld aan by die"
+      },
+      "declined": {
+        "title": "Eienaarskap geweier",
+        "message1": "Jy het die minitoep-eienaarskapoordrag geweier.",
+        "message2": "Indien dit ’n fout was, kontak asseblief die minitoep se eienaar en vra hulle om die oordrag weer te inisieer."
+      }
+    },
+    "invitation": {
+      "loadingInvitation": "Laai tans uitnodiging",
+      "invitationRemoved": "Uitnodiging verwyder",
+      "networkError": "Netwerkfout. Keer terug ",
+      "invitationAlreadyRemoved": "Jou uitnodiging is reeds verwyder.",
+      "invitationAlreadyAccepted": "Uitnodiging is reeds aanvaar",
+      "notAssociatedAccount": "Hierdie uitnodiging is nie geassosieer met die rekening waarby jy tans aangemeld is nie. Meld asseblief aan by die rekening wat verband hou met die e-posadres waarmee jy die uitnodiging ontvang het.",
+      "invitationDeclined": "Uitnodiging is geweier",
+      "home": "Tuis",
+      "invitationAccepted": "Uitnodiging aanvaar",
+      "viewInvitation": "om uitnodiging te besigtig",
+      "acceptInvitation": "om hierdie uitnodiging te aanvaar!",
+      "declineInvitation": "om hierdie uitnodiging te weier",
+      "notFound": "Die uitnodigingskakel is óf ongeldig óf nie meer aktief nie.",
+      "buttons": {
+        "acceptInvitation": "Aanvaar uitnodiging",
+        "declineInvitation": "Weier uitnodiging"
+      },
+      "roles": {
+        "editor": "redigeerder",
+        "coordinator": "koördineerder",
+        "reviewer": "beoordelaar",
+        "manager": "bestuurder"
+      },
+      "inviteContent": {
+        "welcome": "Welkom by ",
+        "title": "Jy is uitgenooi om ’n {{role}} te word van ",
+        "toAccept": "Om hierdie uitnodiging te aanvaar, klik hier onder:",
+        "description": "Nadat jy die uitnodiging aanvaar het, sal jy toegang kan kry tot <strong>{{displayName}}</strong> in die gratis Curious-toep op jou mobiele toestel, as jy drie eenvoudige stappe volg (sien die <a target=\"_blank\" href=\"https://mindlogger.org//guides/user-guide.html\">gebruikersgids</a> vir verdere besonderhede):",
+        "step1": "Installeer die Curious-toep op jou mobiele toestel, indien dit nie reeds geïnstalleer is nie.",
+        "step2": "Maak die Curious-toep op jou mobiele toestel oop en meld aan",
+        "step2_1": " (as jy ’n Curious-rekening het) of registreer (as jy nuut is by Curious). Om aan te meld, tik “Nuwe gebruiker” op die aanmeldskerm en voer die e-posadres in waar jy hierdie e-posuitnodiging ontvang het.",
+        "step3": "Tik <strong>{{displayName}}</strong> op die Curious-tuisskerm en jy is gereed om te begin! As <strong>{{displayName}}</strong> nie verskyn nie, herlaai die skerm deur jou vinger vanaf bo na onder te skuif, en ’n draaiwiel behoort te verskyn terwyl dit laai <strong>{{displayName}}</strong>.",
+        "footer": "Die Child Mind Institute is die skepper van Curious, ’n platform om minitoeps te skep, maar dit is nie verantwoordelik vir minitoep-inhoud wat deur buitepartye geskep word nie.",
+        "loading": "Laai tans uitnodigingskakel",
+        "reviewers": "Gebruikers wat jou data vir hierdie minitoep kan sien:",
+        "managers": "Gebruikers wat hierdie minitoep se instellings kan verander, insluitend wie toegang tot jou data het:",
+        "coordinators": "Gebruikers wat hierdie minitoep se instellings kan verander, maar wat nie kan verander wie jou data kan sien nie:",
+        "notFound": "Die uitnodigingskakel is óf ongeldig óf nie meer aktief nie."
+      }
+    },
+    "Login": {
+      "title": "Meld aan",
+      "appType": "Webtoepassing",
+      "button": "Meld aan",
+      "submit": "Dien in",
+      "passwordRequiredError": "Jy moet ’n wagwoord spesifiseer",
+      "password": "Wagwoord",
+      "email": "E-pos",
+      "accountMessage": " Nie ’n rekening nie? ",
+      "forgotPassword": " Wagwoord vergeet?",
+      "create": "Skep ’n rekening",
+      "reset": " Stel dit terug",
+      "errorMessage": "Wagwoord verkeerd, indien daardie gebruiker bestaan.",
+      "or": "Of",
+      "passwordResetSuccessful": "Jou wagwoord is suksesvol teruggestel. Meld asseblief aan met jou nuwe wagwoord.",
+      "invalidCredentials": "Ongeldige e-pos of wagwoord"
+    },
+    "SignUp": {
+      "title": "Skep rekening",
+      "submit": "Dien in",
+      "email": "E-pos",
+      "firstName": "Voornaam",
+      "confirmPassword": "Bevestig wagwoord",
+      "password": "Wagwoord",
+      "lastName": "Van",
+      "signUpError": "Kon nie registreer nie. E-pos is dalk reeds in gebruik.",
+      "accountMessage": " Nie ’n rekening nie? ",
+      "forgotPassword": " Wagwoord vergeet?",
+      "create": " Skep rekening",
+      "reset": " Stel dit terug",
+      "passwordsUnmatched": "Wagwoorde is nie dieselfde nie",
+      "account": "Reeds ’n rekening?",
+      "logIn": "Meld aan",
+      "success": "Registrasie suksesvol voltooi",
+      "or": "Of",
+      "pleaseAgreeTerms": "*Stem asseblief in tot die Diensbepalings.",
+      "iAgreeTo": "Ek stem in tot die",
+      "termsOfService": "Diensbepalings"
+    },
+    "ForgotPassword": {
+      "title": "Stel wagwoord terug",
+      "formTitle": "Voer die e-pos in wat met jou rekening geassosieer word",
+      "submit": "Dien in",
+      "email": "E-pos",
+      "create": " Skep een ",
+      "reset": " Stel dit terug",
+      "button": "Stuur terugstelskakel",
+      "accountMessage": " Nie ’n rekening nie? ",
+      "forgotPassword": " Wagwoord vergeet?",
+      "rememberPassword": "Onthou wagwoord?",
+      "logIn": "Meld aan",
+      "successMessage": "Wagwoordterugstel-skakel is gestuur na {{email}}"
+    },
+    "ChangePassword": {
+      "settings": "{{name}}se instellings",
+      "settingsTitle": "Verander wagwoord",
+      "oldPassword": "Ou wagwoord",
+      "newPassword": "Nuwe wagwoord",
+      "success": "Wagwoord is suksesvol opgedateer",
+      "confirmPassword": "Bevestig wagwoord",
+      "title": "Skep nuwe wagwoord",
+      "formTitle": "Skep die nuwe wagwoord vir {{email}}",
+      "submit": "Dien in",
+      "password": "wagwoord",
+      "failed": "Misluk",
+      "backToLogin": "Terug na aanmelding",
+      "backToSettings": "Terug na instellings",
+      "invalidLink": "Hierdie skakel is ongeldig of het verval. Klik asseblief <a href=\"/forgotpassword\">hier</a> om jou wagwoord terug te stel."
+    },
+    "Landing": {
+      "title": "Welkom by Curious",
+      "login": "Meld aan",
+      "signUp": "Registreer",
+      "or": "of",
+      "getStart": "Kom aan die gang",
+      "reserchStudies": " Neem aanlyn deel aan wetenskaplike navorsingstudies!",
+      "toGet": " Kom aan die gang:"
+    },
+    "Profile": {
+      "title": " Laai Curious af om te begin.",
+      "description": " Dankie dat jy ’n rekening met Curious geskep het. Laai Curious af op ’n iOS- of Android-toestel om te begin."
+    },
+    "Navbar": {
+      "curious": "Curious",
+      "applets": "Minitoeps",
+      "logIn": "Meld aan",
+      "logOut": "Meld af",
+      "profile": "Profiel",
+      "settings": "Instellings"
+    },
+    "SetPassword": {
+      "please": "Doen dit asseblief:",
+      "login": "Meld aan",
+      "toSeeThePage": "om die bladsy te sien",
+      "expiredLink": "“Stuur wagwoord weer”-skakel het verval",
+      "passwordRequired": "Wagwoord word vereis",
+      "passwordShort": "Wagwoord moet ten minste 6 karakters wees",
+      "passwordBlank": "Wagwoord moenie spasies bevat nie",
+      "passwordSame": "Wagwoord mag nie dieselfde as ou wagwoord wees nie"
+    },
+    "Consent": {
+      "aboutStudy": "Meer oor die studie",
+      "doseStudyWork": " Hoe werk die studie?",
+      "howLong": " Hoe lank duur die studie?",
+      "benefitsAndRisks": "Wat is die voordele en risiko’s?",
+      "consentForm": "Toestemmingsvorm",
+      "back": "Terug",
+      "next": "Volgende",
+      "close": "Maak toe",
+      "skip": "Slaan oor",
+      "consent": "Ek stem in",
+      "thanks": "Dankie!",
+      "getStarted": "Jy is amper klaar. Om te begin, doen dit:",
+      "login": "Meld aan",
+      "or": "of",
+      "signUp": "Registreer"
+    },
+    "PhrasalTemplate": {
+      "title": "Hier is jou plan",
+      "download": "Laai af",
+      "filename": "{{appletName}} Aksieplan"
+    },
+    "ActionPlan": {
+      "credit": "Curious-aksieplan",
+      "questionSkipped": "(Vraag oorgeslaan)",
+      "sliderValue": "{{value}} van {{total}}"
+    },
+    "submit": "Dien in",
+    "submitAnswerModalTitle": "Dien antwoord in?",
+    "submitAnswerModalDescription": "As jy gereed is, stuur vir ons jou antwoorde.",
+    "goBack": "Gaan terug",
+    "incorrect_answer": "Antwoord is verkeerd. Probeer asseblief weer",
+    "failed": "Misluk",
+    "additional": {
+      "thanks": "Dankie!",
+      "saved_answers": "Ons het jou antwoorde gestoor!",
+      "close": "Maak toe",
+      "resume_activity": "Hervat aktiwiteit",
+      "restart_activity": "Herbegin aktiwiteit",
+      "cancel": "Kanselleer",
+      "activity_resume_restart": "Is jy seker jy wil alle vordering skoonmaak en herbegin",
+      "activity_already_completed": "<strong>Klaar!</strong> Hierdie opname is reeds op ’n ander toestel voltooi.",
+      "restart": "Herbegin",
+      "resume": "Hervat",
+      "flow_deleted_title": "Aktiwiteitsvloei is verwyder",
+      "flow_deleted_body": "Hierdie aktiwiteitsvloei is deur die admin verwyder. Jy kan steeds voortgaan en jou bestaande vordering voltooi.",
+      "activity_deleted_title": "Aktiwiteit verwyder",
+      "activity_deleted_body": "Hierdie aktiwiteit is deur die admin verwyder.",
+      "in_progress": "Tans aan die gang",
+      "unscheduled": "Ongeskeduleerd",
+      "scheduled": "Geskeduleerd",
+      "past_due": "Agterstallig",
+      "available": "Beskikbaar",
+      "yes": "Yes",
+      "no": "Nee",
+      "okay": "Goed",
+      "response_submit": "Antwoordindiening",
+      "response_submit_text": "Wil jy jou antwoord indien?",
+      "invalid_public_url": "Hierdie assessering aanvaar nie meer respondente nie",
+      "share_report": "Deel verslag",
+      "share_all_reports": "Deel alle verslae",
+      "terms_text": "Ek verstaan dat die inligting wat in hierdie vraelys verskaf word, nie bedoel is om die advies, diagnose of behandeling wat deur ’n mediese of geestesgesondheidskundige aangebied word, te vervang nie, en dat my anonieme antwoorde gebruik en gedeel kan word vir algemene navorsing oor kinders se geestesgesondheid.",
+      "footer_text": "CHILD MIND INSTITUTE, INC. EN CHILD MIND MEDICAL PRACTICE, PLLC (SAAM “CMI”) BEOEFEN NIE DIREK OF INDIREK GENEESKUNDE OF VERSKAF MEDIESE ADVIES AS DEEL VAN HIERDIE VRAELYS NIE. CMI AANVAAR GEEN AANSPREEKLIKHEID VIR ENIGE DIAGNOSE, BEHANDELING, BESLUIT GENEEM OF AKSIE ONDERNEEM WAT VERTROU OP INLIGTING WAT DEUR HIERDIE VRAELYS VERSKAF WORD NIE, EN AANVAAR GEEN VERANTWOORDELIKHEID VIR JOU GEBRUIK VAN HIERDIE VRAELYS NIE.",
+      "child_score": "Jou kind se telling",
+      "child_score_on_subscale": "Jou kind se telling op die {{name}}-subskaal was",
+      "fill_out_fields": "Voltooi asseblief die vereiste velde",
+      "additional_text": "Bykomende teks"
+    },
+    "no_markdown": "Die outeurs van hierdie minitoep het geen inligting verskaf nie!",
+    "no_applets": "Jy het tans geen minitoeps nie.",
+    "unabletoLoadActivity": "Kon nie aktiwiteit laai nie",
+    "reportSummary": "Verslagopsomming",
+    "alerts": "Waarskuwings",
+    "takeNow": {
+      "tooltip": {
+        "providingResponses": "Verskaf antwoorde",
+        "inputtingResponses": "Voer antwoorde in",
+        "subjectOfResponses": "Onderwerp van antwoorde"
+      },
+      "invalidRespondent": "Jy is nie gemagtig om hierdie assessering namens hierdie subjek te voltooi nie.",
+      "mismatchedRespondent": "Die verwagte respondent en die aangemelde webtoep-gebruiker pas nie bymekaar nie. Meld asseblief aan as die korrekte respondent om voort te gaan met “Neem nou”.",
+      "invalidSubject": "Hierdie subjek bestaan nie.",
+      "invalidActivity": "Hierdie aktiwiteit bestaan nie.",
+      "invalidApplet": "Hierdie minitoep bestaan nie.",
+      "successModalTitle": "Aktiwiteit klaar",
+      "successModalLabel": "Jou antwoorde is ingedien. Keer asseblief terug na die Admin-toep om ’n ander aktiwiteit te voltooi of resultate te bekyk.",
+      "successModalPrimaryAction": "Keer terug na Admin-toep",
+      "successModalSecondaryAction": "Weier"
+    },
+    "charactersCount": "{{numCharacters}}/{{maxCharacters}} karakters",
+    "targetSubjectLabel": "Meer oor {{name}}",
+    "targetSubjectBanner": "Maak asseblief seker al jou antwoorde handel oor <strong>{{name}}</strong>",
+    "loading": "Laai tans ...",
+    "footer": {
+      "product": "Curious is ’n produk van die",
+      "support": "Steundiens",
+      "privacy": "Privaatheid",
+      "termsOfService": "Bepalings"
+    },
+    "activity": "Aktiwiteit",
+    "networkError": "Netwerkfout",
+    "timeRemaining": "{{time}} oor",
+    "forItem": "vir hierdie item",
+    "noApplets": "Geen minitoeps nie",
+    "noActivities": "Geen aktiwiteite is vir jou beskikbaar om tans te voltooi nie",
+    "prolific": {
+      "nocode": "’n Fout het voorgekom terwyl jou voltooiingskode van Prolific opgehaal is. Ons vra om verskoning vir hierdie ongerief. Gebruik asseblief “NOCODE” op Prolific as jou voltooiingskode",
+      "alreadyAnswered": "Jy het reeds hierdie aktiwiteit beantwoord. Keer asseblief terug na Prolific en dien jou voltooiingskode in of volg die NOCODE-beleid.",
+      "invalid": "Kan nie die studie valideer nie. Kontak asseblief die studieadministrateur."
+    },
+    "requestHealthRecordData": {
+      "title": "Versoek gesondheidsrekorddata",
+      "linkText": "Vind uit hoe Curious beveiligd toegang tot gesondheidsorgdata verkry.",
+      "partnershipText": "Curious gebruik 1UpHealth se mediese inligtingsdiens om jou navorser in staat te stel om toegang tot inligting in jou gesondheidsorgrekords te verkry.\n\nIn die volgende skerms sal jy gevra word om by jou gesondheidsorgverskafferstelsels aan te meld en jou gesondheidsorgdata met hierdie studie te deel. Jy sal terugkeer na die Curious-aktiwiteit wanneer jy klaar is.",
+      "skipButtonText": "Slaan oor",
+      "additionalPromptText": "Jy het klaar aangemeld by jou gesondheidsorgrekening.\n\nWil jy by enige bykomende gesondheidsorgrekeninge aanmeld?"
+    },
+    "announcementBanner": "<0>Ons kry ’n nuwe voorkoms! </0><1>Ontwerpopdaterings is op pad – dieselfde wonderlike toep, vars nuwe voorkoms. Nuuskierig? </1><2>Klik vir meer inligting.</2>",
+    "oneUpHealth": {
+      "tokenExpired": {
+        "title": "Token het verval",
+        "message": "Hierdie sessie het verval. Verbind tans weer met 1UpHealth ...",
+        "banner": "Jou sessie het verval. Probeer tans om te herlaai ..."
+      },
+      "geographicRestriction": {
+        "title": "Geografiese beperking",
+        "message": "Hierdie inhoud is nie in jou streek beskikbaar nie. Slaan asseblief oor na die volgende stap.",
+        "banner": "Toegang tot 1UpHealth is tans beperk tot gebruikers binne die VSA."
+      },
+      "serviceUnavailable": {
+        "title": "Diens is onbeskikbaar",
+        "message": "Ons kan nie tans met 1UpHealth verbind nie. Slaan asseblief hierdie afdeling oor of probeer later weer.",
+        "banner": "1UpHealth-diens is tans onbeskikbaar. Probeer asseblief weer later."
+      },
+      "communicationError": {
+        "title": "Kommunikasiefout",
+        "message": "Ons kan nie tans met 1UpHealth verbind nie. Slaan asseblief hierdie afdeling oor of probeer later weer.",
+        "banner": "Kon nie met 1UpHealth kommunikeer nie. Probeer asseblief weer later."
+      },
+      "unknownError": {
+        "title": "Onbekende fout",
+        "message": "Ons kan nie tans met 1UpHealth verbind nie. Slaan asseblief hierdie afdeling oor of probeer later weer.",
+        "banner": "’n Onbekende fout het voorgekom. Probeer asseblief weer later."
+      }
+    },
+    "ehrRedirectModal": {
+      "title": "Klaar",
+      "label": "Jy het klaar by hierdie gesondheidsorgverskaffer-rekening aangemeld. Keer asseblief terug na die toep waar jy hierdie proses begin het.",
+      "primaryAction": "Maak toep oop",
+      "secondaryAction": "Gaan voort in blaaier"
+    }
+  }
+}

--- a/src/i18n/el/translation.json
+++ b/src/i18n/el/translation.json
@@ -80,7 +80,10 @@
       "french": "Français",
       "greek": "Ελληνικά",
       "spanish": "Español",
-      "portuguese": "Português"
+      "portuguese": "Português",
+      "afrikaans": "Afrikaans",
+      "xhosa": "isiXhosa",
+      "zulu": "isiZulu"
     },
     "validation": {
       "passwordRequirementsMet": "Όλες οι απαιτήσεις έχουν πληρωθεί.",

--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -80,7 +80,10 @@
       "french": "Français",
       "greek": "Ελληνικά",
       "spanish": "Español",
-      "portuguese": "Português"
+      "portuguese": "Português",
+      "afrikaans": "Afrikaans",
+      "xhosa": "isiXhosa",
+      "zulu": "isiZulu"
     },
     "validation": {
       "passwordRequirementsMet": "All requirements have been met.",

--- a/src/i18n/es/translation.json
+++ b/src/i18n/es/translation.json
@@ -80,7 +80,10 @@
       "french": "Français",
       "greek": "Ελληνικά",
       "spanish": "Español",
-      "portuguese": "Português"
+      "portuguese": "Português",
+      "afrikaans": "Afrikaans",
+      "xhosa": "isiXhosa",
+      "zulu": "isiZulu"
     },
     "validation": {
       "passwordRequirementsMet": "Se han cumplido todos los requisitos.",

--- a/src/i18n/fr/translation.json
+++ b/src/i18n/fr/translation.json
@@ -80,7 +80,10 @@
       "french": "Français",
       "greek": "Ελληνικά",
       "spanish": "Español",
-      "portuguese": "Português"
+      "portuguese": "Português",
+      "afrikaans": "Afrikaans",
+      "xhosa": "isiXhosa",
+      "zulu": "isiZulu"
     },
     "validation": {
       "passwordRequired": "Mot de passe requis.",

--- a/src/i18n/pt/translation.json
+++ b/src/i18n/pt/translation.json
@@ -80,7 +80,10 @@
       "french": "Français",
       "greek": "Ελληνικά",
       "spanish": "Español",
-      "portuguese": "Português"
+      "portuguese": "Português",
+      "afrikaans": "Afrikaans",
+      "xhosa": "isiXhosa",
+      "zulu": "isiZulu"
     },
     "validation": {
       "passwordRequirementsMet": "Todos os requisitos foram cumpridos.",

--- a/src/i18n/xh/translation.json
+++ b/src/i18n/xh/translation.json
@@ -1,0 +1,440 @@
+{
+  "translation": {
+    "downloadMobile": "Khuphela uguqulelo lwezixhobo eziphathwayo:",
+    "about": "Malunga",
+    "time_to_complete": "Ixesha lokugqiba",
+    "time_to_complete_hm": "Ixesha lokugqiba: {{hours}} Iiyure kunye {{minutes}}imizuzu",
+    "hours": "iiyure",
+    "please": "Ndiyacela",
+    "login": "Ngena",
+    "or": "okanye",
+    "singUp": "Bhalisa",
+    "mobileOnly": "Iselula kuphela",
+    "start": "Qala",
+    "startTimedActivity": "Qalisa uMsebenzi oBekelwe ixesha",
+    "continue": "Qhubeka",
+    "saveAndExit": "Gcina & Uphume",
+    "optional": "Ukhetho",
+    "pleaseAnswerTheQuestion": "Nceda uphendule umbuzo.",
+    "pleaseProvideAdditionalText": "Nceda unikeze isicatshulwa esongezelelweyo",
+    "pleaseListenToAudio": "Nceda umamele umsindo kude kube sekupheleni.",
+    "onlyNumbersAllowed": "Ngamanani kuphela avumelekileyo",
+    "answerTooLarge": "Nceda unikeze impendulo emfutshane",
+    "questionCount_one": "{{count}}Umbuzo",
+    "questionCount_other": "{{count}}Imibuzo",
+    "timedActivityTitle": "nguMsebenzi obekiweyo.",
+    "youWillHaveToCompleteIt": "Uya kuba {{hours}} iiyure {{minutes}} imizuzu ukuyigqiba.",
+    "yourWorkWillBeSubmitted": "Umsebenzi wakho uya kuthunyelwa ngokuzenzekelayo xa ixesha liphelile.",
+    "countOfCompletedQuestions_one": "{{countOfCompletedQuestions}}yombuzo {{count}} ogqityiweyo",
+    "countOfCompletedQuestions_other": "{{countOfCompletedQuestions}}ye {{count}} imibuzo igqityiwe",
+    "activityFlowLength_one": "{{count}}Umsebenzi",
+    "activityFlowLength_other": "{{count}}Imisebenzi",
+    "countOfCompletedActivities_one": "{{countOfCompletedActivities}}ye {{count}} umsebenzi ogqityiweyo",
+    "countOfCompletedActivities_other": "{{countOfCompletedActivities}}ye {{count}} imisebenzi egqityiweyo",
+    "pleaseCompleteOnThe": "Nceda ugcwalise kwi",
+    "curiousMobileApp": "I-app yeselula enomdla",
+    "mustBeCompletedUsingMobileApp": "Nceda usebenzise iCurious app mobile",
+    "completeUsingAppNow": "Fumana i-app ngoku",
+    "common_loading_error": "Kukho into engahambi kakuhle ngexesha lokulayishwa kwedatha: (",
+    "toast": {
+      "answers_submitted": "<strong>Ugqibile!</strong> Sizifumene iimpendulo zakho.",
+      "next_activity": "<strong>Ugqibile!</strong> Masiqhubekele kumsebenzi olandelayo."
+    },
+    "applet_list_component": {
+      "noon": "Emini emaqanda",
+      "midnight": "Ezinzulwini zobusuku"
+    },
+    "wrondLinkParametrError": "Ufikelele kule URL ngempazamo. Nceda uqhagamshelane nomququzeleli wale applet ngoncedo olungaphezulu.",
+    "activity_due_date": {
+      "available_all_day": "Ifumaneka Ukusuka",
+      "scheduled_at": "Icwangciswe ngo",
+      "available": "Ifumaneka Ukusuka",
+      "to": "Ukuya",
+      "day": "usuku",
+      "days": "iintsuku",
+      "am": "EKUSENI",
+      "the_following_day": "ngosuku olulandelayo"
+    },
+    "autoCompletion": {
+      "title": "Ukulungiswa kweempendulo",
+      "description": "Nceda ulinde kwaye ungayivali i-app. Iimpendulo zakho ziyasetyenzwa.",
+      "processInProgress": "Sisalungisa iimpendulo zakho. Nceda linda.",
+      "processCompleted": "Iimpendulo zakho ziqwalaselwe. Ungalivala ngoku iphepha.",
+      "processMyAnswers": "Phucula iimpendulo zam",
+      "restartActivityWarning": "Awunakuphinda uqalise uphando kuba ixesha liphelile. Nceda uyiqalise kwakhona kwaye ungenise iimpendulo zakho."
+    },
+    "data_sharing": {
+      "consent": "Ndiyavuma ukwenza iimpendulo zam",
+      "media_consent": "Ndiyavuma ukwenza iimpendulo zam zosasazo",
+      "public": "uluntu",
+      "dialog": {
+        "body": "Ukwabelana ngeempendulo esidlangalaleni kuthetha ukuba ulwazi olunikezelwe ngabasebenzisi ngabanye, njengeempendulo zophando okanye ingxelo, luya kufumaneka ngokuvulelekileyo ukuze abanye bajongwe."
+      }
+    },
+    "timesupModal": {
+      "title": "Ixesha liphelile",
+      "description": "Alisekho ixesha lokusebenza kulo msebenzi. Wonke umsebenzi owenzileyo uya kugcinwa kwaye ungeniswe. "
+    },
+    "Language": {
+      "english": "English",
+      "french": "Français",
+      "greek": "Ελληνικά",
+      "spanish": "Español",
+      "portuguese": "Português"
+    },
+    "validation": {
+      "passwordRequirementsMet": "Zonke iimfuno zifezekisiwe.",
+      "passwordRequired": "Iphasiwedi liyafuneka.",
+      "passwordMinLength": "Iphasiwedi kufuneka ibe {{chars}} nonobumba.",
+      "passwordsUnmatched": "IiPhasiwedi azihambelani",
+      "passwordBlankSpaces": "Iphasiwedi akufuneki iqulathe izithuba.",
+      "passwordCharacterTypes": "Iphasiwedi mayiqulathe ubuncinci {{types}} be: unobumba abakhulu, abancinci, inombolo, isimboli.",
+      "passwordMustInclude": "Iphasiwedi kufuneka iqulathe ubuncinane {{minLength}} amagama, kungabikho zithuba, kwaye noko {{types}} kwezi 4 zingezantsi:",
+      "passwordMustIncludeMinimum": "Iphasiwedi kufuneka iqulathe ubuncinane {{minLength}} amagama kwaye kungabikho zithuba.",
+      "passwordReqCharTypesHeading": "Ubuncinane {{types}} kwezi 4 iindidi zingezantsi",
+      "passwordReqLength": "/{{chars}} abalinganiswa",
+      "passwordReqNoSpaces": "akukho zithuba zingenanto",
+      "passwordReqUppercase": "Oonobumba abakhulu (A-Z)",
+      "passwordReqLowercase": "Oonobumba abancinci (a-z)",
+      "passwordReqNumbers": "Amanani (0-9)",
+      "passwordReqSymbols": "Iimpawu (! @#$...)",
+      "passwordCannotContainEmojis": "Igama lokugqithisa alinakuqulatha i-emojis.",
+      "emailRequired": "Idilesi ye-imeyile iyafuneka.",
+      "invalidEmail": "I-imeyile must be isebenze.",
+      "firstNameRequired": "Igama lokuqala liyafuneka.",
+      "lastNameRequired": "Ifani iyafuneka.",
+      "passwordShouldNotContainSpaces": "Igama lokugqithisa akufuneki liqulathe izithuba.",
+      "mfaCodeRequired": "Ikhowudi yokuqinisekisa iyafuneka.",
+      "mfaCodeFormat": "Ikhowudi yokuqinisekisa must be inamanani ama-6.",
+      "recoveryCodeRequired": "Ikhowudi yokubuyisela iyafuneka.",
+      "recoveryCodeFormat": "Ikhowudi yokubuyisela must be ibekwifomathi XXXXX-XXXXX."
+    },
+    "MFA": {
+      "confirmYourIdentity": "Qinisekisa ukuba ungubani",
+      "enterVerificationCode": "Nceda ngenisa ikhowudi yokuqinisekisa eboniswe kwi-app yakho yesiqinisekiso.",
+      "enterRecoveryCode": "Nceda ngenisa ikhowudi yokubuyisela i-akhawunti.",
+      "verificationCode": "Faka ikhowudi yokugqina",
+      "recoveryCode": "Ikhowudi Yokubuyisela",
+      "cantAccessAuthenticator": "Andikwazi ukufikelela kwi-app yam yesiqinisekisi",
+      "backToAuthenticator": "Emva",
+      "backToLogin": "Buyela ekungeneni",
+      "continue": "Qhubeka",
+      "invalidCode": "Ikhowudi yokuqinisekisa engasebenziyo",
+      "invalidRecoveryCode": "Ikhowudi yokubuyisela engasebenziyo",
+      "mfaSessionExpired": "Iseshoni yakho iphelelwe lixesha. Nceda ungene kwakhona.",
+      "tooManyAttempts": "Mininzi kakhulu imizamo engaphumeleliyo. Nceda uzame kwakhona mva.",
+      "attemptsRemaining_one": ". {{count}} umzamo oseleyo",
+      "attemptsRemaining_other": ". {{count}} imizamo eseleyo",
+      "sessionAttemptsRemaining_one": "{{count}} umzamo weseshoni oseleyo",
+      "sessionAttemptsRemaining_other": "{{count}} Iinzame zeseshoni zishiyekile",
+      "globalAttemptsRemaining_one": "{{count}} umzamo oseleyo phambi kokuvalwa kweakhawunti",
+      "globalAttemptsRemaining_other": "{{count}} Iinzame ezishiyekileyo phambi kokuvalwa kweakhawunti"
+    },
+    "transferOwnership": {
+      "adminPanel": "Iphaneli yoLawulo",
+      "notFound": "Ikhonkco lotshintshiselwano lobunini alikho okanye alisebenzi ixesha elide.",
+      "accepted": {
+        "title": "Ubunini bamkelwe",
+        "message1": "I-Applet ngoku ikubunikazi bakho kwaye iyafikeleleka kwiDashboard yakho.",
+        "message2": "Ukuqala ukusebenza ngeApplet, ngena kwi"
+      },
+      "declined": {
+        "title": "Ubunini Buyaliwe",
+        "message1": "Walile utshintshelo lobunini be-Applet.",
+        "message2": "Ukuba oku bekuyimpazamo, nceda ufikelele kumnini we-Applet kwaye umcele ukuba aqalise ugqithiselo kwakhona."
+      }
+    },
+    "invitation": {
+      "loadingInvitation": "Ilayisha isimemo",
+      "invitationRemoved": "Isimemo Sisusiwe",
+      "networkError": "Impazamo yeNethiwekhi. Buyela ",
+      "invitationAlreadyRemoved": "Isimemo sakho sele sisusiwe.",
+      "invitationAlreadyAccepted": "Isimemo sele samkelwe",
+      "notAssociatedAccount": "Esi simemo asinxulumananga neakhawunti ongene kuyo ngoku. Nceda ungene kwi-akhawunti ehambelana ne-imeyile ofumene isimemo.",
+      "invitationDeclined": "Isimemo saliwe",
+      "home": "Ekhaya",
+      "invitationAccepted": "Isimemo samkelwe",
+      "viewInvitation": "Ukujonga isimemo",
+      "acceptInvitation": "Ukwamkela Esi simemo!",
+      "declineInvitation": "Ukulandula Esi simemo",
+      "notFound": "Ikhonkco lokumema alisebenzi okanye alisasebenzi ixesha elide.",
+      "buttons": {
+        "acceptInvitation": "Yamkela Isimemo",
+        "declineInvitation": "Yala isimemo"
+      },
+      "roles": {
+        "editor": "umhleli",
+        "coordinator": "umnxibelelanisi",
+        "reviewer": "umphengululi",
+        "manager": "umphathi"
+      },
+      "inviteContent": {
+        "welcome": "Wamkelekile kwi ",
+        "title": "Umenyiwe ukuba ube {{role}} ye ",
+        "toAccept": "Ukwamkela esi simemo, cofa ngezantsi:",
+        "description": "Emva kokuba usamkele isimemo, uya kukwazi ukufikelela <strong>{{displayName}}</strong> kwi-app yasimahla yeCurious kwisixhobo sakho esiphathwayo, ukuba ulandela amanyathelo amathathu alula (bona <a target=\"_blank\" href=\"https://mindlogger.org//guides/user-guide.html\">isikhokelo somsebenzisi</a> ngeenkcukacha ezithe vetshe):",
+        "step1": "Faka i-Curious app kwisixhobo sakho esiphathwayo, ukuba ayikafakwa.",
+        "step2": "Vula iCurious app kwisixhobo sakho esiphathwayo, kwaye ungene",
+        "step2_1": " (ukuba une-akhawunti yeCurious) okanye ubhalise (ukuba umtsha kuCurious). Ukubhalisa, cofa \"Umsebenzisi Omtsha\" kwisikrini sokungena, kwaye ufake idilesi ye-imeyile apho ufumene khona esi simemo se-imeyile.",
+        "step3": "Cofa <strong>{{displayName}}</strong> kwi-Curious homescreen kwaye ulungele ukuhamba! Ukuba i<strong>{{displayName}}</strong>ayiveli, hlaziya isikrini ngokutyibiliza umnwe wakho ezantsi ukusuka phezulu, kwaye ivili elijikelezayo kufuneka livele ngelixa ulayisha <strong>{{displayName}}</strong>.",
+        "footer": "I-Child Mind Institute ngumdali weCurious, iqonga lokwenza ii-applet, kodwa alinaxanduva lomxholo we-applet owenziwe ngamaqela angaphandle.",
+        "loading": "Ilayisha ikhonkco lokumema",
+        "reviewers": "Abasebenzisi abangabona idatha yakho yale applet:",
+        "managers": "Abasebenzisi abanokutshintsha iisetingi zale applet, kuquka nabanokufikelela kwidatha yakho:",
+        "coordinators": "Abasebenzisi abanokutshintsha iisetingi zale applet, kodwa abangenakho ukutshintsha abangabona idatha yakho:",
+        "notFound": "Ikhonkco lokumema alisebenzi okanye alisasebenzi ixesha elide."
+      }
+    },
+    "Login": {
+      "title": "Ngena",
+      "appType": "Usetyenziso lweWebhu",
+      "button": "Ngena",
+      "submit": "Ngenisa",
+      "passwordRequiredError": "Kufuneka ucacise igama lokugqithisa",
+      "password": "Inombolo yokuvula",
+      "email": "I-imeyile",
+      "accountMessage": " Awunayo i-akhawunti? ",
+      "forgotPassword": " Ingaba uyilibele iphasiwedi?",
+      "create": "Yenza i-akhawunti",
+      "reset": " Yibuyisele kwakhona",
+      "errorMessage": "Igama lokugqithisa elingalunganga ukuba lo msebenzisi ukhona.",
+      "or": "Okanye",
+      "passwordResetSuccessful": "Igama lokugqithisa lakho limiselwe ngokutsha ngempumelelo. Nceda ungene ngephasiwedi yakho entsha.",
+      "invalidCredentials": "I-imeyile okanye igama eliyimfihlo elingasebenziyo"
+    },
+    "SignUp": {
+      "title": "Yenza i-akhawunti",
+      "submit": "Ngenisa",
+      "email": "I-imeyile",
+      "firstName": "Igama lakho",
+      "confirmPassword": "Ngqina iphasiwedi",
+      "password": "Inombolo yokuvula",
+      "lastName": "Ifani",
+      "signUpError": "Ukubhalisa akuphumelelanga. I-imeyile isenokuba sele isetyenziswa.",
+      "accountMessage": " Awunayo i-akhawunti? ",
+      "forgotPassword": " Ingaba uyilibele iphasiwedi?",
+      "create": " Yenza i-akhawunti",
+      "reset": " Yibuyisele kwakhona",
+      "passwordsUnmatched": "IiPhasiwedi azihambelani",
+      "account": "Ngaba sele unayo i-akhawunti?",
+      "logIn": "Ngena",
+      "success": "Ubhaliso lugqitywe ngempumelelo",
+      "or": "Okanye",
+      "pleaseAgreeTerms": "*Nceda uvumelane neMigqaliselo yeNkonzo.",
+      "iAgreeTo": "Ndiyavumelana ne",
+      "termsOfService": "Imimmisele yenkonzo"
+    },
+    "ForgotPassword": {
+      "title": "Lungisa Igama Lokugqithisa",
+      "formTitle": "Ngenisa i-imeyile ehambelana ne-akhawunti yakho",
+      "submit": "Ngenisa",
+      "email": "I-imeyile",
+      "create": " Yenza enye ",
+      "reset": " Yibuyisele kwakhona",
+      "button": "Thumela ikhonkco lokuseta kwakhona",
+      "accountMessage": " Awunayo i-akhawunti? ",
+      "forgotPassword": " Ingaba uyilibele iphasiwedi?",
+      "rememberPassword": "Khumbula igama lokugqithisa?",
+      "logIn": "Ngena",
+      "successMessage": "Ikhonkco lokuseta kwakhona igama lokugqithisa lithunyelwe ku{{email}}"
+    },
+    "ChangePassword": {
+      "settings": "{{name}}'s Izicwangciso",
+      "settingsTitle": "Tshintsha iphasiwedi",
+      "oldPassword": "Iphasiwdi endala",
+      "newPassword": "Iphasiwedi entsha",
+      "success": "Igama lokugqithisa lihlaziywe ngempumelelo",
+      "confirmPassword": "Ngqina iphasiwedi",
+      "title": "Yenza Iphasiwedi Entsha",
+      "formTitle": "Yenza igama lokugqithisa elitsha le{{email}}",
+      "submit": "Ngenisa",
+      "password": "inombolo yokuvula",
+      "failed": "Ayiphumelelanga",
+      "backToLogin": "Buyela ku-Log in",
+      "backToSettings": "Buyela kwiiSetingi",
+      "invalidLink": "Eli khonkco alisebenzi okanye liphelelwe lixesha. Nceda ucofe <a href=\"/forgotpassword\">apha</a> ukuseta kwakhona igama-mfihlo lakho."
+    },
+    "Landing": {
+      "title": "Wamkelekile kwiCurious",
+      "login": "Ngena",
+      "signUp": "Bhalisa",
+      "or": "okanye",
+      "getStart": "Qalisa",
+      "reserchStudies": " Thatha inxaxheba kwizifundo zophando lwezenzululwazi kwi-intanethi!",
+      "toGet": " Ukuqalisa:"
+    },
+    "Profile": {
+      "title": " Khuphela uCurious ukuze uqalise.",
+      "description": " Enkosi ngokwenza i-akhawunti noCurious. Khuphela Curious kwi iOS okanye isixhobo Android ukuze uqalise."
+    },
+    "Navbar": {
+      "curious": "Unomdla",
+      "applets": "Ii-Applets",
+      "logIn": "Ngena",
+      "logOut": "Phuma",
+      "profile": "Inkangeleko yesimo",
+      "settings": "Iisetingi"
+    },
+    "SetPassword": {
+      "please": "Ndiyacela",
+      "login": "Ngena",
+      "toSeeThePage": "Ukubona Iphepha",
+      "expiredLink": "Password Resent Link iphelelwe lixesha",
+      "passwordRequired": "Igama lokugqithisa liyafuneka",
+      "passwordShort": "Igama lokugqithisa must be libe nonobumba aba-6 ubuncinane",
+      "passwordBlank": "Igama lokugqithisa akufuneki liqulathe izithuba ezingenanto",
+      "passwordSame": "Igama lokugqithisa alinakufana negama lokugqitha elidala"
+    },
+    "Consent": {
+      "aboutStudy": "Malunga neSifundo",
+      "doseStudyWork": " Sisebenza njani isifundo?",
+      "howLong": " Ihlala ixesha elingakanani?",
+      "benefitsAndRisks": "Ziziphi iingenelo neengozi?",
+      "consentForm": "Ifomu yeMvume",
+      "back": "Emva",
+      "next": "Okulandelayo",
+      "close": "Vala",
+      "skip": "Tsiba",
+      "consent": "Ndiyavuma",
+      "thanks": "Enkosi!",
+      "getStarted": "Uphantse walapho. Ukuze uqalise, kuya kufuneka",
+      "login": "Ngena",
+      "or": "okanye",
+      "signUp": "Bhalisa"
+    },
+    "PhrasalTemplate": {
+      "title": "Nali icebo lakho",
+      "download": "Khuphela",
+      "filename": "{{appletName}}Isicwangciso sokwenza"
+    },
+    "ActionPlan": {
+      "credit": "Isicwangciso sokuSebenza esinomdla",
+      "questionSkipped": "(Umbuzo weqiwe)",
+      "sliderValue": "{{value}} ngaphandle kwe{{total}}"
+    },
+    "submit": "Ngenisa",
+    "submitAnswerModalTitle": "Thumela impendulo?",
+    "submitAnswerModalDescription": "Ukuba ulungile, sithumelele iimpendulo zakho.",
+    "goBack": "Buya umva",
+    "incorrect_answer": "Impendulo engalunganga. Nceda zama kwakhona",
+    "failed": "Ayiphumelelanga",
+    "additional": {
+      "thanks": "Enkosi!",
+      "saved_answers": "Sizigcinile iimpendulo zakho!",
+      "close": "Vala",
+      "resume_activity": "Qhubeka nomsebenzi",
+      "restart_activity": "Qala kwakhona umsebenzi",
+      "cancel": "Rhoxisa",
+      "activity_resume_restart": "Uqinisekile ukuba ufuna ukucima yonke inkqubela kwaye uqalise kwakhona",
+      "activity_already_completed": "<strong>Ugqibile!</strong> Olu vavanyo sele lugqityiwe kwisixhobo esahlukileyo.",
+      "restart": "Phinda Uqalele",
+      "resume": "Phinda Uqalele",
+      "flow_deleted_title": "Ukuhamba komsebenzi kususiwe",
+      "flow_deleted_body": "Lo msebenzi wokuhamba ususiwe ngu admin. Usenako ukuqalisa kwakhona kwaye ugqibezele inkqubela yakho ekhoyo.",
+      "activity_deleted_title": "Umsebenzi Ususiwe",
+      "activity_deleted_body": "Lo msebenzi ususiwe admin.",
+      "in_progress": "Iyaqhubeka",
+      "unscheduled": "Ayicwangciswanga",
+      "scheduled": "Icwangcisiwe",
+      "past_due": "Udlule kudala",
+      "available": "Iyafumaneka",
+      "yes": "Ewe",
+      "no": "Hayi",
+      "okay": "KULUNGILE",
+      "response_submit": "Ngenisa impendulo",
+      "response_submit_text": "Ngaba ungathanda ukuthumela impendulo?",
+      "invalid_public_url": "Olu vavanyo alusabamkeli abaphenduli",
+      "share_report": "Yabelana ngeNgxelo",
+      "share_all_reports": "Yabelana Ngazo Zonke Iingxelo",
+      "terms_text": "Ndiyaqonda ukuba ulwazi olunikelwe kolu luhlu ayenzelwanga ukuthatha indawo yengcebiso, uxilongo, okanye unyango olunikwa ngugqirha okanye ingcali yempilo yengqondo, kwaye iimpendulo zam ezingachazwanga zisenokusetyenziswa kwaye kwabelwane ngazo kuphando ngokubanzi ngempilo yengqondo yabantwana.",
+      "footer_text": "KUNYE NOKWENZA UNYANGO LWENGQONDO YOMNTWANA, I-PLLC (KUNYE, “I-CMI”) AYIWENZI NGQO OKANYE NGINGQONDO NGENGQONDO OKANYE IKHIWE INGCEBISO ZEZONYANGO NJENGXALENYE LWEMIBUZO. I-CMI AYIQINISEKI NGAYO NALUPHI UXANDUVA, UNYANGO, ISIGQIBO EESENZELWEYO, OKANYE INYATHELO ELITHATYATHIWEYO NGOKUXHOMEKELA KULWAZI LWEMIBUZO, KWAYE AYIQINISEKI UXANDUVA LOKUSEBENZISA LE MIBUZO.",
+      "child_score": "Inqaku loMntwana wakho",
+      "child_score_on_subscale": "Amanqaku omntwana wakho kwisikali {{name}} besi",
+      "fill_out_fields": "Nceda ugcwalise iindawo ezifunekayo",
+      "additional_text": "Isiqendu esongezelelweyo"
+    },
+    "no_markdown": "Ababhali bale applet abanikanga naluphi na ulwazi!",
+    "no_applets": "Okwangoku awunazo ii applets.",
+    "unabletoLoadActivity": "Ayikwazanga ukulayisha umsebenzi",
+    "reportSummary": "Ingxelo isishwankathelo",
+    "alerts": "Izilumkiso",
+    "takeNow": {
+      "tooltip": {
+        "providingResponses": "Ukubonelela ngeempendulo",
+        "inputtingResponses": "Ukufakwa kweeMpendulo",
+        "subjectOfResponses": "Umxholo weeMpendulo"
+      },
+      "invalidRespondent": "Awugunyaziswanga ukuba ugqibezele olu vavanyo egameni lesi sifundo.",
+      "mismatchedRespondent": "Kukho ukungangqinelani phakathi komphenduli olindelekileyo kunye nomsebenzisi wewebhu ongenileyo. Nceda ungene njengomphenduli ochanekileyo ukuqhubeka noThatha ngoku.",
+      "invalidSubject": "Lo mbandela awukho.",
+      "invalidActivity": "Lo msebenzi awukho.",
+      "invalidApplet": "Le applet ayikho.",
+      "successModalTitle": "Umsebenzi owenziweyo",
+      "successModalLabel": "Iimpendulo zakho zingenisiwe. Nceda ubuyele ku-Admin App ukugqiba omnye umsebenzi okanye ukujonga iziphumo.",
+      "successModalPrimaryAction": "Buyela kwi-Admin App",
+      "successModalSecondaryAction": "Gxotha"
+    },
+    "charactersCount": "{{numCharacters}}/{{maxCharacters}} abalinganiswa",
+    "targetSubjectLabel": "Malunga{{name}}",
+    "targetSubjectBanner": "Nceda uqinisekise ukuba zonke iimpendulo zakho zimalunga<strong>{{name}}</strong>",
+    "loading": "Iyalayisha…",
+    "footer": {
+      "product": "Curious yimveliso ye",
+      "support": "Inkxaso",
+      "privacy": "Ubumfihlo",
+      "termsOfService": "Imigaqo"
+    },
+    "activity": "Umsebenzi",
+    "networkError": "Impazamo yeNethiwekhi",
+    "timeRemaining": "{{time}}eseleyo",
+    "forItem": "yale nto",
+    "noApplets": "Akukho applets",
+    "noActivities": "Akukho misebenzi ikhoyo onokuthi uyigqibe ngoku",
+    "prolific": {
+      "nocode": "Kwenzeke imposiso xa kufunyanwa ikhowudi yakho yokugqiba kwi-Prolific. Siyaxolisa ngale ngxaki. Nceda usebenzise \"NOCODE\" kwiProlific njengekhowudi yakho yokugqibezela",
+      "alreadyAnswered": "Sele uwuphendulile lo msebenzi. Nceda ubuyele kwi-Prolific kwaye ungenise ikhowudi yakho yokugqiba okanye ulandele umgaqo-nkqubo we-NOCODE.",
+      "invalid": "Akunakuqinisekisa uphononongo. Nceda uqhagamshelane nomlawuli wesifundo."
+    },
+    "requestHealthRecordData": {
+      "title": "Cela iData yeRekhodi yezeMpilo",
+      "linkText": "Funda ngakumbi malunga nendlela Curious efikelela ngokukhuselekileyo kwidatha yenkathalo yezempilo.",
+      "partnershipText": "Unomdla usebenzisa i-1upHealth's Medical Information Service ukwenza ukuba umphandi wakho afikelele kulwazi kwiirekhodi zakho zokhathalelo lwempilo.\n\nKwezi zikrini zilandelayo, uya kucelwa ukuba ungene kwiinkqubo zakho zabaBoneleli bezeMpilo kwaye wabelane ngedatha yakho yokhathalelo lwempilo nolu phononongo. Uya kubuyela kumsebenzi weCurious xa ugqibile.",
+      "skipButtonText": "Tsiba",
+      "additionalPromptText": "Ugqibile ukungena kwi-akhawunti yakho yokhathalelo lwempilo.\n\nNgaba ungathanda ukungena kuzo naziphi na ii-akhawunti zokhathalelo lwempilo ezongezelelweyo?"
+    },
+    "announcementBanner": "<0>Uhlaziyo</0><1> loyilo lusendleleni - usetyenziso oluhle olufanayo, inkangeleko entsha. Cofa </1><2>ukufunda ngakumbi.</2>",
+    "oneUpHealth": {
+      "tokenExpired": {
+        "title": "Uphawu Luphelelwe",
+        "message": "Le seshini iphelelwe lixesha. Iqhagamshela kwakhona kwi-1UpHealth...",
+        "banner": "Iseshoni yakho iphelelwe lixesha. Izama ukuhlaziya..."
+      },
+      "geographicRestriction": {
+        "title": "Uthintelo lweJografi",
+        "message": "Lo mxholo awufumaneki kwingingqi yakho. Nceda utsibe uye kwinyathelo elilandelayo.",
+        "banner": "Ukufikelela kwi-1UpHealth okwangoku kuthintelwe kubasebenzisi ngaphakathi eUnited States."
+      },
+      "serviceUnavailable": {
+        "title": "Inkonzo ayifumaneki",
+        "message": "Asikwazi ukuqhagamshela kwi-1UpHealth ngeli xesha. Nceda utsibe eli candelo okanye uzame kwakhona kamva.",
+        "banner": "Inkonzo ye-1UpHealth ayifumaneki okwangoku. Nceda uzame kwakhona mva."
+      },
+      "communicationError": {
+        "title": "Impazamo yoNxibelelwano",
+        "message": "Asikwazi ukuqhagamshela kwi-1UpHealth ngeli xesha. Nceda utsibe eli candelo okanye uzame kwakhona kamva.",
+        "banner": "Impazamo yokunxibelelana ne-1UpHealth. Nceda uzame kwakhona mva."
+      },
+      "unknownError": {
+        "title": "Imposiso engaziwayo",
+        "message": "Asikwazi ukuqhagamshela kwi-1UpHealth ngeli xesha. Nceda utsibe eli candelo okanye uzame kwakhona kamva.",
+        "banner": "Kwenzeke impazamo engaziwayo. Nceda uzame kwakhona mva."
+      }
+    },
+    "ehrRedirectModal": {
+      "title": "Konke kwenzekile",
+      "label": "Ugqibile ukungena kule akhawunti yomboneleli wezempilo. Nceda ubuyele kwi-app apho uqale khona le nkqubo.",
+      "primaryAction": "Vula usetyenziso",
+      "secondaryAction": "Qhubeka kwibhrawuza"
+    }
+  }
+}

--- a/src/i18n/xh/translation.json
+++ b/src/i18n/xh/translation.json
@@ -80,7 +80,10 @@
       "french": "Français",
       "greek": "Ελληνικά",
       "spanish": "Español",
-      "portuguese": "Português"
+      "portuguese": "Português",
+      "afrikaans": "Afrikaans",
+      "xhosa": "isiXhosa",
+      "zulu": "isiZulu"
     },
     "validation": {
       "passwordRequirementsMet": "Zonke iimfuno zifezekisiwe.",

--- a/src/i18n/zu/translation.json
+++ b/src/i18n/zu/translation.json
@@ -1,0 +1,440 @@
+{
+  "translation": {
+    "downloadMobile": "Dawuniloda inguqulo yamadivayisi eselula:",
+    "about": "Mayelana",
+    "time_to_complete": "Isikhathi sokuqeda",
+    "time_to_complete_hm": "Isikhathi sokuqeda: {{hours}} amahora kanye nemizuzu engu-{{minutes}}",
+    "hours": "amahora",
+    "please": "Sicela",
+    "login": "Ngena ngemvume",
+    "or": "noma",
+    "singUp": "Bhalisela",
+    "mobileOnly": "Iselula kuphela",
+    "start": "Qala",
+    "startTimedActivity": "Qala Umsebenzi Obekelwe Isikhathi",
+    "continue": "Qhubeka",
+    "saveAndExit": "Londoloza futhi Uphume",
+    "optional": "Ongakukhetha",
+    "pleaseAnswerTheQuestion": "Ngicela uphendule umbuzo.",
+    "pleaseProvideAdditionalText": "Sicela unikeze umbhalo owengeziwe",
+    "pleaseListenToAudio": "Sicela ulalele umsindo kuze kube sekupheleni.",
+    "onlyNumbersAllowed": "Kuvunyelwe izinombolo kuphela",
+    "answerTooLarge": "Sicela unikeze impendulo emfushane",
+    "questionCount_one": "{{count}} Umbuzo",
+    "questionCount_other": "{{count}} Imibuzo",
+    "timedActivityTitle": "uMsebenzi Obekelwe Isikhathi.",
+    "youWillHaveToCompleteIt": "Uzoba namahora angu-{{hours}} imizuzu engu-{{minutes}} ukuyiqeda.",
+    "yourWorkWillBeSubmitted": "Umsebenzi wakho uzothunyelwa ngokuzenzakalelayo uma isikhathi siphela.",
+    "countOfCompletedQuestions_one": "{{countOfCompletedQuestions}} kombuzo ongu-{{count}} kuqediwe",
+    "countOfCompletedQuestions_other": "{{countOfCompletedQuestions}} kwemibuzo engu-{{count}} kuqediwe",
+    "activityFlowLength_one": "{{count}} Umsebenzi",
+    "activityFlowLength_other": "{{count}} Imisebenzi",
+    "countOfCompletedActivities_one": "{{countOfCompletedActivities}} komsebenzi ongu-{{count}} kuqediwe",
+    "countOfCompletedActivities_other": "{{countOfCompletedActivities}} kwemisebenzi engu-{{count}} kuqediwe",
+    "pleaseCompleteOnThe": "Sicela ugcwalise kokuthi",
+    "curiousMobileApp": "I-app yeselula ye-Curious",
+    "mustBeCompletedUsingMobileApp": "Sicela usebenzise i-app yeselula ye-Curious",
+    "completeUsingAppNow": "Thola i-app manje",
+    "common_loading_error": "Kukhona okungahambanga kahle ngesikhathi kufakwa idatha :(",
+    "toast": {
+      "answers_submitted": "<strong>Kwenziwe!</strong> Sizitholile izimpendulo zakho.",
+      "next_activity": "<strong>Kwenziwe!</strong> Asiqhubekele kumsebenzi olandelayo."
+    },
+    "applet_list_component": {
+      "noon": "Emini",
+      "midnight": "Phakathi kwamabili"
+    },
+    "wrondLinkParametrError": "Ufinyelele le URL ngephutha. Sicela uthinte umhleli wale applet ukuze uthole usizo olwengeziwe.",
+    "activity_due_date": {
+      "available_all_day": "Iyatholakala: Usuku lonke",
+      "scheduled_at": "Ihlelwe Ngo-",
+      "available": "Itholakala Kusuka",
+      "to": "Kuya",
+      "day": "usuku",
+      "days": "izinsuku",
+      "am": "AM",
+      "the_following_day": "ngosuku olulandelayo"
+    },
+    "autoCompletion": {
+      "title": "Icubungula izimpendulo",
+      "description": "Sicela ulinde futhi ungaluvali i-app. Izimpendulo zakho ziyacutshungulwa.",
+      "processInProgress": "Sisacubungula izimpendulo zakho. Ngicela ulinde.",
+      "processCompleted": "Izimpendulo zakho zicutshunguliwe. Manje ungavala ikhasi.",
+      "processMyAnswers": "Cubungula izimpendulo zami",
+      "restartActivityWarning": "Awukwazi ukuqala kabusha inhlolovo ngoba isikhathi siphelile. Sicela uyiqhube futhi uhambise izimpendulo zakho."
+    },
+    "data_sharing": {
+      "consent": "Ngiyavuma ukwenza izimpendulo zami",
+      "media_consent": "Ngiyavuma ukwenza izimpendulo zami zemidiya",
+      "public": "umphakathi",
+      "dialog": {
+        "body": "Ukwabelana ngezimpendulo esidlangalaleni kusho ukuthi ulwazi olunikezwa abasebenzisi ngabanye, njengezimpendulo zenhlolovo noma impendulo, luzotholakala ngokusobala ukuze abanye balubuke."
+      }
+    },
+    "timesupModal": {
+      "title": "Isikhathi Siphelile",
+      "description": "Asisekho isikhathi sokusebenza kulo msebenzi. Wonke umsebenzi owenzile uzogcinwa futhi uhanjiswe. "
+    },
+    "Language": {
+      "english": "IsiNgisi",
+      "french": "Français",
+      "greek": "Ελληνικά",
+      "spanish": "Español",
+      "portuguese": "Português"
+    },
+    "validation": {
+      "passwordRequirementsMet": "Zonke izimfuneko zifinyelelwe.",
+      "passwordRequired": "Iphasiwedi iyadingeka.",
+      "passwordMinLength": "Iphasiwedi kufanele okungenani ibe izinhlamvu ezingu-{{chars}}.",
+      "passwordsUnmatched": "Amaphasiwedi Awafani",
+      "passwordBlankSpaces": "Iphasiwedi akumele iqukathe izikhala.",
+      "passwordCharacterTypes": "Iphasiwedi kumele okungenani iqukathe okuthi {{types}} kokuthi: usonhlamvukazi, uhlamvu oluncane, inombolo, uphawu..",
+      "passwordMustInclude": "Iphasiwedi kumele okungenani iqukathe izinhlamvu ezingu-{{minLength}}, azikho izikhala, futhi okungenani okuthi {{types}} koku-4 kokungezansi:",
+      "passwordMustIncludeMinimum": "Iphasiwedi kumele okungenani iqukathe izinhlamvu ezingu-{{minLength}} futhi kungabikhona izikhala.",
+      "passwordReqCharTypesHeading": "Okungenani okuthi {{types}} kulezi zinhlobo ezi-4 ezingezansi",
+      "passwordReqLength": "{{chars}} izinhlamvu zamagama",
+      "passwordReqNoSpaces": "azikho izikhala ezingenalutho",
+      "passwordReqUppercase": "Izinhlamvu ezinkulu (A-Z)",
+      "passwordReqLowercase": "Izinhlamvu ezincane (a-z)",
+      "passwordReqNumbers": "Izinombolo (0-9)",
+      "passwordReqSymbols": "Izimpawu (!@#$...)",
+      "passwordCannotContainEmojis": "Iphasiwedi ayikwazi ukuqukatha ama-emoji.",
+      "emailRequired": "Ikheli le-imeyili liyadingeka.",
+      "invalidEmail": "I-imeyili kufanele ivumeleke.",
+      "firstNameRequired": "Igama liyadingeka.",
+      "lastNameRequired": "Isibongo siyadingeka.",
+      "passwordShouldNotContainSpaces": "Iphasiwedi akufanele ibe nezikhala.",
+      "mfaCodeRequired": "Ikhodi yokuqinisekisa iyadingeka.",
+      "mfaCodeFormat": "Ikhodi yokuqinisekisa kufanele ibe namadijithi ayi-6.",
+      "recoveryCodeRequired": "Ikhodi yokutakula iyadingeka.",
+      "recoveryCodeFormat": "Ikhodi yokutakula kufanele ibe ngefomethi ethi XXXXX-XXXXX."
+    },
+    "MFA": {
+      "confirmYourIdentity": "Qinisekisa Ubuwena",
+      "enterVerificationCode": "Sicela ufake ikhodi yokuqinisekisa eboniswe ku-app yakho yokufakazela ubuqiniso.",
+      "enterRecoveryCode": "Sicela ufake ikhodi yokutakula i-akhawunti.",
+      "verificationCode": "Faka ikhodi yokuqinisekisa",
+      "recoveryCode": "Ikhodi Yokutakula",
+      "cantAccessAuthenticator": "Angikwazi ukufinyelela i-app yami yokufakazela ubuqiniso",
+      "backToAuthenticator": "Emuva",
+      "backToLogin": "Buyela ekungeneni",
+      "continue": "Qhubeka",
+      "invalidCode": "Ikhodi yokuqinisekisa engavumelekile",
+      "invalidRecoveryCode": "Ikhodi yokutakula engavumelekile",
+      "mfaSessionExpired": "Isikhathi sakho siphelelwe yisikhathi. Sicela ungene futhi.",
+      "tooManyAttempts": "Imizamo eminingi kakhulu ehlulekile. Sicela uzame futhi emuva kwesikhathi.",
+      "attemptsRemaining_one": "{{count}} umzamo osele",
+      "attemptsRemaining_other": "{{count}} imizamo esele",
+      "sessionAttemptsRemaining_one": "{{count}} umzamo wesikhathi osele",
+      "sessionAttemptsRemaining_other": "{{count}} imizamo yeseshini esele",
+      "globalAttemptsRemaining_one": "{{count}} zama okusele ngaphambi kokuvala i-akhawunti",
+      "globalAttemptsRemaining_other": "{{count}} imizamo esele ngaphambi kokuvalwa kwe-akhawunti"
+    },
+    "transferOwnership": {
+      "adminPanel": "Iphaneli yokuphatha",
+      "notFound": "Ilinki yokudlulisa ubunikazi ayivumelekile noma asisasebenzi.",
+      "accepted": {
+        "title": "Ubunikazi Bumukelwe",
+        "message1": "I-Applet manje isikubunikazi bakho futhi iyafinyeleleka kokuthi Ideshibhodi yakho.",
+        "message2": "Ukuze uqale ukusebenza nge-Applet, ngena kokuthi"
+      },
+      "declined": {
+        "title": "Ubunikazi Bunqatshiwe",
+        "message1": "Unqabile ukudluliswa kobunikazi be-Applet.",
+        "message2": "Uma lokhu bekuyiphutha, sicela uthinte umnikazi we-Applet umcele ukuthi aqale ukudlulisa futhi."
+      }
+    },
+    "invitation": {
+      "loadingInvitation": "Ilayisha Isimemo",
+      "invitationRemoved": "Isimemo Sisusiwe",
+      "networkError": "Iphutha Lenethiwekhi. Buyela ",
+      "invitationAlreadyRemoved": "Isimemo sakho sesisusiwe.",
+      "invitationAlreadyAccepted": "Isimemo sesivele samukelwe",
+      "notAssociatedAccount": "Lesi simemo asihlobene ne-akhawunti ongene kuyo manje. Sicela ungene ku-akhawunti ehambisana ne-imeyili othole kuyo isimemo.",
+      "invitationDeclined": "Isimemo sinqatshiwe",
+      "home": "Ikhaya",
+      "invitationAccepted": "Isimemo Samukelwe",
+      "viewInvitation": "ukuze Ubuke Isimemo",
+      "acceptInvitation": "Ukuze Wamukele Lesi simemo!",
+      "declineInvitation": "Ukwenqaba Lesi simemo",
+      "notFound": "Ilinki yesimemo ayivumelekile noma ayisasebenzi.",
+      "buttons": {
+        "acceptInvitation": "Yamukela Isimemo",
+        "declineInvitation": "Yenqaba Isimemo"
+      },
+      "roles": {
+        "editor": "umhleli",
+        "coordinator": "umxhumanisi",
+        "reviewer": "umbuyekezi",
+        "manager": "umphathi"
+      },
+      "inviteContent": {
+        "welcome": "Siyakwamukela kokuthi ",
+        "title": "Umenyiwe ukuthi ube okuthi {{role}} kokuthi ",
+        "toAccept": "Ukuze wamukele lesi simemo, chofoza ngezansi:",
+        "description": "Ngemva kokuthi wamukele isimemo, uzokwazi ukufinyelela <strong>{{displayName}}</strong> ku-app yamahhala ye-Curious kudivayisi yakho yeselula, uma ulandela izinyathelo ezintathu ezilula (bona <a target=\"_blank\" href=\"https://mindlogger.org//guides/user-guide.html\">umhlahlandlela womsebenzisi</a> ukuze uthole imininingwane eyengeziwe):",
+        "step1": "Faka i-app ye-Curious kudivayisi yakho yeselula, uma lungakafakwa.",
+        "step2": "Vula i-app ye-Curious kudivayisi yakho yeselula, bese ungena ngemvume",
+        "step2_1": " (uma une-akhawunti ye-Curious) noma bhalisa (uma umusha ku-Curious). Ukuze ubhalise, thepha okuthi “Umsebenzisi Omusha” esikrinini sokungena ngemvume, bese ufaka ikheli le-imeyili lapho othole khona lesi simemo se-imeyili.",
+        "step3": "Thepha okuthi <strong>{{displayName}}</strong> esikrinini sasekhaya se-Curious futhi usulungele ukuhamba! Uma u-<strong>{{displayName}}</strong> engaveli, qala kabusha isikrini ngokuslayida umunwe wakho uye phansi ukusuka phezulu, futhi isondo elijikelezayo kufanele livele ngenkathi ulayisha. <strong>{{displayName}}</strong>.",
+        "footer": "I-Child Mind Institute ingumsunguli we-Curious, inkundla yokusungula ama-applet, kodwa ayinasibopho ngokuqukethwe kwe-applet okudalwe amaqembu angaphandle.",
+        "loading": "Ilayisha ilinki yesimemo",
+        "reviewers": "Abasebenzisi abangabona idatha yakho yale applet:",
+        "managers": "Abasebenzisi abangakwazi ukushintsha amasethingi ale applet, okuhlanganisa ukuthi ubani ongafinyelela idatha yakho:",
+        "coordinators": "Abasebenzisi abangakwazi ukushintsha amasethingi ale applet, kodwa abangakwazi ukushintsha ukuthi ubani ongabona idatha yakho:",
+        "notFound": "Ilinki yesimemo ayivumelekile noma ayisasebenzi."
+      }
+    },
+    "Login": {
+      "title": "Ngena ngemvume",
+      "appType": "Isicelo Sewebhu",
+      "button": "Ngena ngemvume",
+      "submit": "Thumela",
+      "passwordRequiredError": "Kufanele ucacise iphasiwedi",
+      "password": "Iphasiwedi",
+      "email": "I-imeyili",
+      "accountMessage": " Awunayo i-akhawunti? ",
+      "forgotPassword": " Ukhohlwe iphasiwedi?",
+      "create": "Yenza i-akhawunti",
+      "reset": " Isethe kabusha",
+      "errorMessage": "Iphasiwedi engalungile uma lowo msebenzisi ekhona.",
+      "or": "Noma",
+      "passwordResetSuccessful": "Iphasiwedi yakho isethwe kabusha ngempumelelo. Sicela ungene ngemvume ngephasiwedi yakho entsha.",
+      "invalidCredentials": "I-imeyili noma iphasiwedi engavumelekile"
+    },
+    "SignUp": {
+      "title": "Yenza i-akhawunti",
+      "submit": "Thumela",
+      "email": "I-imeyili",
+      "firstName": "Igama",
+      "confirmPassword": "Qinisekisa Iphasiwedi",
+      "password": "Iphasiwedi",
+      "lastName": "Isibongo",
+      "signUpError": "Ukubhalisa kuhlulekile. I-imeyili kungenzeka isivele iyasetshenziswa.",
+      "accountMessage": " Awunayo i-akhawunti? ",
+      "forgotPassword": " Ukhohlwe iphasiwedi?",
+      "create": " Yenza i-akhawunti",
+      "reset": " Isethe kabusha",
+      "passwordsUnmatched": "Amaphasiwedi Awafani",
+      "account": "Usuvele unayo i-akhawunti?",
+      "logIn": "Ngena ngemvume",
+      "success": "Ukubhalisa kuqedwe ngempumelelo",
+      "or": "Noma",
+      "pleaseAgreeTerms": "*Sicela wamukele Imigomo Yesevisi.",
+      "iAgreeTo": "Ngivumelana ne",
+      "termsOfService": "Imigomo Yesevisi"
+    },
+    "ForgotPassword": {
+      "title": "Setha kabusha Iphasiwedi",
+      "formTitle": "Faka i-imeyili ehlotshaniswa ne-akhawunti yakho",
+      "submit": "Thumela",
+      "email": "I-imeyili",
+      "create": " Sungula Okukodwa ",
+      "reset": " Isethe kabusha",
+      "button": "Thumela ilinki yokusetha kabusha",
+      "accountMessage": " Awunayo i-akhawunti? ",
+      "forgotPassword": " Ukhohlwe iphasiwedi?",
+      "rememberPassword": "Khumbula iphasiwedi?",
+      "logIn": "Ngena ngemvume",
+      "successMessage": "Ilinki yokusetha kabusha iphasiwedi ithunyelwe {{email}}"
+    },
+    "ChangePassword": {
+      "settings": "{{name}}kumaSethingi",
+      "settingsTitle": "Shintsha iphasiwedi",
+      "oldPassword": "Iphasiwedi Endala",
+      "newPassword": "Iphasiwedi Entsha",
+      "success": "Iphasiwedi ibuyekezwe ngempumelelo",
+      "confirmPassword": "Qinisekisa Iphasiwedi",
+      "title": "Sungula Iphasiwedi Entsha",
+      "formTitle": "Sungula iphasiwedi entsha ye {{email}}",
+      "submit": "Thumela",
+      "password": "iphasiwedi",
+      "failed": "Yehlulekile",
+      "backToLogin": "Buyela kokuthi Ngena ngemvume",
+      "backToSettings": "Buyela kumaSethingi",
+      "invalidLink": "Le linki ayivumelekile noma iphelelwe yisikhathi. Sicela uchofoze <a href=\"/forgotpassword\">lapha</a> ukusetha kabusha iphasiwedi yakho."
+    },
+    "Landing": {
+      "title": "Siyakwamukela ku-Curious",
+      "login": "Ngena ngemvume",
+      "signUp": "Bhalisela",
+      "or": "noma",
+      "getStart": "Qalisa",
+      "reserchStudies": " Bamba iqhaza ezifundweni zocwaningo lwesayensi ku-inthanethi!",
+      "toGet": " Ukuze uqalise:"
+    },
+    "Profile": {
+      "title": " Dawuniloda i-Curious ukukhulekela.",
+      "description": " Siyabonga ngokusungula i-akhawunti ne-Curious. Dawuniloda i-Curious kudivayisi ye-iOS noma ye-Android ukuze uqalise."
+    },
+    "Navbar": {
+      "curious": "I-Curious",
+      "applets": "Ama-Applet",
+      "logIn": "Ngena ngemvume",
+      "logOut": "Phuma",
+      "profile": "Iphrofayela",
+      "settings": "Amasethingi"
+    },
+    "SetPassword": {
+      "please": "Sicela",
+      "login": "Ngena ngemvume",
+      "toSeeThePage": "ukuze Ubone Ikhasi",
+      "expiredLink": "Ilinki Yephasiwedi Ethunyelwe Kabusha Iphelelwe Isikhathi",
+      "passwordRequired": "Iphasiwedi iyadingeka",
+      "passwordShort": "Iphasiwedi kumele okungenani ibe nezinhlamvu eziyisi-6",
+      "passwordBlank": "Iphasiwedi akufanele ibe nezikhala ezingenalutho",
+      "passwordSame": "Iphasiwedi ayikwazi ukufana nephasiwedi endala"
+    },
+    "Consent": {
+      "aboutStudy": "Mayelana noCwaningo",
+      "doseStudyWork": " Lusebenza kanjani ucwaningo?",
+      "howLong": " Luqhubeka isikhathi esingakanani?",
+      "benefitsAndRisks": "Yiziphi izinzuzo nezingozi?",
+      "consentForm": "Ifomu Lemvume",
+      "back": "Emuva",
+      "next": "Olandelayo",
+      "close": "Vala",
+      "skip": "Yeqa",
+      "consent": "Ngiyavuma",
+      "thanks": "Siyabonga!",
+      "getStarted": "Usuzofika. Ukuze uqalise, uzodinga",
+      "login": "Ngena ngemvume",
+      "or": "noma",
+      "signUp": "Bhalisela"
+    },
+    "PhrasalTemplate": {
+      "title": "Nalu uhlelo lwakho",
+      "download": "Dawuniloda",
+      "filename": "{{appletName}} Uhlelo Lokuthatha Isinyathelo"
+    },
+    "ActionPlan": {
+      "credit": "Uhlelo Lokuthatha Isinyathelo Lwe-Curious",
+      "questionSkipped": "(Umbuzo weqiwe)",
+      "sliderValue": "{{value}} kokuthi {{total}}"
+    },
+    "submit": "Thumela",
+    "submitAnswerModalTitle": "Thumela impendulo?",
+    "submitAnswerModalDescription": "Uma usulungile, sithumelele izimpendulo zakho.",
+    "goBack": "Buyela emuva",
+    "incorrect_answer": "Impendulo engalungile. Sicela uzame futhi",
+    "failed": "Yehlulekile",
+    "additional": {
+      "thanks": "Siyabonga!",
+      "saved_answers": "Sizigcinile izimpendulo zakho!",
+      "close": "Vala",
+      "resume_activity": "Qalisa kabusha umsebenzi",
+      "restart_activity": "Qala kabusha umsebenzi",
+      "cancel": "Khansela",
+      "activity_resume_restart": "Uqinisekile ukuthi ufuna ukusula konke ukuqhubeka bese uqala kabusha",
+      "activity_already_completed": "<strong>Kwenziwe!</strong> Le nhlolovo bese iqediwe kakade kudivayisi ehlukile.",
+      "restart": "Qala kabusha",
+      "resume": "Qalisa kabusha",
+      "flow_deleted_title": "Ukugeleza komsebenzi Kususiwe",
+      "flow_deleted_body": "Lokhu kugeleza komsebenzi kususwe umlawuli. Usengaqhuba futhi uqedele ukuqhubeka kwakho okukhona.",
+      "activity_deleted_title": "Umsebenzi Ususiwe",
+      "activity_deleted_body": "Lo msebenzi ususwe umlawuli.",
+      "in_progress": "Kuyaqhubeka",
+      "unscheduled": "Akuhleliwe",
+      "scheduled": "Okuhleliwe",
+      "past_due": "Isikhathi Esidlule",
+      "available": "Iyatholakala",
+      "yes": "Yebo",
+      "no": "Cha",
+      "okay": "KULUNGILE",
+      "response_submit": "Phendula Thumela",
+      "response_submit_text": "Ungathanda ukuthumela impendulo?",
+      "invalid_public_url": "Lokhu kuhlola akusabemukeli abaphendulayo",
+      "share_report": "Yabelana ngombiko",
+      "share_all_reports": "Yabelana Ngayo Yonke Imibiko",
+      "terms_text": "Ngiyaqonda ukuthi ulwazi oluhlinzekwe yilolu hlu lwemibuzo akuhloselwe ukuthatha indawo yeseluleko, ukuxilongwa, noma ukwelashwa okunikezwa uchwepheshe wezempilo noma wengqondo, nokuthi izimpendulo zami ezingaziwa zingasetshenziswa futhi kwabelwane ngazo ukuze kwenziwe ucwaningo olujwayelekile mayelana nempilo yengqondo yezingane.",
+      "footer_text": "I-CHILD MIND INSTITUTE, INC. FUTHI UKWELASHWA KOMQONDO WENGANE, I-PLLC (NDAWONYE, “I-CMI”) AYISEBENZI NGEMITHI NGOKUQONDILE NOMA NGOKUNGAQONDILE NOMA IKHIPHE ISELULEKO SOKWELAPHA NJENGXENYE YALE MIBUZO. I-CMI AYITHATHI ISIBOPHO SOKUHLOLA, UKWELASHWA, ISINQUMO ESENZIWE, NOMA ISINYATHELO ESITHATHWE NGOKUTHEMBA ULWAZI OLUNIKEZWE NGALOLU LWEMIBUZO, FUTHI AYIQINISEKI ISIBOPHO NGOKUSEBENZISA KWAKHO LE MIBUZO.",
+      "child_score": "Isikolo Sengane Yakho",
+      "child_score_on_subscale": "Isikolo sengane yakho esikalini esingaphansi se-{{name}} besithi",
+      "fill_out_fields": "Sicela ugcwalise izinkambu ezidingekayo",
+      "additional_text": "Umbhalo Ongeziwe"
+    },
+    "no_markdown": "Ababhali bale applet abanikezanga noma yiluphi ulwazi!",
+    "no_applets": "Okwamanje awunawo ama-applet.",
+    "unabletoLoadActivity": "Ayikwazi ukulayisha umsebenzi",
+    "reportSummary": "Bika Isifinyezo",
+    "alerts": "Izexwayiso",
+    "takeNow": {
+      "tooltip": {
+        "providingResponses": "Ukunikeza Izimpendulo",
+        "inputtingResponses": "Ifaka Izimpendulo",
+        "subjectOfResponses": "Isihloko Sezimpendulo"
+      },
+      "invalidRespondent": "Awugunyaziwe ukuqedela lokhu kuhlola egameni lalesi sihloko.",
+      "mismatchedRespondent": "Kukhona ukungafani phakathi komphenduli olindelekile kanye nomsebenzisi we-app ongene ngemvume. Sicela ungene ngemvume njengomphenduli olungile ukuze uqhubeke nokuthi Thatha Manje.",
+      "invalidSubject": "Lesi sihloko asikho.",
+      "invalidActivity": "Lo msebenzi awukho.",
+      "invalidApplet": "Le applet ayikho.",
+      "successModalTitle": "Umsebenzi Wenziwe",
+      "successModalLabel": "Izimpendulo zakho zithunyelwe. Sicela ubuyele ku-App Yomlawuli ukuze uqedele omunye umsebenzi noma ubuke imiphumela.",
+      "successModalPrimaryAction": "Buyela ku-App Yomlawuli",
+      "successModalSecondaryAction": "Cashisa"
+    },
+    "charactersCount": "{{numCharacters}}/izinhlamvu ezingu-{{maxCharacters}}",
+    "targetSubjectLabel": "Mayelana {{name}}",
+    "targetSubjectBanner": "Sicela uqinisekise ukuthi zonke izimpendulo zakho zimayelana <strong>{{name}}</strong>",
+    "loading": "Iyalayisha...",
+    "footer": {
+      "product": "I-Curious umkhiqizo",
+      "support": "Ukusekela",
+      "privacy": "Ubumfihlo",
+      "termsOfService": "Imigomo"
+    },
+    "activity": "Umsebenzi",
+    "networkError": "Iphutha Lenethiwekhi",
+    "timeRemaining": "{{time}} kusele",
+    "forItem": "kule nto",
+    "noApplets": "Awekho ama-applet",
+    "noActivities": "Ayikho imisebenzi etholakalayo ukuthi uyiqedele njengamanje",
+    "prolific": {
+      "nocode": "Kwenzeke iphutha ngesikhathi kulandwa ikhodi yakho yokuqedela ku-Prolific. Siyaxolisa ngalokhu kuphazamiseka Sicela usebenzise okuthi \"NOCODE\" ku-Prolific njengekhodi yakho yokuqedela",
+      "alreadyAnswered": "Usuvele uwuphendulile lo msebenzi. Sicela ubuyele ku-Prolific bese uhambisa ikhodi yakho yokuqedela noma ulandele inqubomgomo ye-NOCODE.",
+      "invalid": "Ayikwazi ukuqinisekisa ucwaningo. Sicela uthinte umlawuli wocwaningo."
+    },
+    "requestHealthRecordData": {
+      "title": "Cela Idatha Yerekhodi Lezempilo",
+      "linkText": "Funda kabanzi mayelana nendlela i-Curious efinyelela ngayo ngokuphephile kudatha yokunakekelwa kwezempilo.",
+      "partnershipText": "I-Curious isebenzisa i-1upHealth’s Medical Information Service ukuze umcwaningi wakho akwazi ukufinyelela ulwazi kumarekhodi akho okunakekelwa kwezempilo.\n\nKuzikrini ezilandelayo, uzocelwa ukuthi ungene ngemvume kumasistimu akho Abahlinzeki Bezempilo futhi wabelane ngedatha yakho yokunakekelwa kwezempilo nalolu cwaningo.. Uzobuyela emsebenzini we-Curious uma usuqedile.",
+      "skipButtonText": "Yeqa",
+      "additionalPromptText": "Usuqedile ukungena ku-akhawunti yakho yokunakekelwa kwezempilo.\n\nUngathanda ukungena ngemvume kunoma imaphi ama-akhawunti okunakekelwa kwezempilo engeziwe?"
+    },
+    "announcementBanner": "<0>Senza kabusha! </0><1>Izibuyekezo zedizayini zisendleleni — i-app enhle efanayo, ukubukeka okusha. Ufuna ukwazi? </1><2>Chofoza ukuze ufunde kabanzi.</2>",
+    "oneUpHealth": {
+      "tokenExpired": {
+        "title": "Ithokheni iphelelwe yisikhathi",
+        "message": "Lesi sikhathi siphelelwe yisikhathi. Ixhuma kabusha ku-1UpHealth...",
+        "banner": "Isikhathi sakho siphelelwe yisikhathi. Izama ukuvuselela..."
+      },
+      "geographicRestriction": {
+        "title": "Umkhawulo Ongokwendawo",
+        "message": "Lokhu okuqukethwe akutholakali endaweni yangakini. Sicela weqele esinyathelweni esilandelayo.",
+        "banner": "Ukufinyelela ku-1UpHealth okwamanje kukhawulelwe kubasebenzisi abase-United States."
+      },
+      "serviceUnavailable": {
+        "title": "Insizakalo Ayitholakali",
+        "message": "Asikwazi ukuxhuma ku-1UpHealth ngalesi sikhathi. Sicela weqe lesi sigaba noma uzame futhi emuva kwesikhathi.",
+        "banner": "Isevisi ye-1UpHealth ayitholakali okwamanje. Sicela uzame futhi emuva kwesikhathi."
+      },
+      "communicationError": {
+        "title": "Iphutha Lokuxhumana",
+        "message": "Asikwazi ukuxhuma ku-1UpHealth ngalesi sikhathi. Sicela weqe lesi sigaba noma uzame futhi emuva kwesikhathi.",
+        "banner": "Iphutha ukuxhumana ne-1UpHealth. Sicela uzame futhi emuva kwesikhathi."
+      },
+      "unknownError": {
+        "title": "Iphutha Elingaziwa",
+        "message": "Asikwazi ukuxhuma ku-1UpHealth ngalesi sikhathi. Sicela weqe lesi sigaba noma uzame futhi emuva kwesikhathi.",
+        "banner": "Kwenzeke iphutha elingaziwa. Sicela uzame futhi emuva kwesikhathi."
+      }
+    },
+    "ehrRedirectModal": {
+      "title": "Konke kwenziwe",
+      "label": "Usuqedile ukungena ngemvume kule akhawunti yomhlinzeki wezempilo. Sicela ubuyele ku-app lapho uqale khona le nqubo.",
+      "primaryAction": "Vula i-app",
+      "secondaryAction": "Qhubeka kusiphequluli"
+    }
+  }
+}

--- a/src/i18n/zu/translation.json
+++ b/src/i18n/zu/translation.json
@@ -80,7 +80,10 @@
       "french": "Français",
       "greek": "Ελληνικά",
       "spanish": "Español",
-      "portuguese": "Português"
+      "portuguese": "Português",
+      "afrikaans": "Afrikaans",
+      "xhosa": "isiXhosa",
+      "zulu": "isiZulu"
     },
     "validation": {
       "passwordRequirementsMet": "Zonke izimfuneko zifinyelelwe.",


### PR DESCRIPTION
- [x] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [ ] OSS packages added to Curious [open source credit page](https://mindlogger.atlassian.net/jira/servicedesk/projects/MLA/knowledge/articles/340623543?spaceKey=MLA)

### 📝 Description

🔗 [Jira Ticket M2-10766](https://mindlogger.atlassian.net/browse/M2-10766)

Adds web UI support for three new languages - **Afrikaans (af)**, **isiXhosa (xh)**, and **isiZulu (zu)** - extending the existing i18next setup that already covers English, French, Greek, Spanish, and Portuguese.

After this PR merges, the three new languages appear in the footer language dropdown alongside the existing five. Selecting any of them switches the entire UI  into that language and persists the choice via `localStorage.i18nextLng`. The axios interceptor at src/shared/api/services/axios.ts automatically forwards the selection as `Content-Language: af|xh|zu` on every outgoing request, which the backend uses to localise emails (e.g. the password recovery email when the user clicks "Forgot password").

Changes include:

- Added 3 new translation JSON files at `src/i18n/{af,xh,zu}/translation.json` covering all 354 translation keys, each verified to have full key parity with the English source.
- Added native-form language labels (`"afrikaans": "Afrikaans"`, `"xhosa": "isiXhosa"`, `"zulu": "isiZulu"`) to the `translation.Language` section in all 8 locale files (en, fr, el, es, pt + the three new ones), so the dropdown's option labels render correctly regardless of which UI language is currently active. 
- Extended the `SupportableLanguage` enum in src/app/system/locale/constants.ts with `Afrikaans = 'af'`, `Xhosa = 'xh'`, `Zulu = 'zu'`. PascalCase keys are required because `useLanguageList` derives the label-translation path via `.toLocaleLowerCase()`.
- Registered the three new resource bundles in src/app/system/locale/i18n.ts - added imports, extended the `resources` map, and updated `supportedLngs` to `['en', 'fr', 'el', 'es', 'pt', 'af', 'xh', 'zu']`.
- Added `useLanguageList.test.ts` asserting the hook returns exactly 8 entries with the expected `eventKey` and `localizationPath` for each enum member - guards against the picker regressing if anyone removes or reorders a language in the future.


