### PR TITLE
Fixed slider issues for Slider Rows (m2-10901)

### DIFF
--- a/src/entities/activity/ui/items/Matrix/Slider/SliderRow.tsx
+++ b/src/entities/activity/ui/items/Matrix/Slider/SliderRow.tsx
@@ -4,7 +4,7 @@ import { Box, SliderItemBase, Text } from '~/shared/ui';
 type Props = {
   label: string;
 
-  value: number;
+  value: number | undefined;
   minValue: number;
   maxValue: number;
 
@@ -43,7 +43,7 @@ export const SliderRow = ({
       </Text>
 
       <SliderItemBase
-        value={String(value)}
+        value={value !== undefined ? String(value) : undefined}
         minValue={minValue}
         minLabel={minLabel}
         minImage={minImage}

--- a/src/entities/activity/ui/items/Matrix/Slider/SliderRows.test.tsx
+++ b/src/entities/activity/ui/items/Matrix/Slider/SliderRows.test.tsx
@@ -1,0 +1,131 @@
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { SliderRowsItem } from '../../../../lib';
+
+import { SliderRows } from './index';
+
+const theme = createTheme();
+
+const mockSliderRowsItem: SliderRowsItem = {
+  id: 'slider-rows-1',
+  name: 'test-slider-rows',
+  question: 'Rate the following',
+  order: 1,
+  responseType: 'sliderRows',
+  config: {
+    removeBackButton: false,
+    skippableItem: false,
+    timer: null,
+    addScores: false,
+    setAlerts: false,
+  },
+  responseValues: {
+    rows: [
+      {
+        id: 'row-1',
+        label: 'Energy',
+        minLabel: 'Low',
+        maxLabel: 'High',
+        minValue: 0,
+        maxValue: 5,
+        minImage: null,
+        maxImage: null,
+        alerts: null,
+      },
+      {
+        id: 'row-2',
+        label: 'Mood',
+        minLabel: 'Sad',
+        maxLabel: 'Happy',
+        minValue: 0,
+        maxValue: 5,
+        minImage: null,
+        maxImage: null,
+        alerts: null,
+      },
+    ],
+  },
+  answer: [],
+  conditionalLogic: null,
+  isHidden: false,
+};
+
+function renderSliderRows(overrides: { values?: (number | null)[]; item?: SliderRowsItem } = {}) {
+  const onValueChange = vi.fn();
+  const item = overrides.item ?? mockSliderRowsItem;
+  const values = overrides.values ?? [];
+
+  const result = render(
+    <ThemeProvider theme={theme}>
+      <SliderRows item={item} values={values} onValueChange={onValueChange} />
+    </ThemeProvider>,
+  );
+
+  return { ...result, onValueChange };
+}
+
+describe('SliderRows', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Rendering', () => {
+    it('renders a slider for each row', () => {
+      renderSliderRows();
+      const sliders = screen.getAllByRole('slider');
+      expect(sliders).toHaveLength(2);
+    });
+
+    it('renders row labels', () => {
+      renderSliderRows();
+      expect(screen.getByText('Energy')).toBeInTheDocument();
+      expect(screen.getByText('Mood')).toBeInTheDocument();
+    });
+  });
+
+  describe('Value handling', () => {
+    it('has no-value class on all rows when values are empty', () => {
+      renderSliderRows({ values: [] });
+      const containers = screen.getAllByTestId('slider-container');
+      containers.forEach((container) => {
+        expect(container).toHaveClass('no-value');
+      });
+    });
+
+    it('has no-value class only on unanswered rows', () => {
+      renderSliderRows({ values: [3, null] });
+      const containers = screen.getAllByTestId('slider-container');
+      expect(containers[0]).not.toHaveClass('no-value');
+      expect(containers[1]).toHaveClass('no-value');
+    });
+
+    it('does not have no-value class when all values are set', () => {
+      renderSliderRows({ values: [3, 4] });
+      const containers = screen.getAllByTestId('slider-container');
+      containers.forEach((container) => {
+        expect(container).not.toHaveClass('no-value');
+      });
+    });
+  });
+
+  describe('onChange behavior', () => {
+    it('calls onValueChange with the correct index updated', () => {
+      const { onValueChange } = renderSliderRows({ values: [] });
+      const sliders = screen.getAllByRole('slider');
+
+      fireEvent.change(sliders[0], { target: { value: '3' } });
+
+      expect(onValueChange).toHaveBeenCalledWith([3, null]);
+    });
+
+    it('preserves existing values when updating a single row', () => {
+      const { onValueChange } = renderSliderRows({ values: [2, null] });
+      const sliders = screen.getAllByRole('slider');
+
+      fireEvent.change(sliders[1], { target: { value: '4' } });
+
+      expect(onValueChange).toHaveBeenCalledWith([2, 4]);
+    });
+  });
+});

--- a/src/entities/activity/ui/items/Matrix/Slider/index.tsx
+++ b/src/entities/activity/ui/items/Matrix/Slider/index.tsx
@@ -35,7 +35,7 @@ export const SliderRows = (props: Props) => {
           <SliderRow
             key={row.id}
             label={row.label}
-            value={value ? value : row.minValue}
+            value={value ?? undefined}
             minValue={row.minValue}
             minLabel={row.minLabel}
             minImage={row.minImage}


### PR DESCRIPTION
### 📝 Description
PR #747 fixed the following slider bugs:

1. When first viewing the page with a slider activity item it looked as if the min value was already selected, however, when trying to go to the next screen you were prompted to enter a value.
2. In order to select the min value you had to select another value first and then you could select the min value

This PR addresses these same issues but for the Slider Rows

🔗 [Jira Ticket M2-#10901](https://mindlogger.atlassian.net/browse/M2-10901)

<!-- Replace this with a high-level description of the features/functionality proposed in the pull request. -->

Changes include:

- Pass raw value (even if undefined) to SliderItemBase
### 📸 Screenshots

**Not Entering All Values:**

<img width="894" height="985" alt="Screenshot 2026-06-16 at 4 25 53 PM" src="https://github.com/user-attachments/assets/c1f865e0-9b34-4786-8666-77762b335fde" />

**First Viewing the Screen:**

<img width="859" height="926" alt="Screenshot 2026-06-16 at 4 25 33 PM" src="https://github.com/user-attachments/assets/83eb3f9e-2129-4caa-97cf-af53928d324f" />