### PR TITLE
fix: prevent Save & Close button overflow for long translations (M2-10860)

### DIFF
--- a/src/features/PassSurvey/ui/SurveyHeader/index.tsx
+++ b/src/features/PassSurvey/ui/SurveyHeader/index.tsx
@@ -55,7 +55,7 @@ const SurveyHeader = (props: Props) => {
         gridAutoFlow="column"
         alignItems="center"
         justifyContent="center"
-        gridTemplateColumns="1fr minmax(300px, 900px) 1fr"
+        gridTemplateColumns="minmax(0, 1fr) minmax(300px, 900px) minmax(max-content, 1fr)"
         gap={1.5}
       >
         {greaterThanSM && props.entityTimer && (

--- a/src/features/PassSurvey/ui/SurveyHeader/index.tsx
+++ b/src/features/PassSurvey/ui/SurveyHeader/index.tsx
@@ -103,7 +103,7 @@ const SurveyHeader = (props: Props) => {
 
         {greaterThanSM && props.isSaveAndExitButtonShown && (
           <Box
-            width="140px"
+            minWidth="140px"
             height="100%"
             gridColumn="3/3"
             display="flex"


### PR DESCRIPTION
- [ ] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [ ] OSS packages added to Curious [open source credit page](https://mindlogger.atlassian.net/jira/servicedesk/projects/MLA/knowledge/articles/340623543?spaceKey=MLA)

### 📝 Description

🔗 [Jira Ticket M2-10860](https://mindlogger.atlassian.net/browse/M2-10860)

The isiZulu "Save & Close" label (`Londoloza futhi Uphume`) is longer than the English text and overflowed the button, spilling off the right edge of the survey header.

Changes include:

- Changed the desktop Save & Close wrapper from a fixed `width="140px"` to `minWidth="140px"` so the button grows to fit longer translations instead of clipping.

### 🪤 Peer Testing

- Open a survey and switch the language to isiZulu.

    **Expected outcome:** The "Londoloza futhi Uphume" button text stays fully inside the button.

- Switch back to English / other languages.

    **Expected outcome:** The Save & Close button looks unchanged.
