### PR TITLE
Prevent back button text from wrapping in submit modal (M2-10859)

### DIFF
--- a/src/shared/ui/MuiModal/index.tsx
+++ b/src/shared/ui/MuiModal/index.tsx
@@ -130,7 +130,7 @@ export const MuiModal = (props: Props) => {
         >
           {footerSecondaryButton && (
             <Box
-              width={{ xs: canStackButtons ? '100%' : '120px', sm: '120px' }}
+              minWidth={{ xs: canStackButtons ? '100%' : '120px', sm: '120px' }}
               sx={{ order: { xs: canStackButtons ? 2 : 'initial', sm: 'initial' } }}
               data-testid="assessment-back-button"
             >

--- a/src/shared/ui/MuiModal/index.tsx
+++ b/src/shared/ui/MuiModal/index.tsx
@@ -141,6 +141,7 @@ export const MuiModal = (props: Props) => {
                 text={footerSecondaryButton}
                 borderColor={variables.palette.outline}
                 sx={{
+                  whiteSpace: 'nowrap',
                   '&:hover': {
                     border: 'none',
                   },


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-#10859](https://mindlogger.atlassian.net/browse/M2-10859)

Fixes secondary button labels wrapping onto two lines in `MuiModal` footers.

Changes include:

- Changed the secondary button container in `MuiModal` from a fixed `width` of `120px` to `minWidth`, matching the primary button behavior
- Allows the "Go Back" label in any language to stay on a single line while preserving the minimum button width

### 🪤 Peer Testing
- Change app language to isiZulu
- Open a survey activity and proceed to the final question
- Click **Next** to open the submit confirmation modal
- Confirm the **Go Back** button label appears on a single line
- Confirm the **Submit** button still renders correctly beside it

**Expected outcome:** The "Go Back" label no longer wraps; both footer buttons remain usable and properly aligned.

### ✏️ Notes

Small layout-only change in `src/shared/ui/MuiModal/index.tsx`. Affects any modal using `footerSecondaryButton`, not just the survey submit flow.