### PR TITLE
Fix: isixhosa must be translations (M2-10950)

### DIFF
--- a/src/i18n/af/translation.json
+++ b/src/i18n/af/translation.json
@@ -242,7 +242,7 @@
       "successMessage": "Wagwoordterugstel-skakel is gestuur na {{email}}"
     },
     "ChangePassword": {
-      "settings": "{{name}}se instellings",
+      "settings": "{{name}} se instellings",
       "settingsTitle": "Verander wagwoord",
       "oldPassword": "Ou wagwoord",
       "newPassword": "Nuwe wagwoord",

--- a/src/i18n/xh/translation.json
+++ b/src/i18n/xh/translation.json
@@ -103,14 +103,14 @@
       "passwordReqSymbols": "Iimpawu (! @#$...)",
       "passwordCannotContainEmojis": "Igama lokugqithisa alinakuqulatha i-emojis.",
       "emailRequired": "Idilesi ye-imeyile iyafuneka.",
-      "invalidEmail": "I-imeyile must be isebenze.",
+      "invalidEmail": "I-imeyile mayibe yesebenzayo.",
       "firstNameRequired": "Igama lokuqala liyafuneka.",
       "lastNameRequired": "Ifani iyafuneka.",
       "passwordShouldNotContainSpaces": "Igama lokugqithisa akufuneki liqulathe izithuba.",
       "mfaCodeRequired": "Ikhowudi yokuqinisekisa iyafuneka.",
-      "mfaCodeFormat": "Ikhowudi yokuqinisekisa must be inamanani ama-6.",
+      "mfaCodeFormat": "Ikhowudi yokuqinisekisa mayibe ngamanani ama-6.",
       "recoveryCodeRequired": "Ikhowudi yokubuyisela iyafuneka.",
-      "recoveryCodeFormat": "Ikhowudi yokubuyisela must be ibekwifomathi XXXXX-XXXXX."
+      "recoveryCodeFormat": "Ikhowudi yokubuyisela mayibe kwifomathi XXXXX-XXXXX."
     },
     "MFA": {
       "confirmYourIdentity": "Qinisekisa ukuba ungubani",
@@ -284,7 +284,7 @@
       "toSeeThePage": "Ukubona Iphepha",
       "expiredLink": "Password Resent Link iphelelwe lixesha",
       "passwordRequired": "Igama lokugqithisa liyafuneka",
-      "passwordShort": "Igama lokugqithisa must be libe nonobumba aba-6 ubuncinane",
+      "passwordShort": "Igama lokugqithisa malibe nonobumba aba-6 ubuncinane",
       "passwordBlank": "Igama lokugqithisa akufuneki liqulathe izithuba ezingenanto",
       "passwordSame": "Igama lokugqithisa alinakufana negama lokugqitha elidala"
     },

--- a/src/i18n/zu/translation.json
+++ b/src/i18n/zu/translation.json
@@ -223,8 +223,8 @@
       "logIn": "Ngena ngemvume",
       "success": "Ukubhalisa kuqedwe ngempumelelo",
       "or": "Noma",
-      "pleaseAgreeTerms": "*Sicela wamukele Imigomo Yesevisi.",
-      "iAgreeTo": "Ngivumelana ne",
+      "pleaseAgreeTerms": "*Sicela uvume Imigomo Yesevisi.",
+      "iAgreeTo": "Ngiyayivuma",
       "termsOfService": "Imigomo Yesevisi"
     },
     "ForgotPassword": {

--- a/src/i18n/zu/translation.json
+++ b/src/i18n/zu/translation.json
@@ -242,7 +242,7 @@
       "successMessage": "Ilinki yokusetha kabusha iphasiwedi ithunyelwe {{email}}"
     },
     "ChangePassword": {
-      "settings": "{{name}}kumaSethingi",
+      "settings": "{{name}} kumaSethingi",
       "settingsTitle": "Shintsha iphasiwedi",
       "oldPassword": "Iphasiwedi Endala",
       "newPassword": "Iphasiwedi Entsha",


### PR DESCRIPTION
- [ ] Tests for the changes have been added
- [ ] Related documentation has been added / updated
- [ ] OSS packages added to Curious [open source credit page](https://mindlogger.atlassian.net/jira/servicedesk/projects/MLA/knowledge/articles/340623543?spaceKey=MLA)

### 📝 Description

🔗 [Jira Ticket M2-10950](https://mindlogger.atlassian.net/browse/M2-10950)

Changes include:

- Fixed 4 isiXhosa strings that still contained untranslated English "must be" (email validation, MFA code format, recovery code format, password length)
- Fixed missing space in Afrikaans settings label (`{{name}}se instellings` → `{{name}} se instellings`)
- Corrected isiZulu "I agree to the Terms of Service" wording on Sign Up (grammatically incorrect concord fixed, per translation team review)

### 🪤 Peer Testing

- **Set app language to isiXhosa**, trigger email/password/MFA validation errors.

    **Expected outcome:** No "must be" appears in any message; text is fully isiXhosa.

- **Set app language to Afrikaans**, open the Change Password / Settings page.

    **Expected outcome:** Label reads "{{name}} se instellings" with correct spacing.

- **Set app language to isiZulu**, go to Sign Up.

    **Expected outcome:** Terms of Service checkbox label reads "Ngiyayivuma Imigomo Yesevisi" (link) with correct grammar; validation message on unchecked submit reads "*Sicela uvume Imigomo Yesevisi."


