### PR TITLE
feat: Fixed issues with slider and slider rows (M2-10890, M2-10901)

### DIFF
--- a/src/entities/activity/ui/items/Matrix/Slider/SliderRow.tsx
+++ b/src/entities/activity/ui/items/Matrix/Slider/SliderRow.tsx
@@ -4,7 +4,7 @@ import { Box, SliderItemBase, Text } from '~/shared/ui';
 type Props = {
   label: string;
 
-  value: number;
+  value: number | undefined;
   minValue: number;
   maxValue: number;
 
@@ -43,7 +43,7 @@ export const SliderRow = ({
       </Text>
 
       <SliderItemBase
-        value={String(value)}
+        value={value !== undefined ? String(value) : undefined}
         minValue={minValue}
         minLabel={minLabel}
         minImage={minImage}

--- a/src/entities/activity/ui/items/Matrix/Slider/SliderRows.test.tsx
+++ b/src/entities/activity/ui/items/Matrix/Slider/SliderRows.test.tsx
@@ -1,0 +1,131 @@
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { SliderRowsItem } from '../../../../lib';
+
+import { SliderRows } from './index';
+
+const theme = createTheme();
+
+const mockSliderRowsItem: SliderRowsItem = {
+  id: 'slider-rows-1',
+  name: 'test-slider-rows',
+  question: 'Rate the following',
+  order: 1,
+  responseType: 'sliderRows',
+  config: {
+    removeBackButton: false,
+    skippableItem: false,
+    timer: null,
+    addScores: false,
+    setAlerts: false,
+  },
+  responseValues: {
+    rows: [
+      {
+        id: 'row-1',
+        label: 'Energy',
+        minLabel: 'Low',
+        maxLabel: 'High',
+        minValue: 0,
+        maxValue: 5,
+        minImage: null,
+        maxImage: null,
+        alerts: null,
+      },
+      {
+        id: 'row-2',
+        label: 'Mood',
+        minLabel: 'Sad',
+        maxLabel: 'Happy',
+        minValue: 0,
+        maxValue: 5,
+        minImage: null,
+        maxImage: null,
+        alerts: null,
+      },
+    ],
+  },
+  answer: [],
+  conditionalLogic: null,
+  isHidden: false,
+};
+
+function renderSliderRows(overrides: { values?: (number | null)[]; item?: SliderRowsItem } = {}) {
+  const onValueChange = vi.fn();
+  const item = overrides.item ?? mockSliderRowsItem;
+  const values = overrides.values ?? [];
+
+  const result = render(
+    <ThemeProvider theme={theme}>
+      <SliderRows item={item} values={values} onValueChange={onValueChange} />
+    </ThemeProvider>,
+  );
+
+  return { ...result, onValueChange };
+}
+
+describe('SliderRows', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Rendering', () => {
+    it('renders a slider for each row', () => {
+      renderSliderRows();
+      const sliders = screen.getAllByRole('slider');
+      expect(sliders).toHaveLength(2);
+    });
+
+    it('renders row labels', () => {
+      renderSliderRows();
+      expect(screen.getByText('Energy')).toBeInTheDocument();
+      expect(screen.getByText('Mood')).toBeInTheDocument();
+    });
+  });
+
+  describe('Value handling', () => {
+    it('has no-value class on all rows when values are empty', () => {
+      renderSliderRows({ values: [] });
+      const containers = screen.getAllByTestId('slider-container');
+      containers.forEach((container) => {
+        expect(container).toHaveClass('no-value');
+      });
+    });
+
+    it('has no-value class only on unanswered rows', () => {
+      renderSliderRows({ values: [3, null] });
+      const containers = screen.getAllByTestId('slider-container');
+      expect(containers[0]).not.toHaveClass('no-value');
+      expect(containers[1]).toHaveClass('no-value');
+    });
+
+    it('does not have no-value class when all values are set', () => {
+      renderSliderRows({ values: [3, 4] });
+      const containers = screen.getAllByTestId('slider-container');
+      containers.forEach((container) => {
+        expect(container).not.toHaveClass('no-value');
+      });
+    });
+  });
+
+  describe('onChange behavior', () => {
+    it('calls onValueChange with the correct index updated', () => {
+      const { onValueChange } = renderSliderRows({ values: [] });
+      const sliders = screen.getAllByRole('slider');
+
+      fireEvent.change(sliders[0], { target: { value: '3' } });
+
+      expect(onValueChange).toHaveBeenCalledWith([3, null]);
+    });
+
+    it('preserves existing values when updating a single row', () => {
+      const { onValueChange } = renderSliderRows({ values: [2, null] });
+      const sliders = screen.getAllByRole('slider');
+
+      fireEvent.change(sliders[1], { target: { value: '4' } });
+
+      expect(onValueChange).toHaveBeenCalledWith([2, 4]);
+    });
+  });
+});

