### PR TITLE
test: set up AF Resume suite and automate CR1 (M2-11026)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,16 @@ jobs:
         run: |
           yarn test:smoke
 
+      # Non-blocking: coverage is still partial (CR1 only), letting this fail
+      # softly until the suite has proven itself stable in CI.
+      - name: Running af-resume tests
+        continue-on-error: true
+        env:
+          PLAYWRIGHT_BASE_URL: https://web-uat.cmiml.net
+          PLAYWRIGHT_API_BASE_URL: https://api-uat.cmiml.net
+        run: |
+          yarn test:af-resume
+
 
   build:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test:e2e": "TZ=UTC playwright test --project=e2e",
     "test:user": "TZ=UTC playwright test --project=user",
     "test:smoke": "TZ=UTC playwright test --project=smoke",
+    "test:af-resume": "TZ=UTC playwright test --project=af-resume",
     "test:ui": "TZ=UTC vitest --ui",
     "coverage": "TZ=UTC vitest run --coverage"
   },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -39,6 +39,14 @@ export default defineConfig({
         storageState: runtimeConfig.storageState,
       }
     },
+    {
+      name: 'af-resume',
+      testMatch: 'af-resume/**/*.spec.ts',
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: runtimeConfig.storageState,
+      }
+    },
 
     //TODO: Enable other browsers when needed.
     //At the moment all browsers but Chrome fail.

--- a/tests/fixtures/af-applet.fixture.ts
+++ b/tests/fixtures/af-applet.fixture.ts
@@ -1,0 +1,118 @@
+import { AppletAPI } from '../utils/api-client/applet-api';
+import { AnswerAPI } from '../utils/api-client/answer-api';
+import { AssignmentAPI } from '../utils/api-client/assignment-api';
+import { EventAPI } from '../utils/api-client/event-api';
+import { InvitationAPI } from '../utils/api-client/invitation-api';
+import {
+  AF_FLOW_NAME,
+  AF_MANUAL_FLOW_NAME,
+  AF_STANDALONE_ACTIVITY_NAMES,
+  buildAfResumeAppletPayload,
+} from '../utils/data/af-resume-applet';
+import { buildAppletEncryption, getPrivateKey } from '../utils/encryption';
+import { afApiContext, test as sessionTest } from './af-session.fixture';
+
+export type AfApplet = {
+  appletId: string;
+  displayName: string;
+  version: string;
+  flowId: string;
+  // autoAssign=false twin of the flow; visible only after manual assignment.
+  manualFlowId: string;
+  // Activity ids in flow order.
+  flowActivityIds: string[];
+  standaloneActivityIds: string[];
+  // Item ids keyed by activity id, needed for answer submissions.
+  itemIdsByActivityId: Record<string, string[]>;
+  // Owner key material, needed to encrypt seeded answers.
+  ownerPrivateKey: number[];
+  appletPublicKey: number[];
+};
+
+export type AfApi = {
+  applets: AppletAPI;
+  events: EventAPI;
+  answers: AnswerAPI;
+  assignments: AssignmentAPI;
+  invitations: InvitationAPI;
+};
+
+type AfTestFixtures = {
+  // Test-scoped: each test gets a fresh applet. Sharing one applet across
+  // tests piles up in-progress submissions, which breaks the applet page.
+  afApplet: AfApplet;
+};
+
+type AfWorkerApiFixtures = {
+  afApi: AfApi;
+};
+
+export const test = sessionTest.extend<AfTestFixtures, AfWorkerApiFixtures>({
+  afApi: [
+    async ({ afUser }, use) => {
+      const context = await afApiContext(afUser);
+      const answers = new AnswerAPI(context);
+      answers.setRespondent(
+        getPrivateKey({ userId: afUser.id, email: afUser.email, password: afUser.password }),
+      );
+
+      await use({
+        applets: new AppletAPI(context),
+        events: new EventAPI(context),
+        answers,
+        assignments: new AssignmentAPI(context),
+        invitations: new InvitationAPI(context),
+      });
+      await context.dispose();
+    },
+    { scope: 'worker' },
+  ],
+
+  afApplet: async ({ afUser, afApi }, use, testInfo) => {
+    const owner = { userId: afUser.id, email: afUser.email, password: afUser.password };
+    const ownerPrivateKey = getPrivateKey(owner);
+    const encryption = buildAppletEncryption(owner);
+
+    const displayName = `AF Resume w${testInfo.workerIndex} ${Date.now()}`;
+    const created = await afApi.applets.createWorkspaceApplet(
+      afUser.id,
+      buildAfResumeAppletPayload({ displayName, encryption }),
+    );
+
+    const detail = (await afApi.applets.getAppletDetail(created.result.id)).result;
+    const activityIdByName = new Map<string, string>(
+      detail.activities.map((a: { name: string; id: string }) => [a.name, a.id]),
+    );
+    // Applet detail omits items; each activity detail carries them.
+    const itemIdsByActivityId: Record<string, string[]> = {};
+    for (const activity of detail.activities) {
+      const activityDetail = (await afApi.applets.getActivity(activity.id)).result;
+      itemIdsByActivityId[activity.id] = activityDetail.items.map(
+        (item: { id: string }) => item.id,
+      );
+    }
+    const flow = detail.activityFlows.find((f: { name: string }) => f.name === AF_FLOW_NAME);
+    const manualFlow = detail.activityFlows.find(
+      (f: { name: string }) => f.name === AF_MANUAL_FLOW_NAME,
+    );
+
+    await use({
+      appletId: detail.id,
+      displayName,
+      version: detail.version,
+      flowId: flow.id,
+      manualFlowId: manualFlow.id,
+      flowActivityIds: flow.activityIds,
+      standaloneActivityIds: AF_STANDALONE_ACTIVITY_NAMES.map(
+        (name) => activityIdByName.get(name)!,
+      ),
+      itemIdsByActivityId,
+      ownerPrivateKey,
+      appletPublicKey: JSON.parse(encryption.publicKey),
+    });
+
+    await afApi.applets.deleteApplet(detail.id);
+  },
+});
+
+export { expect } from '@playwright/test';

