### PR TITLE
feat: Always render single/multi selection options vertically (M2-10899)

### DIFF
--- a/src/entities/activity/ui/items/CheckboxItem/RegularGrid.tsx
+++ b/src/entities/activity/ui/items/CheckboxItem/RegularGrid.tsx
@@ -1,10 +1,7 @@
-import { useMemo } from 'react';
-
 import { RegularCheckboxOption } from './RegularCheckboxOption';
 import { CheckboxItem } from '../../../lib/types/item';
 
 import { Box } from '~/shared/ui';
-import { splitList, useCustomMediaQuery } from '~/shared/utils';
 
 type Props = {
   options: CheckboxItem['responseValues']['options'];
@@ -24,61 +21,29 @@ export const RegularGrid = ({
   options,
   itemId,
 }: Props) => {
-  const { lessThanSM } = useCustomMediaQuery();
-
-  const [evenColumn, oddColumn] = useMemo(() => {
-    return splitList(options);
-  }, [options]);
-
   return (
-    <Box display="flex" flex={1} gap="16px" flexDirection={lessThanSM ? 'column' : 'row'}>
-      <Box display="flex" flex={1} gap="16px" flexDirection="column">
-        {evenColumn.map((option) => {
-          const isChecked = values.includes(String(option.value));
-          const isNoneAbove = option.isNoneAbove;
+    <Box display="flex" flex={1} gap="16px" flexDirection="column">
+      {options.map((option) => {
+        const isChecked = values.includes(String(option.value));
+        const isNoneAbove = option.isNoneAbove;
 
-          return (
-            <RegularCheckboxOption
-              key={option.id}
-              id={option.id}
-              name={itemId}
-              value={option.value}
-              label={option.text}
-              onChange={() => onValueChange(String(option.value), isNoneAbove)}
-              description={option.tooltip}
-              image={option.image}
-              disabled={isDisabled}
-              defaultChecked={isChecked}
-              color={option.color}
-              replaceText={replaceText}
-            />
-          );
-        })}
-      </Box>
-
-      <Box display="flex" flex={1} gap="16px" flexDirection="column">
-        {oddColumn.map((option) => {
-          const isChecked = values.includes(String(option.value));
-          const isNoneAbove = option.isNoneAbove;
-
-          return (
-            <RegularCheckboxOption
-              key={option.id}
-              id={option.id}
-              name={itemId}
-              value={option.value}
-              label={option.text}
-              onChange={() => onValueChange(String(option.value), isNoneAbove)}
-              description={option.tooltip}
-              image={option.image}
-              disabled={isDisabled}
-              defaultChecked={isChecked}
-              color={option.color}
-              replaceText={replaceText}
-            />
-          );
-        })}
-      </Box>
+        return (
+          <RegularCheckboxOption
+            key={option.id}
+            id={option.id}
+            name={itemId}
+            value={option.value}
+            label={option.text}
+            onChange={() => onValueChange(String(option.value), isNoneAbove)}
+            description={option.tooltip}
+            image={option.image}
+            disabled={isDisabled}
+            defaultChecked={isChecked}
+            color={option.color}
+            replaceText={replaceText}
+          />
+        );
+      })}
     </Box>
   );
 };

--- a/src/entities/activity/ui/items/RadioItem/RegularGrid.tsx
+++ b/src/entities/activity/ui/items/RadioItem/RegularGrid.tsx
@@ -1,12 +1,9 @@
-import { useMemo } from 'react';
-
 import RadioGroup from '@mui/material/RadioGroup';
 
 import { RegularRadioOption } from './RegularRadioOption';
 import { RadioItem } from '../../../lib';
 
 import { Box } from '~/shared/ui';
-import { splitList, useCustomMediaQuery } from '~/shared/utils';
 
 type Props = {
   options: RadioItem['responseValues']['options'];
@@ -26,56 +23,27 @@ export const RegularGrid = ({
   replaceText,
   options,
 }: Props) => {
-  const { lessThanSM } = useCustomMediaQuery();
-
-  const [evenColumn, oddColumn] = useMemo(() => {
-    return splitList(options);
-  }, [options]);
-
   return (
     <RadioGroup name={`${itemId}-radio regular-mode`}>
-      <Box display="flex" flex={1} gap="16px" flexDirection={lessThanSM ? 'column' : 'row'}>
-        <Box display="flex" flex={1} gap="16px" flexDirection="column">
-          {evenColumn.map((option) => {
-            return (
-              <RegularRadioOption
-                key={option.id}
-                id={option.id}
-                name={itemId}
-                value={option.value}
-                label={option.text}
-                onChange={() => onValueChange(String(option.value))}
-                description={option.tooltip}
-                image={option.image}
-                disabled={isDisabled}
-                defaultChecked={String(option.value) === value}
-                color={option.color}
-                replaceText={replaceText}
-              />
-            );
-          })}
-        </Box>
-
-        <Box display="flex" flex={1} gap="16px" flexDirection="column">
-          {oddColumn.map((option) => {
-            return (
-              <RegularRadioOption
-                key={option.id}
-                id={option.id}
-                name={itemId}
-                value={option.value}
-                label={option.text}
-                onChange={() => onValueChange(String(option.value))}
-                description={option.tooltip}
-                image={option.image}
-                disabled={isDisabled}
-                defaultChecked={String(option.value) === value}
-                color={option.color}
-                replaceText={replaceText}
-              />
-            );
-          })}
-        </Box>
+      <Box display="flex" flex={1} gap="16px" flexDirection="column">
+        {options.map((option) => {
+          return (
+            <RegularRadioOption
+              key={option.id}
+              id={option.id}
+              name={itemId}
+              value={option.value}
+              label={option.text}
+              onChange={() => onValueChange(String(option.value))}
+              description={option.tooltip}
+              image={option.image}
+              disabled={isDisabled}
+              defaultChecked={String(option.value) === value}
+              color={option.color}
+              replaceText={replaceText}
+            />
+          );
+        })}
       </Box>
     </RadioGroup>
   );

--- a/src/shared/utils/helpers/index.ts
+++ b/src/shared/utils/helpers/index.ts
@@ -2,7 +2,6 @@ export * from './dateTime';
 export * from './invertColor';
 export * from './randomizeArray';
 export * from './getRandomInt';
-export * from './splitList';
 export * from './getInitials';
 export * from './delay';
 export * from './cutString';

--- a/src/shared/utils/helpers/splitList.ts
+++ b/src/shared/utils/helpers/splitList.ts
@@ -1,6 +1,0 @@
-export const splitList = <TList>(array: Array<TList>): [Array<TList>, Array<TList>] => {
-  const evenItems = array.filter((option, index) => index < Math.ceil(array.length / 2));
-  const oddItems = array.filter((option, index) => index >= Math.ceil(array.length / 2));
-
-  return [evenItems, oddItems];
-};


### PR DESCRIPTION
## Description

🔗 [Jira Ticket M2-10889](https://mindlogger.atlassian.net/browse/M2-10889)

Single and multiple selection items now render their options in **one vertical column at every breakpoint**, replacing the two-column split that applied at ≥600px.

This is the layout the app already used below 600px, so it is an existing, validated design now applied consistently across all widths.

Per the discussion on [M2-10899](https://mindlogger.atlassian.net/browse/M2-10899), this assumes **no configuration flag**. Rather than gate the old and new layouts per item, we are dropping the multi-column approach entirely and always going vertical, to keep behavior consistent across breakpoints and platforms. Existing items pick up the new layout automatically — there is no per-item setting, no backend field, and no admin panel change.

Portrait (tile style) responses are unaffected: `PortraitGrid` keeps its current wrapping grid.

Related to ChildMindInstitute/mindlogger-admin#2252.

## Changes

- `RadioItem/RegularGrid.tsx` and `CheckboxItem/RegularGrid.tsx` render a single flex column at `gap="16px"`. Option cards span the parent's full width via the default `align-items: stretch`, so no explicit width rule was needed.
- Removed `splitList` (`src/shared/utils/helpers/splitList.ts`) and its barrel export. It was the two-column helper and had no other callers or tests.
- Removed the now-unused `useCustomMediaQuery` imports from both grids — `lessThanSM` was their only consumer.

Padding, gap, and card styling are unchanged. Option ordering, `randomizeOptions`, hidden-option filtering, tooltips, images, and palette colors are all untouched.

Net: **41 insertions, 115 deletions.**

## Testing

- `yarn tsc --noEmit` — 0 errors
- `yarn lint:check` — 0 errors, 32 warnings (unchanged from `dev`; none introduced by this change)
- `yarn test` — 751 passed / 44 files
- Manual verification against a real applet: options should render as a single full-width column, identical above and below the 600px breakpoint. Pending design sign-off against the Figma frame.


[M2-10899]: https://mindlogger.atlassian.net/browse/M2-10899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Checklist

### Functionality

- [ ] The feature behaves correctly in practice and fulfills the intended business purpose
- [ ] The implementation accounts for edge cases, avoids subtle logical errors, and handles somewhat rare failure states (e.g. offline mode for mobile, 3rd party being down, etc)

### Testing

- [ ] Verify there are automated tests added that meaningfully cover critical behavior and failure cases
- [x] Code coverage does not go down as result of this change
- [x] Test suite passes

### Security & Data Privacy

- [x] Verify there is no chance we would accidentally log PII to application logs
- [x] Verify this addition does not materially affect our security attack surface, and if so it has undergone security review
- [x] All inputs are sanitized
- [x] New dependencies are well maintained and have significant justification for being added to the project

### Logging/Monitoring

- [ ] Logging is implemented for this change such that you could troubleshoot this feature in production
- [ ] The change/feature is able to be monitored in production

### Performance

- [ ] This change does not introduce n+1 queries or other performance issues within our expected scale (e.g. missing indexes on frequently queried columns, frequently updating tables that are accessed often)

### Readability

- [x] All commented out code is removed
- [x] Debugging code including extraneous log lines are removed
- [x] Code is easy to understand through naming and structure; comments explain intent or non‑obvious decisions

### Change Safety

- [x] ~~Backend changes are backwards compatible with old clients, or it is well known they are not and a deployment/rollout plan is in place. This include backend changes being compatible with old mobile app versions, as well as applet versioning within Curious.~~
- [x] ~~Destructive database migrations are rolled out in stages. For example, renaming a column means adding a new column and migrating the existing data to that columns in one deployment. Then monitoring to ensure that field isn’t used, and finally removing that old column in a separate deployment.~~