--- a/src/entities/activity/ui/items/Matrix/Slider/index.tsx
+++ b/src/entities/activity/ui/items/Matrix/Slider/index.tsx
@@ -35,7 +35,7 @@ export const SliderRows = (props: Props) => {
           <SliderRow
             key={row.id}
             label={row.label}
-            value={value ? value : row.minValue}
+            value={value ?? undefined}
             minValue={row.minValue}
             minLabel={row.minLabel}
             minImage={row.minImage}

--- a/src/entities/activity/ui/items/SliderItem.test.tsx
+++ b/src/entities/activity/ui/items/SliderItem.test.tsx
@@ -1,0 +1,101 @@
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { SliderItem } from './SliderItem';
+import { SliderItem as SliderItemType } from '../../lib';
+
+const theme = createTheme();
+
+const mockSliderItem: SliderItemType = {
+  id: 'slider-1',
+  name: 'test-slider',
+  question: 'Rate your mood',
+  order: 1,
+  responseType: 'slider',
+  config: {
+    removeBackButton: false,
+    skippableItem: false,
+    timer: null,
+    additionalResponseOption: {
+      textInputOption: false,
+      textInputRequired: false,
+    },
+    addScores: false,
+    setAlerts: false,
+    showTickMarks: true,
+    showTickLabels: true,
+    continuousSlider: false,
+  },
+  responseValues: {
+    minLabel: 'Sad',
+    maxLabel: 'Happy',
+    minValue: 0,
+    maxValue: 10,
+    minImage: null,
+    maxImage: null,
+    scores: null,
+    alerts: null,
+  },
+  answer: [],
+  conditionalLogic: null,
+  isHidden: false,
+};
+
+function renderSliderItem(
+  overrides: { value?: string; isDisabled?: boolean; item?: SliderItemType } = {},
+) {
+  const onValueChange = vi.fn();
+  const item = overrides.item ?? mockSliderItem;
+
+  const result = render(
+    <ThemeProvider theme={theme}>
+      <SliderItem
+        item={item}
+        value={overrides.value as string}
+        onValueChange={onValueChange}
+        isDisabled={overrides.isDisabled ?? false}
+      />
+    </ThemeProvider>,
+  );
+
+  return { ...result, onValueChange };
+}
+
+describe('SliderItem', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Config mapping', () => {
+    it('maps responseValues labels to SliderItemBase', () => {
+      renderSliderItem({ value: '5' });
+      expect(screen.getByTestId('slider-min-label')).toHaveTextContent('Sad');
+      expect(screen.getByTestId('slider-max-label')).toHaveTextContent('Happy');
+    });
+
+    it('maps responseValues min/max values to slider range', () => {
+      renderSliderItem({ value: '5' });
+      const slider = screen.getByRole('slider');
+      expect(slider).toHaveAttribute('aria-valuemin', '0');
+      expect(slider).toHaveAttribute('aria-valuemax', '10');
+    });
+  });
+
+  describe('Value handling', () => {
+    it('has no-value class when value is undefined', () => {
+      renderSliderItem({ value: undefined });
+      expect(screen.getByTestId('slider-container')).toHaveClass('no-value');
+    });
+
+    it('does not have no-value class when value is set', () => {
+      renderSliderItem({ value: '5' });
+      expect(screen.getByTestId('slider-container')).not.toHaveClass('no-value');
+    });
+
+    it('wraps onChange value in an array before calling onValueChange', () => {
+      const { onValueChange } = renderSliderItem({ value: '2' });
+      fireEvent.change(screen.getByRole('slider'), { target: { value: '7' } });
+      expect(onValueChange).toHaveBeenCalledWith(['7']);
+    });
+  });
+});