--- a/tests/fixtures/af-session.fixture.ts
+++ b/tests/fixtures/af-session.fixture.ts
@@ -1,0 +1,103 @@
+import { devices, request, test as base } from '@playwright/test';
+
+import { runtimeConfig } from '../config';
+import { mockFeatureFlags, MockedFlagValues } from '../utils/feature-flags';
+import { performUiLogin } from '../utils/ui';
+
+// Each worker gets its own user, so logging in on one worker doesn't log out another.
+
+export type AfUser = {
+  id: string;
+  email: string;
+  password: string;
+  accessToken: string;
+};
+
+type AfSessionWorkerFixtures = {
+  afUser: AfUser;
+  afStorageState: string;
+};
+
+// Creates and logs in a fresh backend user; returns its identity + token.
+export const createTestUser = async (
+  namePrefix: string,
+  lastName = 'User',
+): Promise<AfUser> => {
+  const api = await request.newContext({ baseURL: runtimeConfig.apiBaseURL });
+  const email = `${namePrefix}-${Date.now()}-${Math.floor(Math.random() * 1e6)}@example.com`;
+  const password = 'AfResumeSuite123!';
+
+  const created = await api.post('/users', {
+    data: { email, firstName: 'AF', lastName, password },
+  });
+  if (!created.ok()) {
+    throw new Error(`Failed to create test user: ${created.status()} ${await created.text()}`);
+  }
+
+  const login = await api.post('/auth/login', { data: { email, password } });
+  if (!login.ok()) {
+    throw new Error(`Failed to log in test user: ${login.status()} ${await login.text()}`);
+  }
+  const result = (await login.json()).result;
+  await api.dispose();
+
+  return { id: result.user.id, email, password, accessToken: result.token.accessToken };
+};
+
+export const test = base.extend<object, AfSessionWorkerFixtures>({
+  afUser: [
+    async ({}, use, workerInfo) => {
+      await use(await createTestUser(`af-resume-w${workerInfo.workerIndex}`, `Worker${workerInfo.workerIndex}`));
+    },
+    { scope: 'worker' },
+  ],
+
+  afStorageState: [
+    async ({ browser, afUser }, use, workerInfo) => {
+      // Must use the same browser settings as the tests, or the saved login won't work.
+      const context = await browser.newContext({ ...devices['Desktop Chrome'] });
+      const page = await context.newPage();
+      await performUiLogin(page, `${runtimeConfig.baseURL}/login`, afUser.email, afUser.password);
+      await page.waitForURL(/protected/, { timeout: 30000 });
+
+      const path = `storage/.auth/af-resume-w${workerInfo.workerIndex}.json`;
+      await context.storageState({ path });
+      await context.close();
+      await use(path);
+    },
+    { scope: 'worker' },
+  ],
+
+  // Route every test context in the af-resume suite to the worker's session.
+  storageState: async ({ afStorageState }, use) => {
+    await use(afStorageState);
+  },
+});
+
+// Authenticated API request context acting as the worker user.
+export const afApiContext = async (afUser: AfUser) =>
+  await request.newContext({
+    baseURL: runtimeConfig.apiBaseURL,
+    extraHTTPHeaders: {
+      Authorization: `Bearer ${afUser.accessToken}`,
+      'Content-Type': 'application/json',
+    },
+  });
+
+// Opens a second logged-in browser, acting as another device for the same user.
+export const openWebDevice = async (
+  browser: import('@playwright/test').Browser,
+  afUser: AfUser,
+  options: { timezoneId?: string; flags?: MockedFlagValues } = {},
+) => {
+  const { flags, ...contextOptions } = options;
+  const context = await browser.newContext({ ...devices['Desktop Chrome'], ...contextOptions });
+  await mockFeatureFlags(context, flags);
+  const page = await context.newPage();
+  await performUiLogin(page, `${runtimeConfig.baseURL}/login`, afUser.email, afUser.password);
+  await page.waitForURL(/protected/, { timeout: 30000 });
+
+  return { context, page };
+};
+
+export { expect } from '@playwright/test';

--- a/tests/fixtures/af.fixtures.ts
+++ b/tests/fixtures/af.fixtures.ts
@@ -1,0 +1,26 @@
+import { mergeTests } from '@playwright/test';
+
+import { ActivityCardPage } from '../pages/activity-card.page';
+import { SurveyPage } from '../pages/survey.page';
+import { test as afAppletTest } from './af-applet.fixture';
+import { test as flagsTest } from './flags.fixture';
+import { test as pagesTest } from './pages.fixture';
+
+// One file that pulls together everything an af-resume spec needs.
+
+type AfPagesFixtures = {
+  cards: ActivityCardPage;
+  survey: SurveyPage;
+};
+
+export const test = mergeTests(pagesTest, flagsTest, afAppletTest).extend<AfPagesFixtures>({
+  cards: async ({ page }, use) => {
+    await use(new ActivityCardPage(page));
+  },
+
+  survey: async ({ page }, use) => {
+    await use(new SurveyPage(page));
+  },
+});
+
+export { expect } from '@playwright/test';

--- a/tests/fixtures/flags.fixture.ts
+++ b/tests/fixtures/flags.fixture.ts
@@ -1,0 +1,20 @@
+import { test as base } from '@playwright/test';
+
+import { AF_RESUME_ALL_APPLETS, mockFeatureFlags, MockedFlagValues } from '../utils/feature-flags';
+
+type FlagsFixtures = {
+  // Override with test.use({ mockedFlags: {...} }) to change flag values.
+  mockedFlags: MockedFlagValues;
+};
+
+export const test = base.extend<FlagsFixtures>({
+  mockedFlags: [AF_RESUME_ALL_APPLETS, { option: true }],
+
+  // Auto-install the LD mock on every context before the page loads.
+  context: async ({ context, mockedFlags }, use) => {
+    await mockFeatureFlags(context, mockedFlags);
+    await use(context);
+  },
+});
+
+export { expect } from '@playwright/test';

--- a/tests/pages/activity-card.page.ts
+++ b/tests/pages/activity-card.page.ts
@@ -1,0 +1,34 @@
+import { Locator, Page } from '@playwright/test';
+
+// Entity cards on the applet details page (src ActivityCard widgets).
+export class ActivityCardPage {
+  readonly page: Page;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  flowCard(name: string): Locator {
+    return this.page.getByTestId('flow-card').filter({ hasText: name });
+  }
+
+  activityCard(name: string): Locator {
+    return this.page.getByTestId('activity-card').filter({ hasText: name });
+  }
+
+  resumeButton(card: Locator): Locator {
+    return card.getByRole('button', { name: 'Resume', exact: true });
+  }
+
+  restartButton(card: Locator): Locator {
+    return card.getByRole('button', { name: /restart/i });
+  }
+
+  startButton(card: Locator): Locator {
+    return card.getByRole('button', { name: 'Start' });
+  }
+
+  progressText(card: Locator, completed: number, total: number): Locator {
+    return card.getByText(`${completed} of ${total} activities completed`);
+  }
+}

--- a/tests/pages/survey.page.ts
+++ b/tests/pages/survey.page.ts
@@ -1,0 +1,36 @@
+import { Locator, Page } from '@playwright/test';
+
+// Drives the assessment (PassSurvey) screens for the AF Resume test applet,
+// where every activity is a single one-question single-select.
+export class SurveyPage {
+  readonly startButton: Locator;
+  readonly nextButton: Locator;
+  readonly backButton: Locator;
+  readonly saveAndExitButton: Locator;
+  readonly submitPopupButton: Locator;
+  readonly firstOption: Locator;
+
+  constructor(readonly page: Page) {
+    this.startButton = page.getByRole('button', { name: 'Start' });
+    this.nextButton = page.getByRole('button', { name: 'Next' });
+    this.backButton = page.getByRole('button', { name: 'Back' });
+    this.saveAndExitButton = page.getByRole('button', { name: 'Save & Exit' });
+    this.submitPopupButton = page.getByTestId('popup-primary-button');
+    this.firstOption = page.getByText('Option 1', { exact: true });
+  }
+
+  // From an activity's welcome screen: answers its one question and submits.
+  async completeCurrentActivity(): Promise<void> {
+    await this.startButton.click();
+    await this.firstOption.click();
+    await this.nextButton.click();
+    await this.submitPopupButton.click();
+  }
+
+  // Completes the first `count` activities of the flow from its beginning.
+  async completeFlowActivities(count: number): Promise<void> {
+    for (let i = 0; i < count; i++) {
+      await this.completeCurrentActivity();
+    }
+  }
+}

