### PR TITLE
fix: show English as 'English' in Zulu language list (M2-10838)

### DIFF
--- a/src/i18n/zu/translation.json
+++ b/src/i18n/zu/translation.json
@@ -76,7 +76,7 @@
       "description": "Asisekho isikhathi sokusebenza kulo msebenzi. Wonke umsebenzi owenzile uzogcinwa futhi uhanjiswe. "
     },
     "Language": {
-      "english": "IsiNgisi",
+      "english": "English",
       "french": "Français",
       "greek": "Ελληνικά",
       "spanish": "Español",


### PR DESCRIPTION
- [ ] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [ ] OSS packages added to Curious [open source credit page](https://mindlogger.atlassian.net/jira/servicedesk/projects/MLA/knowledge/articles/340623543?spaceKey=MLA)

### 📝 Description

🔗 [Jira Ticket M2-10838](https://mindlogger.atlassian.net/browse/M2-10838)

English was shown as "IsiNgisi" in the language list when the app language was set to Zulu. The Zulu translation file had translated the English label instead of keeping its native name. Fixed so English always displays as "English", consistent with the other languages which use their native names.

Changes include:

- Updated the Zulu translation (`zu.json`) so the English language label is "English" instead of "IsiNgisi".


### ✏️ Notes

- Mobile has the same issue, fixed separately (M2-10837 / equivalent).