--- a/src/entities/activity/ui/items/SliderItem.tsx
+++ b/src/entities/activity/ui/items/SliderItem.tsx
@@ -20,7 +20,7 @@ export const SliderItem = ({ value, item, onValueChange, isDisabled }: SliderIte
   return (
     <Box padding="0px 16px">
       <SliderItemBase
-        value={value ? value : responseValues.minValue.toString()}
+        value={value}
         minValue={responseValues.minValue}
         minLabel={responseValues.minLabel}
         minImage={responseValues.minImage}

--- a/src/shared/ui/Items/Slider/index.test.tsx
+++ b/src/shared/ui/Items/Slider/index.test.tsx
@@ -133,7 +133,7 @@ describe('SliderItemBase', () => {
 
       fireEvent.mouseDown(sliderRoot, { clientX: 0 });
       fireEvent.mouseUp(sliderRoot);
-      expect(onChange.mock.calls.length).toBeLessThanOrEqual(1);
+      expect(onChange).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/shared/ui/Items/Slider/index.test.tsx
+++ b/src/shared/ui/Items/Slider/index.test.tsx
@@ -117,8 +117,8 @@ describe('SliderItemBase', () => {
 
   // Do we need to check if passes a string value?
 
-  describe('onChangeCommited behavior', () => {
-    it('calls onChange via onChangeCommited when value is undefined', () => {
+  describe('onChangeCommitted behavior', () => {
+    it('calls onChange via onChangeCommitted when value is undefined', () => {
       const { onChange, container } = renderSlider({ value: undefined });
 
       const sliderRoot = container.querySelector('.MuiSlider-root')!;
@@ -127,7 +127,7 @@ describe('SliderItemBase', () => {
       expect(onChange).toHaveBeenCalled();
     });
 
-    it('does not call onChange from onChangeCommited when value is already set', () => {
+    it('does not call onChange from onChangeCommitted when value is already set', () => {
       const { onChange, container } = renderSlider({ value: '3' });
       const sliderRoot = container.querySelector('.MuiSlider-root')!;
 

--- a/src/shared/ui/Items/Slider/index.test.tsx
+++ b/src/shared/ui/Items/Slider/index.test.tsx
@@ -1,0 +1,175 @@
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { SliderItemBase } from './index';
+
+const theme = createTheme();
+
+type SliderItemBaseProps = Parameters<typeof SliderItemBase>[0];
+
+const defaultProps: SliderItemBaseProps = {
+  minImage: null,
+  minLabel: null,
+  minValue: 0,
+  maxImage: null,
+  maxLabel: null,
+  maxValue: 5,
+  onChange: vi.fn(),
+};
+
+function renderSlider(overrides: Partial<SliderItemBaseProps> = {}) {
+  const onChange = overrides.onChange ?? vi.fn();
+  const props = { ...defaultProps, ...overrides, onChange };
+
+  const result = render(
+    <ThemeProvider theme={theme}>
+      <SliderItemBase {...props} />
+    </ThemeProvider>,
+  );
+
+  return { ...result, onChange };
+}
+
+describe('SliderItemBase', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Rendering', () => {
+    it('renders slider container with data-testid', () => {
+      renderSlider();
+      expect(screen.getByTestId('slider-container')).toBeInTheDocument();
+    });
+
+    it('renders the MUI slider input element', () => {
+      renderSlider();
+      expect(screen.getByRole('slider')).toBeInTheDocument();
+    });
+
+    it('renders min label when provided', () => {
+      renderSlider({ minLabel: 'Low' });
+      expect(screen.getByTestId('slider-min-label')).toHaveTextContent('Low');
+    });
+
+    it('does not render min label when null', () => {
+      renderSlider({ minLabel: null });
+      expect(screen.queryByTestId('slider-min-label')).toBeNull();
+    });
+
+    it('renders max label when provided', () => {
+      renderSlider({ maxLabel: 'High' });
+      expect(screen.getByTestId('slider-max-label')).toHaveTextContent('High');
+    });
+
+    it('does not render max label when null', () => {
+      renderSlider({ maxLabel: null });
+      expect(screen.queryByTestId('slider-max-label')).toBeNull();
+    });
+
+    it('renders min image when provided', () => {
+      renderSlider({ minImage: 'https://via.placeholder.com/150' });
+      const img = screen.getByTestId('slider-min-image');
+      expect(img).toBeInTheDocument();
+      expect(img).toHaveAttribute('src', 'https://via.placeholder.com/150');
+    });
+
+    it('does not render min image when null', () => {
+      renderSlider({ minImage: null });
+      expect(screen.queryByTestId('slider-min-image')).toBeNull();
+    });
+
+    it('renders max image when provided', () => {
+      renderSlider({ maxImage: 'https://via.placeholder.com/150' });
+      const img = screen.getByTestId('slider-max-image');
+      expect(img).toBeInTheDocument();
+      expect(img).toHaveAttribute('src', 'https://via.placeholder.com/150');
+    });
+
+    it('does not render max image when null', () => {
+      renderSlider({ maxImage: null });
+      expect(screen.queryByTestId('slider-max-image')).toBeNull();
+    });
+
+    it('renders the slider with the correct value', () => {
+      renderSlider({ value: '3' });
+      expect(screen.getByRole('slider')).toHaveValue('3');
+    });
+  });
+  describe('No-value state (value is undefined)', () => {
+    it('does not have no-value CSS class when value is set', () => {
+      renderSlider({ value: '3' });
+      expect(screen.getByTestId('slider-container')).not.toHaveClass('no-value');
+    });
+
+    it('sets slider input value to the provided value', () => {
+      renderSlider({ value: '3' });
+      expect(screen.getByRole('slider')).toHaveValue('3');
+    });
+  });
+
+  describe('onChange behavior', () => {
+    it('calls onChange with string value when slider changes', () => {
+      const { onChange } = renderSlider({ value: '2' });
+      fireEvent.change(screen.getByRole('slider'), { target: { value: '3' } });
+      expect(onChange).toHaveBeenCalledWith('3');
+    });
+  });
+
+  // Do we need to check if passes a string value?
+
+  describe('onChangeCommited behavior', () => {
+    it('calls onChange via onChangeCommited when value is undefined', () => {
+      const { onChange, container } = renderSlider({ value: undefined });
+
+      const sliderRoot = container.querySelector('.MuiSlider-root')!;
+      fireEvent.mouseDown(sliderRoot, { clientX: 0 });
+      fireEvent.mouseUp(sliderRoot);
+      expect(onChange).toHaveBeenCalled();
+    });
+
+    it('does not call onChange from onChangeCommited when value is already set', () => {
+      const { onChange, container } = renderSlider({ value: '3' });
+      const sliderRoot = container.querySelector('.MuiSlider-root')!;
+
+      fireEvent.mouseDown(sliderRoot, { clientX: 0 });
+      fireEvent.mouseUp(sliderRoot);
+      expect(onChange.mock.calls.length).toBeLessThanOrEqual(1);
+    });
+  });
+
+  describe('Disabled state', () => {
+    it('slider is disabled when disabled prop is true', () => {
+      renderSlider({ disabled: true, value: '3' });
+      expect(screen.getByRole('slider')).toBeDisabled();
+    });
+    it('slider is not disabled by default', () => {
+      renderSlider({ value: '3' });
+      expect(screen.getByRole('slider')).not.toHaveAttribute('aria-disabled', 'true');
+    });
+  });
+
+  describe('Continuous vs Discrete mode', () => {
+    it('uses step 0.1 for continuous slider', () => {
+      renderSlider({ continiusSlider: true, value: '2' });
+      expect(screen.getByRole('slider')).toHaveAttribute('step', '0.1');
+    });
+
+    it('uses step 1 for discrete slider by default', () => {
+      renderSlider({ continiusSlider: false, value: '2' });
+      expect(screen.getByRole('slider')).toHaveAttribute('step', '1');
+    });
+  });
+
+  describe('Tick marks and labels', () => {
+    it('generates correct number of mark labels when showStickLabel is true', () => {
+      const { container } = renderSlider({
+        showStickLabel: true,
+        minValue: 0,
+        maxValue: 5,
+        value: '2',
+      });
+      const markLabels = container.querySelectorAll('.MuiSlider-markLabel');
+      expect(markLabels).toHaveLength(6);
+    });
+  });
+});

--- a/src/shared/ui/Items/Slider/index.tsx
+++ b/src/shared/ui/Items/Slider/index.tsx
@@ -61,7 +61,7 @@ export const SliderItemBase = (props: Props) => {
     <Box
       width="100%"
       margin="auto"
-      className={`slider-widget ${value ? 'no-value' : ''}`}
+      className={`slider-widget ${!value ? 'no-value' : ''}`}
       data-testid="slider-container"
     >
       <Slider
@@ -74,6 +74,16 @@ export const SliderItemBase = (props: Props) => {
         step={continiusSlider ? 0.1 : defaultStep}
         valueLabelDisplay={continiusSlider ? 'off' : 'auto'}
         onChange={(e, value) => onChange(String(value))}
+        // When no value is selected, MUI's controlled value defaults to minValue.
+        // Clicking at minValue position won't fire onChange since MUI sees no change.
+        // onChangeCommitted fires on mouseup regardless, catching that case.
+        // The !value guard ensures this only runs on the first interaction (when no value is set),
+        // preventing duplicate events on subsequent interactions where onChange already fires.
+        onChangeCommitted={(e, newValue) => {
+          if (!value) {
+            onChange(String(newValue));
+          }
+        }}
         sx={{
           height: '8px',
           opacity: 1,
@@ -82,6 +92,7 @@ export const SliderItemBase = (props: Props) => {
             backgroundColor: variables.palette.primary,
             width: '24px',
             height: '24px',
+            ...(!value && { display: 'none' }),
           },
           '& .MuiSlider-rail': {
             width: '102%',
@@ -92,6 +103,7 @@ export const SliderItemBase = (props: Props) => {
             opacity: 1,
             color: variables.palette.primary,
             left: '-1% !important',
+            ...(!value && { display: 'none' }),
           },
           '& .MuiSlider-mark': {
             width: '4px',
@@ -100,6 +112,11 @@ export const SliderItemBase = (props: Props) => {
             borderRadius: '50%',
             opacity: showStickMarks ? 1 : 0,
           },
+          ...(!value && {
+            '& .MuiSlider-mark.MuiSlider-markActive': {
+              backgroundColor: variables.palette.outline,
+            },
+          }),
           '& .MuiSlider-markLabel': {
             opacity: showStickLabel ? 1 : 0,
           },


### PR DESCRIPTION
### 📝 Description

The slider on web worked differently then mobile and contained various bugs.

Bugs:
1. When first viewing the page with a slider activity item it looked as if the min value was already selected, however, when trying to go to the next screen you were prompted to enter a value.
2. In order to select the min value you had to select another value first and then you could select the min value

This PR addresses both of these issues.

🔗 [Jira Ticket M2-10890](https://mindlogger.atlassian.net/browse/M2-10890)
🔗 [Jira Ticket M2-10901](https://mindlogger.atlassian.net/browse/M2-10901)

Changes include:

- Pass raw value (even if undefined) to SliderItemBase instead of defaulting to minValue
- Hide thumb and track when no value is selected
- Add onChangeCommited to handle clicks at minValue position
- Added tests for SliderItemBase and SliderItem

### 📸 Screenshots

<img width="868" height="198" alt="Screenshot 2026-06-16 at 3 21 33 PM" src="https://github.com/user-attachments/assets/f62160cb-e7c1-40b4-a904-a74eed01949f" />

<img width="973" height="299" alt="Screenshot 2026-06-16 at 3 21 28 PM" src="https://github.com/user-attachments/assets/ae137661-de3e-40fc-ad3e-dc5d9e85a935" />