--- a/tests/suites/af-resume/specs/cr1-server-progress-local-empty.spec.ts
+++ b/tests/suites/af-resume/specs/cr1-server-progress-local-empty.spec.ts
@@ -1,0 +1,124 @@
+import crypto from 'node:crypto';
+
+import { expect } from '@playwright/test';
+
+import { test } from '../../../fixtures/af.fixtures';
+import { openWebDevice } from '../../../fixtures/af-session.fixture';
+import { ActivityCardPage } from '../../../pages/activity-card.page';
+import {
+  AF_MANUAL_FLOW_NAME,
+  expectFlowResumeAt,
+  getFlowEvent,
+  openApplet,
+  resumeAndExpectActivity,
+  seedFlowProgress,
+  setupAssignedRespondent,
+} from '../support';
+
+// CR1: server already has progress (2/3), this browser has none. The card must offer Resume at step 3.
+test.describe('CR1: server in-progress, local empty', () => {
+  test('CR1.1: progress appears without a page refresh (client-side navigation)', {
+    tag: '@CR1.1',
+  }, async ({ afApplet, afApi, cards, page }) => {
+    // Seed progress on the server before this browser opens the applet.
+    await page.goto('/protected/applets');
+    await seedFlowProgress(afApi, afApplet, 2);
+
+    // Entering the applet is pure client-side navigation, not a reload.
+    await page.getByText(afApplet.displayName).click();
+    await expectFlowResumeAt(cards, 2);
+  });
+
+  test('CR1.2: progress appears after refreshing the home page', {
+    tag: '@CR1.2',
+  }, async ({ afApplet, afApi, cards, page }) => {
+    await page.goto('/protected/applets');
+    await seedFlowProgress(afApi, afApplet, 2);
+
+    await page.reload();
+    await page.getByText(afApplet.displayName).click();
+    await expectFlowResumeAt(cards, 2);
+  });
+
+  test('CR1.3: progress appears after refreshing the applet page and resumes at step 3', {
+    tag: '@CR1.3',
+  }, async ({ afApplet, afApi, cards, page }) => {
+    await openApplet(page, afApplet);
+    const { submitId } = await seedFlowProgress(afApi, afApplet, 2);
+
+    await page.reload();
+    await expectFlowResumeAt(cards, 2);
+
+    // Extra check here only: Resume lands on activity 3 and finishes the same submission.
+    await resumeAndExpectActivity(page, cards, 3);
+
+    const fromDate = new Date(Date.now() - 24 * 3600 * 1000).toISOString().slice(0, 10);
+    const completions = (
+      await afApi.answers.getCompletedEntities(afApplet.appletId, afApplet.version, fromDate)
+    ).result;
+    const ours = completions.activityFlows.filter(
+      (f: { submitId: string }) => f.submitId === submitId,
+    );
+    expect(ours.length).toBeGreaterThan(0);
+  });
+
+  test('CR1.4: progress appears after logging out and back in on the same device', {
+    tag: '@CR1.4',
+  }, async ({ afApplet, afApi, afUser, cards, page, loginPage }) => {
+    await seedFlowProgress(afApi, afApplet, 2);
+
+    // App-level logout, then a fresh login in the same browser context.
+    await page.goto('/protected/applets');
+    await page.getByRole('button', { name: /AF Worker/ }).click();
+    await page.getByText(/log ?out/i).click();
+    await expect(page).toHaveURL(/login/, { timeout: 10000 });
+
+    await loginPage.login(afUser.email, afUser.password);
+    await expect(page).toHaveURL(/protected/, { timeout: 15000 });
+
+    await page.getByText(afApplet.displayName).click();
+    await expectFlowResumeAt(cards, 2);
+  });
+
+  test('CR1.5: progress appears when logging in on a different device', {
+    tag: '@CR1.5',
+  }, async ({ afApplet, afApi, afUser, browser }) => {
+    await seedFlowProgress(afApi, afApplet, 2);
+
+    const device2 = await openWebDevice(browser, afUser);
+    try {
+      const cards2 = new ActivityCardPage(device2.page);
+      await openApplet(device2.page, afApplet);
+      await expectFlowResumeAt(cards2, 2);
+    } finally {
+      await device2.context.close();
+    }
+  });
+
+  // Uses a separate invited respondent, not self-assignment (self-assignment hits an unrelated app bug).
+  test('CR1.6: progress appears for a manually assigned flow', {
+    tag: '@CR1.6',
+  }, async ({ afApplet, afApi, browser }) => {
+    const respondent = await setupAssignedRespondent(afApi, afApplet, {
+      activityFlowId: afApplet.manualFlowId,
+    });
+
+    const flowEvent = await getFlowEvent(afApi, afApplet, afApplet.manualFlowId);
+    await respondent.answers.seedFlowProgress(afApplet, 2, {
+      submitId: crypto.randomUUID(),
+      flowId: afApplet.manualFlowId,
+      eventId: flowEvent.id,
+      eventVersion: flowEvent.version,
+      targetSubjectId: respondent.subjectId,
+    });
+
+    const device = await openWebDevice(browser, respondent.user);
+    try {
+      const respondentCards = new ActivityCardPage(device.page);
+      await openApplet(device.page, afApplet);
+      await expectFlowResumeAt(respondentCards, 2, AF_MANUAL_FLOW_NAME);
+    } finally {
+      await device.context.close();
+    }
+  });
+});

--- a/tests/suites/af-resume/specs/harness.spec.ts
+++ b/tests/suites/af-resume/specs/harness.spec.ts
@@ -1,0 +1,88 @@
+import { expect } from '@playwright/test';
+
+import { test } from '../../../fixtures/af.fixtures';
+import { getEntityProgress, getGroupProgress, clearAllLocalProgress } from '../../../utils/local-progress';
+
+// Checks that the af-resume test setup itself works, before real tests use it.
+test.describe('AF Resume harness', () => {
+  test('authenticated session survives navigation to the protected area', async ({ page }) => {
+    await page.goto('/protected/applets');
+    // The header shows the logged-in user's name only when /users/me succeeds.
+    await expect(page.getByRole('button', { name: /AF Worker/ })).toBeVisible({ timeout: 10000 });
+    await expect(page).toHaveURL(/.*\/protected\/applets/);
+  });
+
+  test('LaunchDarkly mock serves EnableFlowResume to the app', async ({ page }) => {
+    const ldResponse = page.waitForResponse(
+      (response) => response.url().includes('/sdk/eval'),
+      { timeout: 15000 },
+    );
+
+    await page.goto('/protected/applets');
+
+    const flags = (await (await ldResponse).json()) as Record<string, { value: unknown }>;
+    expect(flags.enableFlowResume.value).toEqual(['*']);
+  });
+
+  test('applet factory creates the AF Resume applet visible in the UI', async ({
+    afApplet,
+    page,
+  }) => {
+    expect(afApplet.flowActivityIds).toHaveLength(3);
+    expect(afApplet.standaloneActivityIds).toHaveLength(2);
+
+    await page.goto('/protected/applets');
+    await expect(page.getByText(afApplet.displayName)).toBeVisible({ timeout: 15000 });
+  });
+
+  test('event client can create and delete a scheduled event for the flow', async ({
+    afApplet,
+    afApi,
+  }) => {
+    const created = await afApi.events.createScheduledEvent(
+      afApplet.appletId,
+      { flowId: afApplet.flowId },
+      { type: 'DAILY' },
+    );
+    expect(created.result.id).toBeTruthy();
+
+    const events = await afApi.events.getEvents(afApplet.appletId);
+    const ids = events.result.map((e: { id: string }) => e.id);
+    expect(ids).toContain(created.result.id);
+
+    await afApi.events.deleteEvent(afApplet.appletId, created.result.id);
+  });
+
+  test('survey driver creates local progress the storage helpers can read and clear', async ({
+    afApplet,
+    afApi,
+    cards,
+    survey,
+    page,
+  }) => {
+    const events = await afApi.events.getEvents(afApplet.appletId);
+    const flowEvent = events.result.find(
+      (e: { flowId: string | null }) => e.flowId === afApplet.flowId,
+    );
+
+    await page.goto('/protected/applets');
+    await page.getByText(afApplet.displayName).click();
+    const startButton = cards.startButton(cards.flowCard('AF Resume Flow'));
+    // Retry the click: React may not have attached handlers on first paint.
+    await expect(async () => {
+      await startButton.click();
+      await expect(survey.saveAndExitButton).toBeVisible({ timeout: 2000 });
+    }).toPass({ timeout: 15000 });
+
+    // Finish activity 1; the flow advances to activity 2's welcome screen.
+    await survey.completeCurrentActivity();
+    await expect(page.getByText('Activity 2 • 1 Question')).toBeVisible({ timeout: 15000 });
+
+    const progress = await getEntityProgress(page, afApplet.flowId, flowEvent.id);
+    expect(progress, 'flow progress should be tracked locally').toBeTruthy();
+    expect(progress.type).toBeTruthy();
+
+    await clearAllLocalProgress(page);
+    expect(Object.keys(await getGroupProgress(page))).toHaveLength(0);
+  });
+});

--- a/tests/suites/af-resume/specs/seeding.spec.ts
+++ b/tests/suites/af-resume/specs/seeding.spec.ts
@@ -1,0 +1,47 @@
+import crypto from 'node:crypto';
+
+import { expect } from '@playwright/test';
+
+import { test } from '../../../fixtures/af.fixtures';
+
+// Proves that answers seeded through the API look the same as answers from a real device.
+test.describe('AF Resume answer seeding', () => {
+  test('API-seeded partial flow progress reaches the server and surfaces in the web UI', async ({
+    afApplet,
+    afApi,
+    page,
+  }) => {
+    // The backend auto-creates a default Always Available event per entity.
+    const events = await afApi.events.getEvents(afApplet.appletId);
+    const flowEvent = events.result.find(
+      (e: { flowId: string | null }) => e.flowId === afApplet.flowId,
+    );
+    expect(flowEvent, 'default AA event for the flow should exist').toBeTruthy();
+
+    // Seed 2 of 3 flow activities under one submission.
+    const submitId = crypto.randomUUID();
+    await afApi.answers.seedFlowProgress(afApplet, 2, {
+      submitId,
+      eventId: flowEvent.id,
+      eventVersion: flowEvent.version,
+    });
+
+    // Server view: the submission exists and is still in progress.
+    const fromDate = new Date(Date.now() - 24 * 3600 * 1000).toISOString().slice(0, 10);
+    const completions = (
+      await afApi.answers.getCompletedEntities(afApplet.appletId, afApplet.version, fromDate)
+    ).result;
+    const seeded = completions.activityFlows.filter(
+      (f: { submitId: string }) => f.submitId === submitId,
+    );
+    expect(seeded.length).toBeGreaterThan(0);
+    expect(seeded.some((f: { isFlowCompleted: boolean | null }) => f.isFlowCompleted)).toBe(false);
+
+    // Web view: the flow card shows seeded progress with Resume/Restart controls.
+    await page.goto('/protected/applets');
+    await page.getByText(afApplet.displayName).click();
+    await expect(page.getByText('2 of 3 activities completed')).toBeVisible({ timeout: 15000 });
+    await expect(page.getByRole('button', { name: 'Resume', exact: true })).toBeVisible();
+    await expect(page.getByRole('button', { name: /restart/i })).toBeVisible();
+  });
+});

--- a/tests/suites/af-resume/support.ts
+++ b/tests/suites/af-resume/support.ts
@@ -1,0 +1,115 @@
+import crypto from 'node:crypto';
+
+import { Page, expect } from '@playwright/test';
+
+import { AfApi, AfApplet } from '../../fixtures/af-applet.fixture';
+import { AfUser, afApiContext, createTestUser } from '../../fixtures/af-session.fixture';
+import { ActivityCardPage } from '../../pages/activity-card.page';
+import { AnswerAPI } from '../../utils/api-client/answer-api';
+import { AssignmentAPI } from '../../utils/api-client/assignment-api';
+import { InvitationAPI } from '../../utils/api-client/invitation-api';
+import { AF_FLOW_NAME } from '../../utils/data/af-resume-applet';
+import { getPrivateKey } from '../../utils/encryption';
+
+export { AF_FLOW_NAME, AF_MANUAL_FLOW_NAME } from '../../utils/data/af-resume-applet';
+
+export const FLOW_TOTAL_ACTIVITIES = 3;
+
+export const getFlowEvent = async (afApi: AfApi, afApplet: AfApplet, flowId?: string) => {
+  const events = await afApi.events.getEvents(afApplet.appletId);
+  const flowEvent = events.result.find(
+    (e: { flowId: string | null }) => e.flowId === (flowId ?? afApplet.flowId),
+  );
+  expect(flowEvent, 'event for the flow should exist').toBeTruthy();
+
+  return flowEvent as { id: string; version: string };
+};
+
+// Seeds partial flow progress directly on the server (N of 3 activities done).
+export const seedFlowProgress = async (
+  afApi: AfApi,
+  afApplet: AfApplet,
+  completedActivities: number,
+  options: { flowId?: string; endTime?: number; targetSubjectId?: string } = {},
+) => {
+  const flowEvent = await getFlowEvent(afApi, afApplet, options.flowId);
+  const submitId = crypto.randomUUID();
+  await afApi.answers.seedFlowProgress(afApplet, completedActivities, {
+    submitId,
+    flowId: options.flowId,
+    eventId: flowEvent.id,
+    eventVersion: flowEvent.version,
+    endTime: options.endTime,
+    targetSubjectId: options.targetSubjectId,
+  });
+
+  return { submitId, flowEvent };
+};
+
+export type AssignedRespondent = {
+  user: AfUser;
+  subjectId: string;
+  // Clients authenticated as the respondent.
+  answers: AnswerAPI;
+};
+
+// Invites a separate user, has them accept, then assigns the flow to them.
+export const setupAssignedRespondent = async (
+  ownerApi: AfApi,
+  afApplet: AfApplet,
+  target: { activityFlowId?: string; activityId?: string },
+): Promise<AssignedRespondent> => {
+  const user = await createTestUser('af-respondent');
+  const key = await ownerApi.invitations.inviteRespondent(afApplet.appletId, {
+    email: user.email,
+    firstName: 'AF',
+    lastName: 'Respondent',
+  });
+
+  const respondentContext = await afApiContext(user);
+  await new InvitationAPI(respondentContext).acceptInvite(key);
+  const subjectId = await new AssignmentAPI(respondentContext).getMySubjectId(afApplet.appletId);
+
+  await ownerApi.assignments.createAssignments(afApplet.appletId, [
+    { ...target, respondentSubjectId: subjectId, targetSubjectId: subjectId },
+  ]);
+
+  const answers = new AnswerAPI(respondentContext);
+  answers.setRespondent(getPrivateKey({ userId: user.id, email: user.email, password: user.password }));
+
+  return { user, subjectId, answers };
+};
+
+// Opens the applet details page from the home screen (client-side navigation).
+export const openApplet = async (page: Page, afApplet: AfApplet) => {
+  await page.goto('/protected/applets');
+  await page.getByText(afApplet.displayName).click();
+  await expect(page.getByRole('heading', { name: 'Available' })).toBeVisible({ timeout: 15000 });
+};
+
+// Asserts the flow card offers Resume at `completed` of 3 progress.
+export const expectFlowResumeAt = async (
+  cards: ActivityCardPage,
+  completed: number,
+  flowName: string = AF_FLOW_NAME,
+) => {
+  const card = cards.flowCard(flowName);
+  await expect(cards.progressText(card, completed, FLOW_TOTAL_ACTIVITIES)).toBeVisible({
+    timeout: 15000,
+  });
+  await expect(cards.resumeButton(card)).toBeVisible();
+  await expect(cards.restartButton(card)).toBeVisible();
+};
+
+// Clicks Resume and verifies the survey opens on the expected flow activity.
+export const resumeAndExpectActivity = async (
+  page: Page,
+  cards: ActivityCardPage,
+  activityNumber: number,
+  flowName: string = AF_FLOW_NAME,
+) => {
+  await cards.resumeButton(cards.flowCard(flowName)).click();
+  await expect(page.getByText(`Activity ${activityNumber} • 1 Question`)).toBeVisible({
+    timeout: 15000,
+  });
+};

--- a/tests/utils/api-client/answer-api.ts
+++ b/tests/utils/api-client/answer-api.ts
@@ -1,0 +1,127 @@
+import { encryptData, getAesKey, getPublicKey } from '../encryption';
+import { CuriousApi } from './api';
+
+// Seeds server-side answer state via POST /answers, mirroring the payload the
+// web app builds in src/features/PassSurvey/model/AnswersConstructService.ts.
+
+// Only the applet fields this file needs (kept local so this file has no
+// import from the fixtures folder, which itself imports this class).
+type SeedableApplet = {
+  appletId: string;
+  version: string;
+  flowId: string;
+  flowActivityIds: string[];
+  itemIdsByActivityId: Record<string, string[]>;
+  appletPublicKey: number[];
+};
+
+export type SeedOptions = {
+  submitId: string;
+  eventId: string;
+  eventVersion?: string;
+  targetSubjectId?: string;
+  // Epoch ms; defaults keep start < end < now.
+  startTime?: number;
+  endTime?: number;
+};
+
+const pad = (n: number) => String(n).padStart(2, '0');
+const toLocalDate = (d: Date) => `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+const toLocalTime = (d: Date) => `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+
+export class AnswerAPI extends CuriousApi {
+  // Respondent key material, derived once via setRespondent().
+  private privateKey: number[] = [];
+
+  setRespondent(privateKey: number[]) {
+    this.privateKey = privateKey;
+  }
+
+  // Submits one activity answer; flow progress = repeated calls sharing submitId.
+  async submitActivityAnswer(
+    applet: SeedableApplet,
+    activityId: string,
+    options: SeedOptions & { flowId?: string; isFlowCompleted?: boolean },
+  ): Promise<void> {
+    const aesKey = getAesKey(this.privateKey, applet.appletPublicKey);
+    const endTime = options.endTime ?? Date.now();
+    const endDate = new Date(endTime);
+
+    const payload = {
+      appletId: applet.appletId,
+      activityId,
+      flowId: options.flowId ?? null,
+      submitId: options.submitId,
+      version: applet.version,
+      createdAt: endTime,
+      isFlowCompleted: options.flowId ? (options.isFlowCompleted ?? false) : true,
+      targetSubjectId: options.targetSubjectId,
+      answer: {
+        answer: encryptData(JSON.stringify([{ value: 0 }]), aesKey),
+        itemIds: applet.itemIdsByActivityId[activityId],
+        events: encryptData('[]', aesKey),
+        userPublicKey: JSON.stringify(getPublicKey(this.privateKey)),
+        startTime: options.startTime ?? endTime - 60_000,
+        endTime,
+        identifier: null,
+        scheduledEventId: options.eventId,
+        localEndDate: toLocalDate(endDate),
+        localEndTime: toLocalTime(endDate),
+      },
+      alerts: [],
+      client: { appId: 'mindlogger-web', appVersion: 'af-resume-suite', width: 1920, height: 1080 },
+      ...(options.eventVersion && { eventHistoryId: `${options.eventId}_${options.eventVersion}` }),
+    };
+
+    const response = await this.apiContext.post('/answers', { data: payload });
+    if (!response.ok()) {
+      throw new Error(`Failed to submit answer: ${response.status()} ${await response.text()}`);
+    }
+  }
+
+  // Seeds partial flow progress: first `completedActivities` of the flow answered.
+  async seedFlowProgress(
+    applet: SeedableApplet,
+    completedActivities: number,
+    options: SeedOptions & { flowId?: string },
+  ): Promise<void> {
+    for (let i = 0; i < completedActivities; i++) {
+      await this.submitActivityAnswer(applet, applet.flowActivityIds[i], {
+        ...options,
+        flowId: options.flowId ?? applet.flowId,
+        isFlowCompleted: false,
+        endTime: (options.endTime ?? Date.now()) - (completedActivities - 1 - i) * 1000,
+      });
+    }
+  }
+
+  // Completes the whole flow under one submitId.
+  async completeFlow(
+    applet: SeedableApplet,
+    options: SeedOptions & { flowId?: string },
+  ): Promise<void> {
+    for (let i = 0; i < applet.flowActivityIds.length; i++) {
+      const isLast = i === applet.flowActivityIds.length - 1;
+      await this.submitActivityAnswer(applet, applet.flowActivityIds[i], {
+        ...options,
+        flowId: options.flowId ?? applet.flowId,
+        isFlowCompleted: isLast,
+      });
+    }
+  }
+
+  async getCompletedEntities(
+    appletId: string,
+    version: string,
+    fromDate: string,
+    includeInProgress = true,
+  ): Promise<any> {
+    const response = await this.apiContext.get(`/answers/applet/${appletId}/completions`, {
+      params: { version, fromDate, includeInProgress: String(includeInProgress) },
+    });
+    if (!response.ok()) {
+      throw new Error(`Failed to fetch completions: ${response.status()} ${await response.text()}`);
+    }
+    return await response.json();
+  }
+}

--- a/tests/utils/api-client/applet-api.ts
+++ b/tests/utils/api-client/applet-api.ts
@@ -29,6 +29,39 @@ export class AppletAPI extends CuriousApi {
         return await response.json();
     }
 
+    // Applet creation lives under the workspace router on the backend.
+    async createWorkspaceApplet(ownerId: string, appletData: object): Promise<any> {
+        const response = await this.apiContext.post(`/workspaces/${ownerId}/applets`, { data: appletData });
+        if (!response.ok()) {
+            throw new Error(`Failed to create applet: ${response.status()} ${await response.text()}`);
+        }
+        return await response.json();
+    }
+
+    async getAppletDetail(appletId: string): Promise<any> {
+        const response = await this.apiContext.get(`/applets/${appletId}`);
+        if (!response.ok()) {
+            throw new Error(`Failed to fetch applet: ${response.status()} ${await response.text()}`);
+        }
+        return await response.json();
+    }
+
+    // Activity detail (incl. items) is a separate endpoint from applet detail.
+    async getActivity(activityId: string): Promise<any> {
+        const response = await this.apiContext.get(`/activities/${activityId}`);
+        if (!response.ok()) {
+            throw new Error(`Failed to fetch activity: ${response.status()} ${await response.text()}`);
+        }
+        return await response.json();
+    }
+
+    async deleteApplet(appletId: string): Promise<void> {
+        const response = await this.apiContext.delete(`/applets/${appletId}`);
+        if (!response.ok()) {
+            throw new Error(`Failed to delete applet: ${response.status()} ${await response.text()}`);
+        }
+    }
+
     async createManagerInvite(inviteData: { email: string; firstName: string; lastName: string; language: string; role: string; workspacePrefix: string; title: string; }, appletID: string): Promise<any> {
         const response = await this.apiContext.post(`/invitations/${appletID}/managers`, { data: inviteData });
         console.log(response);

--- a/tests/utils/api-client/assignment-api.ts
+++ b/tests/utils/api-client/assignment-api.ts
@@ -1,0 +1,49 @@
+import { CuriousApi } from './api';
+
+export type AssignmentCreate = {
+  activityId?: string;
+  activityFlowId?: string;
+  respondentSubjectId: string;
+  targetSubjectId: string;
+};
+
+export class AssignmentAPI extends CuriousApi {
+  // The caller's own subject in an applet (respondent identity).
+  async getMySubjectId(appletId: string): Promise<string> {
+    const response = await this.apiContext.get(`/users/me/subjects/${appletId}`);
+    if (!response.ok()) {
+      throw new Error(`Failed to fetch my subject: ${response.status()} ${await response.text()}`);
+    }
+    return (await response.json()).result.id;
+  }
+
+  async createAssignments(appletId: string, assignments: AssignmentCreate[]): Promise<any> {
+    // This endpoint expects snake_case (no camelCase aliasing on the backend model).
+    const response = await this.apiContext.post(`/assignments/applet/${appletId}`, {
+      data: {
+        assignments: assignments.map((a) => ({
+          activity_id: a.activityId ?? null,
+          activity_flow_id: a.activityFlowId ?? null,
+          respondent_subject_id: a.respondentSubjectId,
+          target_subject_id: a.targetSubjectId,
+        })),
+      },
+    });
+    if (!response.ok()) {
+      throw new Error(`Failed to create assignments: ${response.status()} ${await response.text()}`);
+    }
+    return await response.json();
+  }
+
+  // Convenience: manually assign the flow/activity to the caller (self-report).
+  async assignToSelf(
+    appletId: string,
+    target: { activityId?: string; activityFlowId?: string },
+  ): Promise<string> {
+    const subjectId = await this.getMySubjectId(appletId);
+    await this.createAssignments(appletId, [
+      { ...target, respondentSubjectId: subjectId, targetSubjectId: subjectId },
+    ]);
+    return subjectId;
+  }
+}

--- a/tests/utils/api-client/event-api.ts
+++ b/tests/utils/api-client/event-api.ts
@@ -1,0 +1,122 @@
+import { CuriousApi } from './api';
+
+// Client for the backend schedule API (/applets/{appletId}/events).
+
+export type PeriodicityType = 'ALWAYS' | 'ONCE' | 'DAILY' | 'WEEKLY' | 'WEEKDAYS' | 'MONTHLY';
+
+// Exactly one of activityId / flowId must be set.
+export type EventTarget = {
+  activityId?: string;
+  flowId?: string;
+  respondentId?: string;
+};
+
+export type ScheduledEventOptions = {
+  type?: Exclude<PeriodicityType, 'ALWAYS'>;
+  // Times are HH:MM:SS strings; dates are YYYY-MM-DD.
+  startTime?: string;
+  endTime?: string;
+  startDate?: string;
+  endDate?: string;
+  selectedDate?: string;
+  accessBeforeSchedule?: boolean;
+  oneTimeCompletion?: boolean;
+  // timerType IDLE with timer 'HH:MM:SS' drives the idle-timeout cases.
+  timerType?: 'NOT_SET' | 'TIMER' | 'IDLE';
+  timer?: string;
+};
+
+const isoDate = (offsetDays = 0): string => {
+  const d = new Date();
+  d.setDate(d.getDate() + offsetDays);
+  return d.toISOString().slice(0, 10);
+};
+
+export class EventAPI extends CuriousApi {
+  async getEvents(appletId: string): Promise<any> {
+    const response = await this.apiContext.get(`/applets/${appletId}/events`);
+    if (!response.ok()) {
+      throw new Error(`Failed to fetch events: ${response.status()} ${await response.text()}`);
+    }
+    return await response.json();
+  }
+
+  async createAlwaysAvailableEvent(
+    appletId: string,
+    target: EventTarget,
+    { oneTimeCompletion = false }: { oneTimeCompletion?: boolean } = {},
+  ): Promise<any> {
+    return this.createEvent(appletId, {
+      ...target,
+      periodicity: { type: 'ALWAYS' },
+      oneTimeCompletion,
+      timerType: 'NOT_SET',
+    });
+  }
+
+  async createScheduledEvent(
+    appletId: string,
+    target: EventTarget,
+    options: ScheduledEventOptions = {},
+  ): Promise<any> {
+    const {
+      type = 'DAILY',
+      startTime = '00:00:00',
+      endTime = '23:59:00',
+      startDate = isoDate(-1),
+      endDate = isoDate(365),
+      selectedDate,
+      accessBeforeSchedule = false,
+      timerType = 'NOT_SET',
+      timer,
+    } = options;
+
+    return this.createEvent(appletId, {
+      ...target,
+      periodicity: {
+        type,
+        // ONCE uses selectedDate only; recurring types use the date range.
+        ...(type === 'ONCE'
+          ? { selectedDate: selectedDate ?? isoDate() }
+          : { startDate, endDate, ...(type === 'MONTHLY' && { selectedDate: selectedDate ?? isoDate() }) }),
+      },
+      startTime,
+      endTime,
+      accessBeforeSchedule,
+      timerType,
+      ...(timer && { timer }),
+    });
+  }
+
+  async createEvent(appletId: string, payload: object): Promise<any> {
+    const response = await this.apiContext.post(`/applets/${appletId}/events`, { data: payload });
+    if (!response.ok()) {
+      throw new Error(`Failed to create event: ${response.status()} ${await response.text()}`);
+    }
+    return await response.json();
+  }
+
+  async updateEvent(appletId: string, eventId: string, payload: object): Promise<any> {
+    const response = await this.apiContext.put(`/applets/${appletId}/events/${eventId}`, {
+      data: payload,
+    });
+    if (!response.ok()) {
+      throw new Error(`Failed to update event: ${response.status()} ${await response.text()}`);
+    }
+    return await response.json();
+  }
+
+  async deleteEvent(appletId: string, eventId: string): Promise<void> {
+    const response = await this.apiContext.delete(`/applets/${appletId}/events/${eventId}`);
+    if (!response.ok()) {
+      throw new Error(`Failed to delete event: ${response.status()} ${await response.text()}`);
+    }
+  }
+
+  async deleteAllEvents(appletId: string): Promise<void> {
+    const response = await this.apiContext.delete(`/applets/${appletId}/events`);
+    if (!response.ok()) {
+      throw new Error(`Failed to delete events: ${response.status()} ${await response.text()}`);
+    }
+  }
+}

--- a/tests/utils/api-client/invitation-api.ts
+++ b/tests/utils/api-client/invitation-api.ts
@@ -1,0 +1,33 @@
+import crypto from 'node:crypto';
+
+import { CuriousApi } from './api';
+
+export class InvitationAPI extends CuriousApi {
+  // Owner invites a user as respondent; returns the invitation key.
+  async inviteRespondent(
+    appletId: string,
+    invitee: { email: string; firstName: string; lastName: string },
+  ): Promise<string> {
+    const response = await this.apiContext.post(`/invitations/${appletId}/respondent`, {
+      data: {
+        email: invitee.email,
+        firstName: invitee.firstName,
+        lastName: invitee.lastName,
+        language: 'en',
+        secretUserId: crypto.randomUUID(),
+      },
+    });
+    if (!response.ok()) {
+      throw new Error(`Failed to invite respondent: ${response.status()} ${await response.text()}`);
+    }
+    return (await response.json()).result.key;
+  }
+
+  // Called with the invitee's own auth context.
+  async acceptInvite(key: string): Promise<void> {
+    const response = await this.apiContext.post(`/invitations/${key}/accept`);
+    if (!response.ok()) {
+      throw new Error(`Failed to accept invite: ${response.status()} ${await response.text()}`);
+    }
+  }
+}

--- a/tests/utils/api-client/user-api.ts
+++ b/tests/utils/api-client/user-api.ts
@@ -68,6 +68,15 @@ export class UserAPI extends CuriousApi {
     }
   }
 
+  async getMe(): Promise<{ result: { id: string; email: string } }> {
+    const response = await this.apiContext.get('/users/me');
+
+    if (!response.ok()) {
+      throw new Error(`Failed to fetch current user: ${response.status()} ${await response.text()}`);
+    }
+    return await response.json();
+  }
+
   async dispose() {
     try {
       await this.apiContext.dispose();

--- a/tests/utils/data/af-resume-applet.ts
+++ b/tests/utils/data/af-resume-applet.ts
@@ -1,0 +1,105 @@
+import crypto from 'node:crypto';
+
+import { AppletEncryption } from '../encryption';
+
+// Builders for the AF Resume (M2-8431) test applet:
+// one flow of 3 single-select activities + 2 standalone activities.
+
+export const AF_FLOW_NAME = 'AF Resume Flow';
+// Same activities, but autoAssign=false: only visible once manually assigned.
+export const AF_MANUAL_FLOW_NAME = 'AF Manual Flow';
+export const AF_FLOW_ACTIVITY_NAMES = ['AF Activity 1', 'AF Activity 2', 'AF Activity 3'];
+export const AF_STANDALONE_ACTIVITY_NAMES = ['AF Standalone 1', 'AF Standalone 2'];
+
+const buildSingleSelectItem = (name: string, question: string) => ({
+  responseType: 'singleSelect',
+  name,
+  question: { en: question },
+  config: {
+    removeBackButton: false,
+    skippableItem: false,
+    randomizeOptions: false,
+    addScores: false,
+    setAlerts: false,
+    addTooltip: false,
+    setPalette: false,
+    timer: 0,
+    additionalResponseOption: { textInputOption: false, textInputRequired: false },
+    portraitLayout: false,
+    autoAdvance: false,
+    responseDataIdentifier: false,
+  },
+  isHidden: false,
+  allowEdit: true,
+  responseValues: {
+    options: [
+      { id: crypto.randomUUID(), text: 'Option 1', isHidden: false, value: 0 },
+      { id: crypto.randomUUID(), text: 'Option 2', isHidden: false, value: 1 },
+    ],
+  },
+});
+
+const buildActivity = (name: string, key: string) => ({
+  name,
+  description: { en: name },
+  showAllAtOnce: false,
+  isSkippable: false,
+  responseIsEditable: true,
+  isHidden: false,
+  autoAssign: true,
+  isReviewable: false,
+  items: [buildSingleSelectItem(`${name} Item`, `${name} question`)],
+  scoresAndReports: { generateReport: false, reports: [], showScoreSummary: false },
+  key,
+  reportIncludedItemName: '',
+});
+
+export const buildAfResumeAppletPayload = ({
+  displayName,
+  encryption,
+}: {
+  displayName: string;
+  encryption: AppletEncryption;
+}) => {
+  const flowActivityKeys = AF_FLOW_ACTIVITY_NAMES.map(() => crypto.randomUUID());
+  const standaloneActivityKeys = AF_STANDALONE_ACTIVITY_NAMES.map(() => crypto.randomUUID());
+
+  return {
+    displayName,
+    description: { en: 'AF Resume (M2-8431) automated test applet' },
+    themeId: null,
+    about: { en: '' },
+    image: '',
+    watermark: '',
+    activities: [
+      ...AF_FLOW_ACTIVITY_NAMES.map((name, i) => buildActivity(name, flowActivityKeys[i])),
+      ...AF_STANDALONE_ACTIVITY_NAMES.map((name, i) =>
+        buildActivity(name, standaloneActivityKeys[i]),
+      ),
+    ],
+    activityFlows: [
+      {
+        name: AF_FLOW_NAME,
+        description: { en: 'Three-activity flow for resume scenarios' },
+        isSingleReport: false,
+        hideBadge: false,
+        isHidden: false,
+        autoAssign: true,
+        items: flowActivityKeys.map((activityKey) => ({ activityKey })),
+      },
+      {
+        name: AF_MANUAL_FLOW_NAME,
+        description: { en: 'Manually assigned flow for resume scenarios' },
+        isSingleReport: false,
+        hideBadge: false,
+        isHidden: false,
+        autoAssign: false,
+        items: flowActivityKeys.map((activityKey) => ({ activityKey })),
+      },
+    ],
+    reportEmailBody: 'Please see the report attached to this email.',
+    streamIpAddress: null,
+    streamPort: null,
+    encryption,
+  };
+};

--- a/tests/utils/encryption.ts
+++ b/tests/utils/encryption.ts
@@ -1,0 +1,64 @@
+import { Buffer } from 'buffer';
+import crypto from 'node:crypto';
+
+// Copied from src/shared/utils/encryption (that version needs import.meta.env, which isn't available here).
+const IV_LENGTH = 16;
+
+// Public numbers used to build the encryption keys (not secret), copied from api-client/applet-api.ts.
+// prettier-ignore
+export const APPLET_PRIME: number[] = [148,187,155,90,57,66,144,3,154,113,206,8,135,246,49,190,183,47,52,148,8,73,234,204,210,211,80,234,245,125,69,247,156,15,20,218,136,226,167,14,47,135,101,213,192,25,237,113,187,103,7,28,249,119,213,91,251,132,152,74,168,226,116,182,197,242,230,164,138,2,10,165,175,236,34,124,33,126,240,207,161,211,50,136,184,165,168,33,187,35,184,198,52,251,14,217,188,249,68,18,96,37,102,82,219,233,0,147,37,202,223,200,15,209,242,17,196,110,125,146,117,131,247,37,73,232,101,115];
+export const APPLET_BASE: number[] = [2];
+
+type Credentials = { userId: string; email: string; password: string };
+
+export const getPrivateKey = ({ userId, email, password }: Credentials): number[] => {
+  const key1 = crypto
+    .createHash('sha512')
+    .update(password + email)
+    .digest();
+  const key2 = crypto
+    .createHash('sha512')
+    .update(userId + email)
+    .digest();
+
+  return Array.from(Buffer.concat([Buffer.from(key1), Buffer.from(key2)]));
+};
+
+export const getPublicKey = (privateKey: number[]): number[] => {
+  const key = crypto.createDiffieHellman(Buffer.from(APPLET_PRIME), Buffer.from(APPLET_BASE));
+  key.setPrivateKey(Buffer.from(privateKey));
+  key.generateKeys();
+
+  return Array.from(key.getPublicKey());
+};
+
+export const getAesKey = (userPrivateKey: number[], appletPublicKey: number[]): number[] => {
+  const key = crypto.createDiffieHellman(Buffer.from(APPLET_PRIME), Buffer.from(APPLET_BASE));
+  key.setPrivateKey(Buffer.from(userPrivateKey));
+  const secretKey = key.computeSecret(Buffer.from(appletPublicKey));
+
+  return Array.from(crypto.createHash('sha256').update(secretKey).digest());
+};
+
+export const encryptData = (text: string, key: number[]): string => {
+  const iv = crypto.randomBytes(IV_LENGTH);
+  const cipher = crypto.createCipheriv('aes-256-cbc', Buffer.from(key), iv);
+  const encrypted = Buffer.concat([cipher.update(text), cipher.final()]);
+
+  return `${iv.toString('hex')}:${encrypted.toString('hex')}`;
+};
+
+export type AppletEncryption = {
+  publicKey: string;
+  prime: string;
+  base: string;
+  accountId: string;
+};
+
+// Builds the encryption block an applet needs, from the owner's login info.
+export const buildAppletEncryption = (owner: Credentials): AppletEncryption => ({
+  publicKey: JSON.stringify(getPublicKey(getPrivateKey(owner))),
+  prime: JSON.stringify(APPLET_PRIME),
+  base: JSON.stringify(APPLET_BASE),
+  accountId: owner.userId,
+});

--- a/tests/utils/feature-flags.ts
+++ b/tests/utils/feature-flags.ts
@@ -1,0 +1,51 @@
+import { BrowserContext, Page } from '@playwright/test';
+
+// Flag keys as the app reads them from useFlags() (already camelCased).
+export type MockedFlagValues = Record<string, unknown>;
+
+export const AF_RESUME_ALL_APPLETS: MockedFlagValues = {
+  enableFlowResume: ['*'],
+};
+
+const toEvalxBody = (flags: MockedFlagValues) =>
+  JSON.stringify(
+    Object.fromEntries(
+      Object.entries(flags).map(([key, value], index) => [
+        key,
+        { value, version: 1, variation: index, trackEvents: false },
+      ]),
+    ),
+  );
+
+// Serves mocked LaunchDarkly flags for a page/context. Install before navigation.
+export const mockFeatureFlags = async (
+  target: Page | BrowserContext,
+  flags: MockedFlagValues = AF_RESUME_ALL_APPLETS,
+): Promise<void> => {
+  await target.route('**/*.launchdarkly.com/**', async (route) => {
+    const url = route.request().url();
+
+    // Polling endpoint: answer with the mocked flags.
+    if (url.includes('/sdk/evalx/') || url.includes('/sdk/eval/')) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: toEvalxBody(flags),
+      });
+      return;
+    }
+
+    // Streaming: reply once with the flags so the SDK stops retrying.
+    if (url.includes('clientstream')) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'text/event-stream',
+        body: `retry: 3600000\nevent: put\ndata: ${toEvalxBody(flags)}\n\n`,
+      });
+      return;
+    }
+
+    // Event uploads etc: succeed silently.
+    await route.fulfill({ status: 202, contentType: 'application/json', body: '{}' });
+  });
+};

--- a/tests/utils/local-progress.ts
+++ b/tests/utils/local-progress.ts
@@ -1,0 +1,63 @@
+import { Page } from '@playwright/test';
+
+// Helpers over the app's redux-persist state in localStorage ('persist:root').
+// Group progress keys are `${entityId}/${eventId}` (src/abstract/lib/getProgressId.ts).
+
+export const getGroupProgress = async (page: Page): Promise<Record<string, any>> =>
+  await page.evaluate(() => {
+    const raw = localStorage.getItem('persist:root');
+    if (!raw) return {};
+    const applets = JSON.parse(JSON.parse(raw).applets ?? '{}');
+    return applets.groupProgress ?? {};
+  });
+
+export const getEntityProgress = async (
+  page: Page,
+  entityId: string,
+  eventId: string,
+): Promise<any | undefined> => (await getGroupProgress(page))[`${entityId}/${eventId}`];
+
+const writeApplets = async (page: Page, mutate: string, arg: unknown): Promise<void> => {
+  await page.evaluate(
+    ([mutateKey, value]) => {
+      const raw = localStorage.getItem('persist:root');
+      if (!raw) return;
+      const root = JSON.parse(raw);
+      const applets = JSON.parse(root.applets ?? '{}');
+      applets.groupProgress = applets.groupProgress ?? {};
+
+      if (mutateKey === 'clear') {
+        applets.groupProgress = {};
+        applets.progress = {};
+      } else if (mutateKey === 'set') {
+        const { key, progress } = value as { key: string; progress: unknown };
+        applets.groupProgress[key] = progress;
+      } else if (mutateKey === 'delete') {
+        delete applets.groupProgress[value as string];
+      }
+
+      root.applets = JSON.stringify(applets);
+      localStorage.setItem('persist:root', JSON.stringify(root));
+    },
+    [mutate, arg] as const,
+  );
+};
+
+// Wipes all local assessment progress; takes effect after the page reloads.
+export const clearAllLocalProgress = async (page: Page): Promise<void> =>
+  await writeApplets(page, 'clear', null);
+
+// Overwrites one entity's saved progress (e.g. to fake old/stale data).
+export const setEntityProgress = async (
+  page: Page,
+  entityId: string,
+  eventId: string,
+  progress: unknown,
+): Promise<void> =>
+  await writeApplets(page, 'set', { key: `${entityId}/${eventId}`, progress });
+
+export const deleteEntityProgress = async (
+  page: Page,
+  entityId: string,
+  eventId: string,
+): Promise<void> => await writeApplets(page, 'delete', `${entityId}/${eventId}`);


### PR DESCRIPTION
- [x] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [ ] OSS packages added to Curious open source credit page

### 📝 Description

🔗 [Jira Ticket M2-11026](https://mindlogger.atlassian.net/browse/M2-11026)

Sets up an automated Playwright suite for the AF Resume regression cases and
automates the first group: CR1 (server has in-progress flow, this device has no
local progress).

Changes include:

- New `af-resume` Playwright project + `test:af-resume` script
- Test harness: mocked `EnableFlowResume` flag, a fresh test applet per test
  (with a manually-assigned twin flow), and API clients to seed flow progress
  directly on the server
- CR1.1–CR1.6 specs: no refresh, refresh home, refresh applet, logout/login,
  different device, manually assigned flow
- Wired into CI to run on every PR (non-blocking for now, since coverage is
  still partial)

Test-only - no production code changes.

### 🪤 Peer Testing

**Requires `yarn install`**

- Run `yarn test:af-resume` against a running web app + backend.

    **Expected outcome:** All 6 CR1 cases pass (plus the harness/seeding checks).

